### PR TITLE
fixing the _dot operation with return on blas1 interface.

### DIFF
--- a/cmake/Modules/FindComputeCpp.cmake
+++ b/cmake/Modules/FindComputeCpp.cmake
@@ -18,14 +18,14 @@
 #   limitations under the License.
 
 #########################
-#  FindComputeCpp.cmake  
+#  FindComputeCpp.cmake
 #########################
 #
 #  Tools for finding and building with ComputeCpp.
 #
-#  User must define COMPUTECPP_PACKAGE_ROOT_DIR pointing to the ComputeCpp 
+#  User must define COMPUTECPP_PACKAGE_ROOT_DIR pointing to the ComputeCpp
 #   installation.
-#  
+#
 #  Latest version of this file can be found at:
 #    https://github.com/codeplaysoftware/computecpp-sdk
 
@@ -159,7 +159,7 @@ else()
 endif()
 
 ####################
-#   __build_sycl   
+#   __build_sycl
 ####################
 #
 #  Adds a custom target for running compute++ and adding a dependency for the
@@ -173,7 +173,7 @@ endif()
 #       but located in different directories, are used for the same target.
 #
 function(__build_spir targetName sourceFile binaryDir fileCounter)
-  
+
   # Retrieve source file name.
   get_filename_component(sourceFileName ${sourceFile} NAME)
 
@@ -208,12 +208,13 @@ function(__build_spir targetName sourceFile binaryDir fileCounter)
             -o ${outputSyclFile}
             -c ${sourceFile}
     DEPENDS ${sourceFile}
+    IMPLICIT_DEPENDS CXX "${sourceFile}"
     WORKING_DIRECTORY ${binaryDir}
   COMMENT "Building ComputeCpp integration header file ${outputSyclFile}")
 
   # Name: (user-defined name)_(source file)_(counter for same source file name)_integration_header
   set(headerTargetName ${targetName}_${sourceFileName}_${fileCounter}_integration_header)
-  
+
   # Add a custom target for the generated integration header
   add_custom_target(${headerTargetName} DEPENDS ${outputSyclFile})
 
@@ -223,7 +224,7 @@ function(__build_spir targetName sourceFile binaryDir fileCounter)
   # Force inclusion of the integration header for the host compiler
   set(compileFlags -include ${outputSyclFile})
   target_compile_options(${targetName} PUBLIC ${compileFlags})
-  
+
   # Disable GCC dual ABI on GCC 5.1 and higher
   if(COMPUTECPP_DISABLE_GCC_DUAL_ABI)
     set_property(TARGET ${targetName} APPEND PROPERTY COMPILE_DEFINITIONS

--- a/include/executors/executor_sycl.hpp
+++ b/include/executors/executor_sycl.hpp
@@ -44,7 +44,11 @@ namespace blas {
 /*!using_shared_mem.
  * @brief Indicates whether if the kernel uses shared memory or not.
  */
-enum class using_shared_mem { enabled, disabled };
+//enum class using_shared_mem { enabled, disabled };
+namespace using_shared_mem {
+  static const int enabled=0;
+  static const int disabled=1;
+};
 
 /*!
 @brief Template alias for a local accessor.
@@ -62,7 +66,7 @@ accessor.
 @tparam valueT Value type of the local accessor.
 @tparam usingSharedMem Enum class specifying whether shared memory is enabled.
 */
-template <typename valueT, using_shared_mem usingSharedMem>
+template <typename valueT, int usingSharedMem>
 struct shared_mem {
   /*!
   @brief Constructor that creates a local accessor from a size and a SYCL
@@ -103,6 +107,7 @@ struct shared_mem<valueT, using_shared_mem::disabled> {
   shared_mem(size_t size, cl::sycl::handler &cgh) {}
 };
 
+
 /*!
 @brief Template struct defining the value type of shared memory if enabled.
 Non-specialised case for usingSharedMem == enabled, which defines the type as
@@ -110,7 +115,7 @@ the value type of the tree.
 @tparam usingSharedMemory Enum class specifying whether shared memory is
 enabled.
 */
-template <using_shared_mem usingSharedMem, typename treeT>
+template <int usingSharedMem, typename treeT>
 struct shared_mem_type {
   using type = typename blas::Evaluate<treeT>::value_type;
 };
@@ -134,7 +139,7 @@ on the tree with the shared_memory as well as an index.
 @tparam treeT Type of the tree.
 @tparam sharedMemT Value type of the shared memory.
 */
-template <using_shared_mem usingSharedMem, typename treeT, typename sharedMemT>
+template <int usingSharedMem, typename treeT, typename sharedMemT>
 struct tree {
   /*!
   @brief Static function that calls eval on a tree, passing the shared_memory
@@ -174,6 +179,7 @@ struct tree<using_shared_mem::disabled, treeT, sharedMemT> {
   }
 };
 
+
 /*! execute_tree.
 @brief Static function for executing a tree in SYCL.
 @tparam usingSharedMem Enum class specifying whether shared memory is enabled.
@@ -185,7 +191,15 @@ struct tree<using_shared_mem::disabled, treeT, sharedMemT> {
 @param _shMem Size in elements of the shared memory (should be zero if
 usingSharedMem == false).
 */
-template <using_shared_mem usingSharedMem, typename Tree>
+template<int usingSharedMem, typename Evaluator, typename SharedMem, typename value_type> struct ReductionFunctor{
+  SharedMem scratch;
+  Evaluator evaluator;
+  ReductionFunctor(SharedMem scratch_, Evaluator evaluator_):scratch(scratch_), evaluator(evaluator_){}
+  void operator()(cl::sycl::nd_item<1> i){
+    tree<usingSharedMem, Evaluator, value_type>::eval(evaluator, scratch,i);
+  }
+};
+template <int usingSharedMem, typename Tree>
 static void execute_tree(cl::sycl::queue &q_, Tree t, size_t _localSize,
                          size_t _globalSize, size_t _shMem) {
   using value_type = typename shared_mem_type<usingSharedMem, Tree>::type;
@@ -199,13 +213,10 @@ static void execute_tree(cl::sycl::queue &q_, Tree t, size_t _localSize,
 
     auto scratch = shared_mem<value_type, usingSharedMem>(shMem, h);
 
-    auto k1 = [=](cl::sycl::nd_item<1> i) mutable {
-      tree<usingSharedMem, decltype(nTree), value_type>::eval(nTree, scratch,
-                                                              i);
-    };
     cl::sycl::nd_range<1> gridConfiguration = cl::sycl::nd_range<1>{
         cl::sycl::range<1>{globalSize}, cl::sycl::range<1>{localSize}};
-    h.parallel_for<decltype(nTree)>(gridConfiguration, k1);
+    auto reductionFunctor = ReductionFunctor<usingSharedMem, decltype(nTree),decltype(scratch), value_type>(scratch, nTree);
+    h.parallel_for(gridConfiguration, reductionFunctor);
   };
 
   q_.submit(cg1);

--- a/include/executors/executor_sycl.hpp
+++ b/include/executors/executor_sycl.hpp
@@ -233,7 +233,7 @@ static void execute_tree(cl::sycl::queue &q_, Tree t, size_t _localSize,
         cl::sycl::range<1>{globalSize}, cl::sycl::range<1>{localSize}};
     h.parallel_for(
         gridConfiguration,
-        ReductionFunctor<usingSharedMem, decltype(nTree), decltype(scratch),
+        ExecTreeFunctor<usingSharedMem, decltype(nTree), decltype(scratch),
                          value_type>(scratch, nTree));
   };
 

--- a/include/operations/blas1_trees.hpp
+++ b/include/operations/blas1_trees.hpp
@@ -198,7 +198,6 @@ struct ScalarOp {
   ScalarOp(SCL _scl, RHS& _r) : scl(_scl), r(_r){};
 
   size_t getSize() { return r.getSize(); }
-
   value_type eval(size_t i) {
     return Operator::eval(internal::get_scalar(scl), r.eval(i));
   }
@@ -285,7 +284,9 @@ struct ReducAssignNewOp2 {
     }
     return l.eval(i) = val;
   }
-
+  value_type eval(cl::sycl::nd_item<1> ndItem) {
+    return eval(ndItem.get_global(0));
+  }
   template <typename sharedT>
   value_type eval(sharedT scratch, cl::sycl::nd_item<1> ndItem) {
     size_t localid = ndItem.get_local(0);
@@ -392,7 +393,9 @@ struct ReducAssignNewOp3 {
     }
     return l.eval(i) = val;
   }
-
+  value_type eval(cl::sycl::nd_item<1> ndItem) {
+    return eval(ndItem.get_global(0));
+  }
   template <typename sharedT>
   res_type eval(sharedT scratch, cl::sycl::nd_item<1> ndItem) {
     size_t localid = ndItem.get_local(0);

--- a/include/operations/blas1_trees.hpp
+++ b/include/operations/blas1_trees.hpp
@@ -26,13 +26,13 @@
 #ifndef BLAS1_TREES_HPP
 #define BLAS1_TREES_HPP
 
+#include <complex>
 #include <iostream>
 #include <stdexcept>
 #include <vector>
-#include <complex>
 
-#include <views/view_sycl.hpp>
 #include <operations/blas_operators.hpp>
+#include <views/view_sycl.hpp>
 
 namespace blas {
 namespace internal {
@@ -261,7 +261,7 @@ struct ReducAssignNewOp2 {
   size_t grdS;  // grid  size
 
   ReducAssignNewOp2(LHS& _l, RHS& _r, size_t _blqS, size_t _grdS)
-      : l(_l), r(_r), blqS(_blqS), grdS(_grdS){ };
+      : l(_l), r(_r), blqS(_blqS), grdS(_grdS){};
 
   size_t getSize() { return r.getSize(); }
 

--- a/include/operations/blas_operators.hpp
+++ b/include/operations/blas_operators.hpp
@@ -30,6 +30,7 @@
 #include <stdexcept>
 #include <vector>
 #include <operations/blas_constants.hpp>
+#include <CL/sycl.hpp>
 
 namespace blas {
 
@@ -87,7 +88,7 @@ struct IndVal {
  * When using ComputeCpp CE, the Device Compiler uses Address Spaces
  * to deal with the different global memories.
  * However, this causes problem with std type traits, which see the
- * types with address space qualifiers as different from the C++ 
+ * types with address space qualifiers as different from the C++
  * standard types.
  *
  * This is strip_asp function servers as a workaround that removes
@@ -119,7 +120,7 @@ GENERATE_STRIP_ASP(double)
 GENERATE_STRIP_ASP(float)
 #endif  // __SYCL_DEVICE_ONLY__  && __COMPUTECPP__
 
-/** 
+/**
  * syclblas_abs.
  *
  * SYCL 1.2 defines different functions for abs for floating point
@@ -130,7 +131,7 @@ GENERATE_STRIP_ASP(float)
 struct syclblas_abs {
 
   template<typename Type>
-  static Type eval(const Type& val, 
+  static Type eval(const Type& val,
         typename std::enable_if<!std::is_floating_point<typename strip_asp<Type>::type>::value>::type* = 0) {
     return cl::sycl::abs(val);
   }

--- a/tests/blas1_interface_test.cpp
+++ b/tests/blas1_interface_test.cpp
@@ -1,9 +1,9 @@
 #include <algorithm>
 #include <cstdlib>
+#include <interface/blas1_interface_sycl.hpp>
 #include <iostream>
 #include <stdexcept>
 #include <vector>
-#include <interface/blas1_interface_sycl.hpp>
 
 using namespace cl::sycl;
 using namespace blas;
@@ -125,7 +125,7 @@ int main(int argc, char* argv[]) {
       // EXECUTION OF THE ROUTINES
       _axpy<SYCL>(ex, bX.get_count(), alpha, bvX, 1, bvY, 1);
       _asum<SYCL>(ex, bY.get_count(), bvY, 1, bvR);
-      vS[0]=_dot<SYCL>(ex, bY.get_count(), bvX, 1, bvY, 1);
+      vS[0] = _dot<SYCL>(ex, bY.get_count(), bvX, 1, bvY, 1);
       _nrm2<SYCL>(ex, bY.get_count(), bvY, 1, bvT);
       _iamax<SYCL>(ex, bY.get_count(), bvY, 1, bvI);
       _rot<SYCL>(ex, bY.get_count(), bvX, 1, bvY, 1, _cos, _sin);

--- a/tests/blas1_interface_test.cpp
+++ b/tests/blas1_interface_test.cpp
@@ -125,7 +125,7 @@ int main(int argc, char* argv[]) {
       // EXECUTION OF THE ROUTINES
       _axpy<SYCL>(ex, bX.get_count(), alpha, bvX, 1, bvY, 1);
       _asum<SYCL>(ex, bY.get_count(), bvY, 1, bvR);
-      _dot<SYCL>(ex, bY.get_count(), bvX, 1, bvY, 1, bvS);
+      vS[0]=_dot<SYCL>(ex, bY.get_count(), bvX, 1, bvY, 1);
       _nrm2<SYCL>(ex, bY.get_count(), bvY, 1, bvT);
       _iamax<SYCL>(ex, bY.get_count(), bvY, 1, bvI);
       _rot<SYCL>(ex, bY.get_count(), bvX, 1, bvY, 1, _cos, _sin);


### PR DESCRIPTION
Fixing the _dot operation when return the value. Replacing the enum with namespace and static int as enum value cannot be detected by duplicator.