### PR TITLE
Added benchmarks for clblas, clblast and syclblas

### DIFF
--- a/bench/clblas_benchmark.cpp
+++ b/bench/clblas_benchmark.cpp
@@ -325,79 +325,35 @@ ClBlasBenchmarker blasbenchmark;
 
 BENCHMARK_REGISTER_FUNCTION("scal_float", scal_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("scal_double", scal_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("scal_complex_float", */
-/*                             scal_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("scal_complex_double", */
-/*                             scal_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("axpy_float", axpy_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("axpy_double", axpy_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("axpy_complex_float", */
-/*                             axpy_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("axpy_complex_double", */
-/*                             axpy_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("asum_float", asum_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("asum_double", asum_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("asum_complex_float", */
-/*                             asum_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("asum_complex_double", */
-/*                             asum_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("nrm2_float", nrm2_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("nrm2_double", nrm2_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("nrm2_complex_float", */
-/*                             nrm2_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("nrm2_complex_double", */
-/*                             nrm2_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("dot_float", dot_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("dot_double", dot_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("dot_complex_float", */
-/*                             dot_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("dot_complex_double", */
-/*                             dot_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("iamax_float", iamax_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("iamax_double", iamax_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("iamax_complex_float", */
-/*                             iamax_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("iamax_complex_double", */
-/*                             iamax_bench<std::complex<double>>); */
 
 /* BENCHMARK_REGISTER_FUNCTION("iamin_float", iamin_bench<float>); */
 /* BENCHMARK_REGISTER_FUNCTION("iamin_double", iamin_bench<double>); */
-/* BENCHMARK_REGISTER_FUNCTION("iamin_complex_float", */
-/*                             iamin_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("iamin_complex_double", */
-/*                             iamin_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("scal2op_float", scal2op_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("scal2op_double", scal2op_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("scal2op_complex_float", */
-/*                             scal2op_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("scal2op_complex_double", */
-/*                             scal2op_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("scal3op_float", scal3op_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("scal3op_double", scal3op_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("scal3op_complex_float", */
-/*                             scal3op_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("scal3op_complex_double", */
-/*                             scal3op_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("axpy3op_float", axpy3op_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("axpy3op_double", axpy3op_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("axpy3op_complex_float", */
-/*                             axpy3op_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("axpy3op_complex_double", */
-/*                             axpy3op_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("blas1_float", blas1_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("blas1_double", blas1_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("blas1_complex_float", */
-/*                             blas1_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("blas1_complex_double", */
-/*                             blas1_bench<std::complex<double>>); */
 
 BENCHMARK_MAIN_END();

--- a/bench/clblas_benchmark.cpp
+++ b/bench/clblas_benchmark.cpp
@@ -1,0 +1,403 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) 2016 Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename clblas_benchmark.cpp
+ *
+ **************************************************************************/
+
+#include "blas_benchmark.hpp"
+
+#include <complex>
+#include <vector>
+
+#include <clBLAS.h>
+
+#include "clwrap.hpp"
+
+#define UNPACK_PARAM using ScalarT = TypeParam;
+
+#define CLBLAS_FUNCTION(postfix)                          \
+  template <typename T>                                   \
+  struct clblasX##postfix;                                \
+  template <>                                             \
+  struct clblasX##postfix<float> {                        \
+    static constexpr const auto func = &clblasS##postfix; \
+  };                                                      \
+  template <>                                             \
+  struct clblasX##postfix<double> {                       \
+    static constexpr const auto func = &clblasD##postfix; \
+  };
+/* template <> struct clblasX##postfix<std::complex<float>> { \ */
+/*   static constexpr const auto value = clblasC##postfix; \ */
+/* }; \ */
+/* template <> struct clblasX##postfix<std::complex<double>> { \ */
+/*   static constexpr const auto value = clblasZ##postfix; \ */
+/* }; */
+
+#define CLBLASI_FUNCTION(postfix)                          \
+  template <typename T>                                    \
+  struct clblasiX##postfix;                                \
+  template <>                                              \
+  struct clblasiX##postfix<float> {                        \
+    static constexpr const auto func = &clblasiS##postfix; \
+  };                                                       \
+  template <>                                              \
+  struct clblasiX##postfix<double> {                       \
+    static constexpr const auto func = &clblasiD##postfix; \
+  };
+/* template <> struct clblasiX##postfix<std::complex<float>> { \ */
+/*   static constexpr const auto value = clblasiC##postfix; \ */
+/* }; \ */
+/* template <> struct clblasiX##postfix<std::complex<double>> { \ */
+/*   static constexpr const auto value = clblasiZ##postfix; \ */
+/* }; */
+
+CLBLAS_FUNCTION(scal);
+CLBLAS_FUNCTION(asum);
+CLBLAS_FUNCTION(axpy);
+CLBLAS_FUNCTION(nrm2);
+CLBLAS_FUNCTION(dot);
+CLBLASI_FUNCTION(amax);
+
+class ClBlasBenchmarker {
+  Context context;
+
+ public:
+  ClBlasBenchmarker() : context() { clblasSetup(); }
+
+  BENCHMARK_FUNCTION(scal_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT alpha(2.4367453465);
+      MemBuffer<ScalarT> buf1(context, size);
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 1, [&]() {
+        clblasXscal<ScalarT>::func(size, alpha, buf1.dev(), 0, 1, 1,
+                                   context._queue(), 0, NULL, &event);
+        clWaitForEvents(1, &event);
+        clReleaseEvent(event);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(axpy_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT alpha(2.4367453465);
+      MemBuffer<ScalarT> buf1(context, size);
+      MemBuffer<ScalarT> buf2(context, size);
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 1, [&]() {
+        clblasXaxpy<ScalarT>::func(size, alpha, buf1.dev(), 0, 1, buf2.dev(), 0,
+                                   1, 1, context._queue(), 0, NULL, &event);
+        clWaitForEvents(1, &event);
+        clReleaseEvent(event);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(asum_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT vr;
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
+      MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufr(context, &vr, 1);
+      MemBuffer<ScalarT, CL_MEM_HOST_NO_ACCESS> scratch(context, size);
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        clblasXasum<ScalarT>::func(size, bufr.dev(), 0, buf1.dev(), 0, 1,
+                                   scratch.dev(), 1, context._queue(), 0, NULL,
+                                   &event);
+        clWaitForEvents(1, &event);
+        clReleaseEvent(event);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(nrm2_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT vr;
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
+      MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufr(context, &vr, 1);
+      MemBuffer<ScalarT, CL_MEM_HOST_NO_ACCESS> scratch(context, 2 * size);
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        clblasXnrm2<ScalarT>::func(size, bufr.dev(), 0, buf1.dev(), 0, 1,
+                                   scratch.dev(), 1, context._queue(), 0, NULL,
+                                   &event);
+        clWaitForEvents(1, &event);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(dot_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT vr;
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf2(context, size);
+      MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufr(context, &vr, 1);
+      MemBuffer<ScalarT, CL_MEM_HOST_NO_ACCESS> scratch(context, size);
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        clblasXdot<ScalarT>::func(size, bufr.dev(), 0, buf1.dev(), 0, 1,
+                                  buf2.dev(), 0, 1, scratch.dev(), 1,
+                                  context._queue(), 0, NULL, &event);
+        clWaitForEvents(1, &event);
+        clReleaseEvent(event);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(iamax_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      unsigned vi;
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
+      MemBuffer<unsigned, CL_MEM_READ_ONLY> buf_i(context, &vi, 1);
+      MemBuffer<ScalarT, CL_MEM_HOST_NO_ACCESS> scratch(context, 2 * size);
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        clblasiXamax<ScalarT>::func(size, buf_i.dev(), 0, buf1.dev(), 0, 1,
+                                    scratch.dev(), 1, context._queue(), 0, NULL,
+                                    &event);
+        clWaitForEvents(1, &event);
+        clReleaseEvent(event);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(scal2op_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT alpha(2.4367453465);
+      MemBuffer<ScalarT> buf1(context, size);
+      MemBuffer<ScalarT> buf2(context, size);
+      cl_event events[2];
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        clblasXscal<ScalarT>::func(size, alpha, buf1.dev(), 0, 1, 1,
+                                   context._queue(), 0, NULL, &events[0]);
+        clblasXscal<ScalarT>::func(size, alpha, buf2.dev(), 0, 1, 1,
+                                   context._queue(), 0, NULL, &events[1]);
+        clWaitForEvents(2, events);
+        clReleaseEvent(events[0]);
+        clReleaseEvent(events[1]);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(scal3op_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT alpha(2.4367453465);
+      MemBuffer<ScalarT> buf1(context, size);
+      MemBuffer<ScalarT> buf2(context, size);
+      MemBuffer<ScalarT> buf3(context, size);
+      cl_event events[3];
+      flops = benchmark<>::measure(no_reps, size * 3, [&]() {
+        clblasXscal<ScalarT>::func(size, alpha, buf1.dev(), 0, 1, 1,
+                                   context._queue(), 0, NULL, &events[0]);
+        clblasXscal<ScalarT>::func(size, alpha, buf2.dev(), 0, 1, 1,
+                                   context._queue(), 0, NULL, &events[1]);
+        clblasXscal<ScalarT>::func(size, alpha, buf3.dev(), 0, 1, 1,
+                                   context._queue(), 0, NULL, &events[2]);
+        clWaitForEvents(3, events);
+        clReleaseEvent(events[0]);
+        clReleaseEvent(events[1]);
+        clReleaseEvent(events[2]);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(axpy3op_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT alpha(2.4367453465);
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> bufsrc1(context, size);
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> bufsrc2(context, size);
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> bufsrc3(context, size);
+      MemBuffer<ScalarT> bufdst1(context, size);
+      MemBuffer<ScalarT> bufdst2(context, size);
+      MemBuffer<ScalarT> bufdst3(context, size);
+      cl_event events[3];
+      flops = benchmark<>::measure(no_reps, size * 3, [&]() {
+        clblasXaxpy<ScalarT>::func(size, alpha, bufsrc1.dev(), 0, 1,
+                                   bufdst1.dev(), 0, 1, 1, context._queue(), 0,
+                                   NULL, &events[0]);
+        clblasXaxpy<ScalarT>::func(size, alpha, bufsrc2.dev(), 0, 1,
+                                   bufdst2.dev(), 0, 1, 1, context._queue(), 0,
+                                   NULL, &events[1]);
+        clblasXaxpy<ScalarT>::func(size, alpha, bufsrc3.dev(), 0, 1,
+                                   bufdst3.dev(), 0, 1, 1, context._queue(), 0,
+                                   NULL, &events[2]);
+        clWaitForEvents(3, events);
+        clReleaseEvent(events[0]);
+        clReleaseEvent(events[1]);
+        clReleaseEvent(events[2]);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(blas1_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT alpha(3.135345123);
+      ScalarT vr[4];
+      unsigned vi;
+      MemBuffer<ScalarT> buf1(context, size);
+      MemBuffer<ScalarT> buf2(context, size);
+      MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufr(context, vr, 4);
+      MemBuffer<unsigned, CL_MEM_READ_ONLY> buf_i(context, &vi, 1);
+
+      MemBuffer<ScalarT, CL_MEM_HOST_NO_ACCESS> scratch[4]{
+          MemBuffer<ScalarT, CL_MEM_HOST_NO_ACCESS>(context, size),
+          MemBuffer<ScalarT, CL_MEM_HOST_NO_ACCESS>(context, size),
+          MemBuffer<ScalarT, CL_MEM_HOST_NO_ACCESS>(context, 2 * size),
+          MemBuffer<ScalarT, CL_MEM_HOST_NO_ACCESS>(context, 2 * size),
+      };
+
+      cl_event events[5];
+      flops = benchmark<>::measure(no_reps, size * 12, [&]() {
+        clblasXaxpy<ScalarT>::func(size, alpha, buf1.dev(), 0, 1, buf2.dev(), 0,
+                                   1, 1, context._queue(), 0, NULL, &events[0]);
+        clblasXasum<ScalarT>::func(size, bufr.dev(), 0, buf2.dev(), 0, 1,
+                                   scratch[0].dev(), 1, context._queue(), 0,
+                                   NULL, &events[1]);
+        clblasXdot<ScalarT>::func(size, bufr.dev(), 1, buf1.dev(), 0, 1,
+                                  buf2.dev(), 0, 1, scratch[1].dev(), 1,
+                                  context._queue(), 0, NULL, &events[2]);
+        clblasXnrm2<ScalarT>::func(size, bufr.dev(), 2, buf1.dev(), 0, 1,
+                                   scratch[2].dev(), 1, context._queue(), 0,
+                                   NULL, &events[3]);
+        clblasiXamax<ScalarT>::func(size, buf_i.dev(), 0, buf1.dev(), 0, 1,
+                                    scratch[3].dev(), 1, context._queue(), 0,
+                                    NULL, &events[4]);
+        clWaitForEvents(5, events);
+        for (int i = 0; i < 5; ++i) clReleaseEvent(events[i]);
+      });
+    }
+    return flops;
+  }
+
+  ~ClBlasBenchmarker() { clblasTeardown(); }
+};
+
+BENCHMARK_MAIN_BEGIN(1 << 1, 1 << 24, 10);
+ClBlasBenchmarker blasbenchmark;
+
+BENCHMARK_REGISTER_FUNCTION("scal_float", scal_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("scal_double", scal_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("scal_complex_float", */
+/*                             scal_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("scal_complex_double", */
+/*                             scal_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("axpy_float", axpy_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("axpy_double", axpy_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("axpy_complex_float", */
+/*                             axpy_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("axpy_complex_double", */
+/*                             axpy_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("asum_float", asum_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("asum_double", asum_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("asum_complex_float", */
+/*                             asum_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("asum_complex_double", */
+/*                             asum_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("nrm2_float", nrm2_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("nrm2_double", nrm2_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("nrm2_complex_float", */
+/*                             nrm2_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("nrm2_complex_double", */
+/*                             nrm2_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("dot_float", dot_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("dot_double", dot_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("dot_complex_float", */
+/*                             dot_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("dot_complex_double", */
+/*                             dot_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("iamax_float", iamax_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("iamax_double", iamax_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("iamax_complex_float", */
+/*                             iamax_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("iamax_complex_double", */
+/*                             iamax_bench<std::complex<double>>); */
+
+/* BENCHMARK_REGISTER_FUNCTION("iamin_float", iamin_bench<float>); */
+/* BENCHMARK_REGISTER_FUNCTION("iamin_double", iamin_bench<double>); */
+/* BENCHMARK_REGISTER_FUNCTION("iamin_complex_float", */
+/*                             iamin_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("iamin_complex_double", */
+/*                             iamin_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("scal2op_float", scal2op_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("scal2op_double", scal2op_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("scal2op_complex_float", */
+/*                             scal2op_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("scal2op_complex_double", */
+/*                             scal2op_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("scal3op_float", scal3op_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("scal3op_double", scal3op_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("scal3op_complex_float", */
+/*                             scal3op_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("scal3op_complex_double", */
+/*                             scal3op_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("axpy3op_float", axpy3op_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("axpy3op_double", axpy3op_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("axpy3op_complex_float", */
+/*                             axpy3op_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("axpy3op_complex_double", */
+/*                             axpy3op_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("blas1_float", blas1_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("blas1_double", blas1_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("blas1_complex_float", */
+/*                             blas1_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("blas1_complex_double", */
+/*                             blas1_bench<std::complex<double>>); */
+
+BENCHMARK_MAIN_END();

--- a/bench/clblas_benchmark.cpp
+++ b/bench/clblas_benchmark.cpp
@@ -43,12 +43,6 @@
   struct clblasX##postfix<double> {                       \
     static constexpr const auto func = &clblasD##postfix; \
   };
-/* template <> struct clblasX##postfix<std::complex<float>> { \ */
-/*   static constexpr const auto value = clblasC##postfix; \ */
-/* }; \ */
-/* template <> struct clblasX##postfix<std::complex<double>> { \ */
-/*   static constexpr const auto value = clblasZ##postfix; \ */
-/* }; */
 
 #define CLBLASI_FUNCTION(postfix)                          \
   template <typename T>                                    \
@@ -108,7 +102,8 @@ class ClBlasBenchmarker {
       Event event;
       flops = benchmark<>::measure(no_reps, size * 1, [&]() {
         clblasXaxpy<ScalarT>::func(size, alpha, buf1.dev(), 0, 1, buf2.dev(), 0,
-                                   1, 1, context._queue(), 0, NULL, &event._cl());
+                                   1, 1, context._queue(), 0, NULL,
+                                   &event._cl());
         event.wait();
         event.release();
       });
@@ -291,7 +286,8 @@ class ClBlasBenchmarker {
       Event events[5];
       flops = benchmark<>::measure(no_reps, size * 12, [&]() {
         clblasXaxpy<ScalarT>::func(size, alpha, buf1.dev(), 0, 1, buf2.dev(), 0,
-                                   1, 1, context._queue(), 0, NULL, &events[0]._cl());
+                                   1, 1, context._queue(), 0, NULL,
+                                   &events[0]._cl());
         clblasXasum<ScalarT>::func(size, bufr.dev(), 0, buf2.dev(), 0, 1,
                                    scratch[0].dev(), 1, context._queue(), 0,
                                    NULL, &events[1]._cl());
@@ -334,9 +330,6 @@ BENCHMARK_REGISTER_FUNCTION("dot_double", dot_bench<double>);
 
 BENCHMARK_REGISTER_FUNCTION("iamax_float", iamax_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("iamax_double", iamax_bench<double>);
-
-/* BENCHMARK_REGISTER_FUNCTION("iamin_float", iamin_bench<float>); */
-/* BENCHMARK_REGISTER_FUNCTION("iamin_double", iamin_bench<double>); */
 
 BENCHMARK_REGISTER_FUNCTION("scal2op_float", scal2op_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("scal2op_double", scal2op_bench<double>);

--- a/bench/clblast_benchmark.cpp
+++ b/bench/clblast_benchmark.cpp
@@ -280,79 +280,35 @@ ClBlastBenchmarker blasbenchmark;
 
 BENCHMARK_REGISTER_FUNCTION("scal_float", scal_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("scal_double", scal_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("scal_complex_float", */
-/*                             scal_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("scal_complex_double", */
-/*                             scal_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("axpy_float", axpy_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("axpy_double", axpy_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("axpy_complex_float", */
-/*                             axpy_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("axpy_complex_double", */
-/*                             axpy_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("asum_float", asum_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("asum_double", asum_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("asum_complex_float", */
-/*                             asum_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("asum_complex_double", */
-/*                             asum_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("nrm2_float", nrm2_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("nrm2_double", nrm2_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("nrm2_complex_float", */
-/*                             nrm2_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("nrm2_complex_double", */
-/*                             nrm2_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("dot_float", dot_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("dot_double", dot_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("dot_complex_float", */
-/*                             dot_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("dot_complex_double", */
-/*                             dot_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("iamax_float", iamax_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("iamax_double", iamax_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("iamax_complex_float", */
-/*                             iamax_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("iamax_complex_double", */
-/*                             iamax_bench<std::complex<double>>); */
 
 /* BENCHMARK_REGISTER_FUNCTION("iamin_float", iamin_bench<float>); */
 /* BENCHMARK_REGISTER_FUNCTION("iamin_double", iamin_bench<double>); */
-/* BENCHMARK_REGISTER_FUNCTION("iamin_complex_float", */
-/*                             iamin_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("iamin_complex_double", */
-/*                             iamin_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("scal2op_float", scal2op_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("scal2op_double", scal2op_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("scal2op_complex_float", */
-/*                             scal2op_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("scal2op_complex_double", */
-/*                             scal2op_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("scal3op_float", scal3op_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("scal3op_double", scal3op_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("scal3op_complex_float", */
-/*                             scal3op_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("scal3op_complex_double", */
-/*                             scal3op_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("axpy3op_float", axpy3op_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("axpy3op_double", axpy3op_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("axpy3op_complex_float", */
-/*                             axpy3op_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("axpy3op_complex_double", */
-/*                             axpy3op_bench<std::complex<double>>); */
 
 BENCHMARK_REGISTER_FUNCTION("blas1_float", blas1_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("blas1_double", blas1_bench<double>);
-/* BENCHMARK_REGISTER_FUNCTION("blas1_complex_float", */
-/*                             blas1_bench<std::complex<float>>); */
-/* BENCHMARK_REGISTER_FUNCTION("blas1_complex_double", */
-/*                             blas1_bench<std::complex<double>>); */
 
 BENCHMARK_MAIN_END();

--- a/bench/clblast_benchmark.cpp
+++ b/bench/clblast_benchmark.cpp
@@ -1,0 +1,358 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) 2016 Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename clblast_benchmark.cpp
+ *
+ **************************************************************************/
+
+#include "blas_benchmark.hpp"
+
+#include <complex>
+#include <vector>
+
+#include <clblast.h>
+
+#include "clwrap.hpp"
+
+#define UNPACK_PARAM using ScalarT = TypeParam;
+
+class ClBlastBenchmarker {
+  Context context;
+
+ public:
+  ClBlastBenchmarker() : context() {}
+
+  BENCHMARK_FUNCTION(scal_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT alpha(2.4367453465);
+      MemBuffer<ScalarT> buf1(context, size);
+
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 1, [&]() {
+        clblast::Scal<ScalarT>(size, alpha, buf1.dev(), 0, 1, context._queue(),
+                               &event);
+        clWaitForEvents(1, &event);
+        clReleaseEvent(event);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(axpy_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT alpha(2.4367453465);
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
+      MemBuffer<ScalarT> buf2(context, size);
+
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        clblast::Axpy<ScalarT>(size, alpha, buf1.dev(), 0, 1, buf2.dev(), 0, 1,
+                               context._queue(), &event);
+        clWaitForEvents(1, &event);
+        clReleaseEvent(event);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(asum_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT vr;
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
+      MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufr(context, &vr, 1);
+
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        clblast::Asum<ScalarT>(size, bufr.dev(), 0, buf1.dev(), 0, 1,
+                               context._queue(), &event);
+        clWaitForEvents(1, &event);
+        clReleaseEvent(event);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(nrm2_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT vr;
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
+      MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufr(context, &vr, 1);
+
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        clblast::Nrm2<ScalarT>(size, bufr.dev(), 0, buf1.dev(), 0, 1,
+                               context._queue(), &event);
+        clWaitForEvents(1, &event);
+        clReleaseEvent(event);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(dot_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT vr;
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf2(context, size);
+      MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufr(context, &vr, 1);
+
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        clblast::Dot<ScalarT>(size, bufr.dev(), 0, buf1.dev(), 0, 1, buf2.dev(),
+                              0, 1, context._queue(), &event);
+        clWaitForEvents(1, &event);
+        clReleaseEvent(event);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(iamax_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      int vi;
+      MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
+      MemBuffer<int, CL_MEM_READ_ONLY> buf_i(context, &vi, 1);
+
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        clblast::Amax<ScalarT>(size, buf_i.dev(), 0, buf1.dev(), 0, 1,
+                               context._queue(), &event);
+        clWaitForEvents(1, &event);
+        clReleaseEvent(event);
+      });
+    }
+    return flops;
+  }
+
+  // not supported at current release yet
+  /* BENCHMARK_FUNCTION(iamin_bench) { */
+  /*   UNPACK_PARAM; */
+  /*   double flops; */
+  /*   { */
+  /*     int vi; */
+  /*     MemBuffer<ScalarT> buf1(context, size); */
+  /*     MemBuffer<int> buf_i(context, &vi, 1); */
+
+  /*     cl_event event; */
+  /*     flops = benchmark<>::measure(no_reps, [&]() { */
+  /*       clblast::Amin<ScalarT>(size, buf_i.dev(), 0, buf1.dev(), 0, 1, */
+  /*                               context._queue(), &event); */
+  /*       clWaitForEvents(1, &event); */
+  /*       clReleaseEvent(event); */
+  /*     }); */
+  /*   } */
+  /*   return flops; */
+  /* } */
+
+  BENCHMARK_FUNCTION(scal2op_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT alpha(2.4367453465);
+      MemBuffer<ScalarT> buf1(context, size);
+      MemBuffer<ScalarT> buf2(context, size);
+
+      cl_event events[2];
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        clblast::Scal<ScalarT>(size, alpha, buf1.dev(), 0, 1, context._queue(),
+                               &events[0]);
+        clblast::Scal<ScalarT>(size, alpha, buf2.dev(), 0, 1, context._queue(),
+                               &events[1]);
+        clWaitForEvents(2, events);
+        clReleaseEvent(events[0]);
+        clReleaseEvent(events[1]);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(scal3op_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT alpha(2.4367453465);
+      MemBuffer<ScalarT> buf1(context, size);
+      MemBuffer<ScalarT> buf2(context, size);
+      MemBuffer<ScalarT> buf3(context, size);
+
+      cl_event events[3];
+      flops = benchmark<>::measure(no_reps, size * 3, [&]() {
+        clblast::Scal<ScalarT>(size, alpha, buf1.dev(), 0, 1, context._queue(),
+                               &events[0]);
+        clblast::Scal<ScalarT>(size, alpha, buf2.dev(), 0, 1, context._queue(),
+                               &events[1]);
+        clblast::Scal<ScalarT>(size, alpha, buf3.dev(), 0, 1, context._queue(),
+                               &events[2]);
+        clWaitForEvents(3, events);
+        clReleaseEvent(events[0]);
+        clReleaseEvent(events[1]);
+        clReleaseEvent(events[2]);
+      });
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(axpy3op_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT alphas[] = {1.78426458744, 2.187346575843, 3.78164387328};
+      size_t offsets[] = {0, size, size * 2};
+      MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufsrc(context, size * 3);
+      MemBuffer<ScalarT> bufdst(context, size * 3);
+
+      cl_event event;
+      flops = benchmark<>::measure(no_reps, size * 3 * 2, [&]() {
+        clblast::AxpyBatched<ScalarT>(size, alphas, bufsrc.dev(), offsets, 1,
+                                      bufdst.dev(), offsets, 1, 3,
+                                      context._queue(), &event);
+      });
+      clWaitForEvents(1, &event);
+      clReleaseEvent(event);
+    }
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(blas1_bench) {
+    UNPACK_PARAM;
+    double flops;
+    {
+      ScalarT alpha(3.135345123);
+      MemBuffer<ScalarT> buf1(context, size);
+      MemBuffer<ScalarT> buf2(context, size);
+      ScalarT vr[3];
+      size_t vi;
+      MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufr(context, vr, 3);
+      MemBuffer<size_t, CL_MEM_READ_ONLY> buf_i(context, &vi, 1);
+
+      cl_event events[5];
+      flops = benchmark<>::measure(no_reps, size * 12, [&]() {
+        clblast::Axpy<ScalarT>(size, alpha, buf1.dev(), 0, 1, buf2.dev(), 0, 1,
+                               context._queue(), &events[0]);
+        clblast::Asum<ScalarT>(size, bufr.dev(), 0, buf2.dev(), 0, 1,
+                               context._queue(), &events[1]);
+        clblast::Dot<ScalarT>(size, bufr.dev(), 1, buf1.dev(), 0, 1, buf2.dev(),
+                              0, 1, context._queue(), &events[2]);
+        clblast::Nrm2<ScalarT>(size, bufr.dev(), 2, buf1.dev(), 0, 1,
+                               context._queue(), &events[3]);
+        clblast::Amax<ScalarT>(size, buf_i.dev(), 0, buf1.dev(), 0, 1,
+                               context._queue(), &events[4]);
+        clWaitForEvents(5, events);
+        for (int i = 0; i < 5; ++i) clReleaseEvent(events[i]);
+      });
+    }
+    return flops;
+  }
+};
+
+BENCHMARK_MAIN_BEGIN(1 << 1, 1 << 24, 10);
+ClBlastBenchmarker blasbenchmark;
+
+BENCHMARK_REGISTER_FUNCTION("scal_float", scal_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("scal_double", scal_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("scal_complex_float", */
+/*                             scal_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("scal_complex_double", */
+/*                             scal_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("axpy_float", axpy_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("axpy_double", axpy_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("axpy_complex_float", */
+/*                             axpy_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("axpy_complex_double", */
+/*                             axpy_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("asum_float", asum_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("asum_double", asum_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("asum_complex_float", */
+/*                             asum_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("asum_complex_double", */
+/*                             asum_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("nrm2_float", nrm2_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("nrm2_double", nrm2_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("nrm2_complex_float", */
+/*                             nrm2_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("nrm2_complex_double", */
+/*                             nrm2_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("dot_float", dot_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("dot_double", dot_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("dot_complex_float", */
+/*                             dot_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("dot_complex_double", */
+/*                             dot_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("iamax_float", iamax_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("iamax_double", iamax_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("iamax_complex_float", */
+/*                             iamax_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("iamax_complex_double", */
+/*                             iamax_bench<std::complex<double>>); */
+
+/* BENCHMARK_REGISTER_FUNCTION("iamin_float", iamin_bench<float>); */
+/* BENCHMARK_REGISTER_FUNCTION("iamin_double", iamin_bench<double>); */
+/* BENCHMARK_REGISTER_FUNCTION("iamin_complex_float", */
+/*                             iamin_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("iamin_complex_double", */
+/*                             iamin_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("scal2op_float", scal2op_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("scal2op_double", scal2op_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("scal2op_complex_float", */
+/*                             scal2op_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("scal2op_complex_double", */
+/*                             scal2op_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("scal3op_float", scal3op_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("scal3op_double", scal3op_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("scal3op_complex_float", */
+/*                             scal3op_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("scal3op_complex_double", */
+/*                             scal3op_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("axpy3op_float", axpy3op_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("axpy3op_double", axpy3op_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("axpy3op_complex_float", */
+/*                             axpy3op_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("axpy3op_complex_double", */
+/*                             axpy3op_bench<std::complex<double>>); */
+
+BENCHMARK_REGISTER_FUNCTION("blas1_float", blas1_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("blas1_double", blas1_bench<double>);
+/* BENCHMARK_REGISTER_FUNCTION("blas1_complex_float", */
+/*                             blas1_bench<std::complex<float>>); */
+/* BENCHMARK_REGISTER_FUNCTION("blas1_complex_double", */
+/*                             blas1_bench<std::complex<double>>); */
+
+BENCHMARK_MAIN_END();

--- a/bench/clblast_benchmark.cpp
+++ b/bench/clblast_benchmark.cpp
@@ -32,8 +32,6 @@
 
 #include "clwrap.hpp"
 
-#define UNPACK_PARAM using ScalarT = TypeParam;
-
 class ClBlastBenchmarker {
   Context context;
 
@@ -41,82 +39,82 @@ class ClBlastBenchmarker {
   ClBlastBenchmarker() : context() {}
 
   BENCHMARK_FUNCTION(scal_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     double flops;
     {
       ScalarT alpha(2.4367453465);
       MemBuffer<ScalarT> buf1(context, size);
 
-      cl_event event;
+      Event event;
       flops = benchmark<>::measure(no_reps, size * 1, [&]() {
         clblast::Scal<ScalarT>(size, alpha, buf1.dev(), 0, 1, context._queue(),
-                               &event);
-        clWaitForEvents(1, &event);
-        clReleaseEvent(event);
+                               &event._cl());
+        event.wait();
+        event.release();
       });
     }
     return flops;
   }
 
   BENCHMARK_FUNCTION(axpy_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     double flops;
     {
       ScalarT alpha(2.4367453465);
       MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
       MemBuffer<ScalarT> buf2(context, size);
 
-      cl_event event;
+      Event event;
       flops = benchmark<>::measure(no_reps, size * 2, [&]() {
         clblast::Axpy<ScalarT>(size, alpha, buf1.dev(), 0, 1, buf2.dev(), 0, 1,
-                               context._queue(), &event);
-        clWaitForEvents(1, &event);
-        clReleaseEvent(event);
+                               context._queue(), &event._cl());
+        event.wait();
+        event.release();
       });
     }
     return flops;
   }
 
   BENCHMARK_FUNCTION(asum_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     double flops;
     {
       ScalarT vr;
       MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
       MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufr(context, &vr, 1);
 
-      cl_event event;
+      Event event;
       flops = benchmark<>::measure(no_reps, size * 2, [&]() {
         clblast::Asum<ScalarT>(size, bufr.dev(), 0, buf1.dev(), 0, 1,
-                               context._queue(), &event);
-        clWaitForEvents(1, &event);
-        clReleaseEvent(event);
+                               context._queue(), &event._cl());
+        event.wait();
+        event.release();
       });
     }
     return flops;
   }
 
   BENCHMARK_FUNCTION(nrm2_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     double flops;
     {
       ScalarT vr;
       MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
       MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufr(context, &vr, 1);
 
-      cl_event event;
+      Event event;
       flops = benchmark<>::measure(no_reps, size * 2, [&]() {
         clblast::Nrm2<ScalarT>(size, bufr.dev(), 0, buf1.dev(), 0, 1,
-                               context._queue(), &event);
-        clWaitForEvents(1, &event);
-        clReleaseEvent(event);
+                               context._queue(), &event._cl());
+        event.wait();
+        event.release();
       });
     }
     return flops;
   }
 
   BENCHMARK_FUNCTION(dot_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     double flops;
     {
       ScalarT vr;
@@ -124,80 +122,79 @@ class ClBlastBenchmarker {
       MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf2(context, size);
       MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufr(context, &vr, 1);
 
-      cl_event event;
+      Event event;
       flops = benchmark<>::measure(no_reps, size * 2, [&]() {
         clblast::Dot<ScalarT>(size, bufr.dev(), 0, buf1.dev(), 0, 1, buf2.dev(),
-                              0, 1, context._queue(), &event);
-        clWaitForEvents(1, &event);
-        clReleaseEvent(event);
+                              0, 1, context._queue(), &event._cl());
+        event.wait();
+        event.release();
       });
     }
     return flops;
   }
 
   BENCHMARK_FUNCTION(iamax_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     double flops;
     {
       int vi;
       MemBuffer<ScalarT, CL_MEM_WRITE_ONLY> buf1(context, size);
       MemBuffer<int, CL_MEM_READ_ONLY> buf_i(context, &vi, 1);
 
-      cl_event event;
+      Event event;
       flops = benchmark<>::measure(no_reps, size * 2, [&]() {
         clblast::Amax<ScalarT>(size, buf_i.dev(), 0, buf1.dev(), 0, 1,
-                               context._queue(), &event);
-        clWaitForEvents(1, &event);
-        clReleaseEvent(event);
+                               context._queue(), &event._cl());
+        event.wait();
+        event.release();
       });
     }
     return flops;
   }
 
   // not supported at current release yet
-  /* BENCHMARK_FUNCTION(iamin_bench) { */
-  /*   UNPACK_PARAM; */
-  /*   double flops; */
-  /*   { */
-  /*     int vi; */
-  /*     MemBuffer<ScalarT> buf1(context, size); */
-  /*     MemBuffer<int> buf_i(context, &vi, 1); */
+  BENCHMARK_FUNCTION(iamin_bench) {
+    using ScalarT = TypeParam;
+    double flops;
+    {
+      int vi;
+      MemBuffer<ScalarT> buf1(context, size);
+      MemBuffer<int> buf_i(context, &vi, 1);
 
-  /*     cl_event event; */
-  /*     flops = benchmark<>::measure(no_reps, [&]() { */
-  /*       clblast::Amin<ScalarT>(size, buf_i.dev(), 0, buf1.dev(), 0, 1, */
-  /*                               context._queue(), &event); */
-  /*       clWaitForEvents(1, &event); */
-  /*       clReleaseEvent(event); */
-  /*     }); */
-  /*   } */
-  /*   return flops; */
-  /* } */
+      Event event;
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        clblast::Amin<ScalarT>(size, buf_i.dev(), 0, buf1.dev(), 0, 1,
+                                context._queue(), &event._cl());
+        event.wait();
+        event.release();
+      });
+    }
+    return flops;
+  }
 
   BENCHMARK_FUNCTION(scal2op_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     double flops;
     {
       ScalarT alpha(2.4367453465);
       MemBuffer<ScalarT> buf1(context, size);
       MemBuffer<ScalarT> buf2(context, size);
 
-      cl_event events[2];
+      Event event1, event2;
       flops = benchmark<>::measure(no_reps, size * 2, [&]() {
         clblast::Scal<ScalarT>(size, alpha, buf1.dev(), 0, 1, context._queue(),
-                               &events[0]);
+                               &event1._cl());
         clblast::Scal<ScalarT>(size, alpha, buf2.dev(), 0, 1, context._queue(),
-                               &events[1]);
-        clWaitForEvents(2, events);
-        clReleaseEvent(events[0]);
-        clReleaseEvent(events[1]);
+                               &event2._cl());
+        Event::wait({event1, event2});
+        Event::release({event1, event2});
       });
     }
     return flops;
   }
 
   BENCHMARK_FUNCTION(scal3op_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     double flops;
     {
       ScalarT alpha(2.4367453465);
@@ -205,25 +202,23 @@ class ClBlastBenchmarker {
       MemBuffer<ScalarT> buf2(context, size);
       MemBuffer<ScalarT> buf3(context, size);
 
-      cl_event events[3];
+      Event event1, event2, event3;
       flops = benchmark<>::measure(no_reps, size * 3, [&]() {
         clblast::Scal<ScalarT>(size, alpha, buf1.dev(), 0, 1, context._queue(),
-                               &events[0]);
+                               &event1._cl());
         clblast::Scal<ScalarT>(size, alpha, buf2.dev(), 0, 1, context._queue(),
-                               &events[1]);
+                               &event2._cl());
         clblast::Scal<ScalarT>(size, alpha, buf3.dev(), 0, 1, context._queue(),
-                               &events[2]);
-        clWaitForEvents(3, events);
-        clReleaseEvent(events[0]);
-        clReleaseEvent(events[1]);
-        clReleaseEvent(events[2]);
+                               &event3._cl());
+        Event::wait({event1, event2, event3});
+        Event::release({event1, event2, event3});
       });
     }
     return flops;
   }
 
   BENCHMARK_FUNCTION(axpy3op_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     double flops;
     {
       ScalarT alphas[] = {1.78426458744, 2.187346575843, 3.78164387328};
@@ -231,20 +226,20 @@ class ClBlastBenchmarker {
       MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufsrc(context, size * 3);
       MemBuffer<ScalarT> bufdst(context, size * 3);
 
-      cl_event event;
+      Event event;
       flops = benchmark<>::measure(no_reps, size * 3 * 2, [&]() {
         clblast::AxpyBatched<ScalarT>(size, alphas, bufsrc.dev(), offsets, 1,
                                       bufdst.dev(), offsets, 1, 3,
-                                      context._queue(), &event);
+                                      context._queue(), &event._cl());
       });
-      clWaitForEvents(1, &event);
-      clReleaseEvent(event);
+      event.wait();
+      event.release();
     }
     return flops;
   }
 
   BENCHMARK_FUNCTION(blas1_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     double flops;
     {
       ScalarT alpha(3.135345123);
@@ -255,20 +250,20 @@ class ClBlastBenchmarker {
       MemBuffer<ScalarT, CL_MEM_READ_ONLY> bufr(context, vr, 3);
       MemBuffer<size_t, CL_MEM_READ_ONLY> buf_i(context, &vi, 1);
 
-      cl_event events[5];
+      Event events[5];
       flops = benchmark<>::measure(no_reps, size * 12, [&]() {
         clblast::Axpy<ScalarT>(size, alpha, buf1.dev(), 0, 1, buf2.dev(), 0, 1,
-                               context._queue(), &events[0]);
+                               context._queue(), &events[0]._cl());
         clblast::Asum<ScalarT>(size, bufr.dev(), 0, buf2.dev(), 0, 1,
-                               context._queue(), &events[1]);
+                               context._queue(), &events[1]._cl());
         clblast::Dot<ScalarT>(size, bufr.dev(), 1, buf1.dev(), 0, 1, buf2.dev(),
-                              0, 1, context._queue(), &events[2]);
+                              0, 1, context._queue(), &events[2]._cl());
         clblast::Nrm2<ScalarT>(size, bufr.dev(), 2, buf1.dev(), 0, 1,
-                               context._queue(), &events[3]);
+                               context._queue(), &events[3]._cl());
         clblast::Amax<ScalarT>(size, buf_i.dev(), 0, buf1.dev(), 0, 1,
-                               context._queue(), &events[4]);
-        clWaitForEvents(5, events);
-        for (int i = 0; i < 5; ++i) clReleaseEvent(events[i]);
+                               context._queue(), &events[4]._cl());
+        Event::wait({events[0], events[1], events[2], events[3], events[4]});
+        Event::release({events[0], events[1], events[2], events[3], events[4]});
       });
     }
     return flops;
@@ -296,8 +291,8 @@ BENCHMARK_REGISTER_FUNCTION("dot_double", dot_bench<double>);
 BENCHMARK_REGISTER_FUNCTION("iamax_float", iamax_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("iamax_double", iamax_bench<double>);
 
-/* BENCHMARK_REGISTER_FUNCTION("iamin_float", iamin_bench<float>); */
-/* BENCHMARK_REGISTER_FUNCTION("iamin_double", iamin_bench<double>); */
+BENCHMARK_REGISTER_FUNCTION("iamin_float", iamin_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("iamin_double", iamin_bench<double>);
 
 BENCHMARK_REGISTER_FUNCTION("scal2op_float", scal2op_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("scal2op_double", scal2op_bench<double>);

--- a/bench/clblast_benchmark.cpp
+++ b/bench/clblast_benchmark.cpp
@@ -164,7 +164,7 @@ class ClBlastBenchmarker {
       Event event;
       flops = benchmark<>::measure(no_reps, size * 2, [&]() {
         clblast::Amin<ScalarT>(size, buf_i.dev(), 0, buf1.dev(), 0, 1,
-                                context._queue(), &event._cl());
+                               context._queue(), &event._cl());
         event.wait();
         event.release();
       });
@@ -290,9 +290,6 @@ BENCHMARK_REGISTER_FUNCTION("dot_double", dot_bench<double>);
 
 BENCHMARK_REGISTER_FUNCTION("iamax_float", iamax_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("iamax_double", iamax_bench<double>);
-
-BENCHMARK_REGISTER_FUNCTION("iamin_float", iamin_bench<float>);
-BENCHMARK_REGISTER_FUNCTION("iamin_double", iamin_bench<double>);
 
 BENCHMARK_REGISTER_FUNCTION("scal2op_float", scal2op_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("scal2op_double", scal2op_bench<double>);

--- a/bench/clwrap.hpp
+++ b/bench/clwrap.hpp
@@ -39,28 +39,40 @@ class Context {
 
   static cl_uint get_platform_count() {
     cl_uint num_platforms;
-    clGetPlatformIDs(0, NULL, &num_platforms);
+    cl_int status = clGetPlatformIDs(0, NULL, &num_platforms);
+    if(status != CL_SUCCESS) {
+      throw std::runtime_error("failure in clGetPlatformIDs");
+    }
     return num_platforms;
   }
 
   static cl_platform_id get_platform_id(size_t platform_id = 0) {
     cl_uint num_platforms = get_platform_count();
     cl_platform_id platforms[num_platforms];
-    clGetPlatformIDs(num_platforms, platforms, NULL);
+    cl_int status = clGetPlatformIDs(num_platforms, platforms, NULL);
+    if(status != CL_SUCCESS) {
+      throw std::runtime_error("failure in clGetPlatformIDs");
+    }
     cl_platform_id platform = platforms[platform_id];
     return platform;
   }
 
   static cl_uint get_device_count(cl_platform_id plat) {
     cl_uint num_devices;
-    clGetDeviceIDs(plat, CL_DEVICE_TYPE_ALL, 0, NULL, &num_devices);
+    cl_int status = clGetDeviceIDs(plat, CL_DEVICE_TYPE_ALL, 0, NULL, &num_devices);
+    if(status != CL_SUCCESS) {
+      throw std::runtime_error("failure in clGetDeviceIDs");
+    }
     return num_devices;
   }
 
   static cl_device_id get_device_id(cl_platform_id plat, size_t device_id = 0) {
     cl_uint num_devices = get_device_count(plat);
     cl_device_id devices[num_devices];
-    clGetDeviceIDs(plat, CL_DEVICE_TYPE_ALL, num_devices, devices, NULL);
+    cl_int status = clGetDeviceIDs(plat, CL_DEVICE_TYPE_ALL, num_devices, devices, NULL);
+    if(status != CL_SUCCESS) {
+      throw std::runtime_error("failure in clGetDeviceIDs");
+    }
     cl_device_id device = devices[device_id];
     return device;
   }
@@ -74,14 +86,27 @@ class Context {
 
   void create() {
     if (is_active) throw std::runtime_error("context is already active");
-    context = clCreateContext(NULL, 1, &device, NULL, NULL, NULL);
-    command_queue = clCreateCommandQueue(context, device, 0, NULL);
+    cl_int status;
+    context = clCreateContext(NULL, 1, &device, NULL, NULL, &status);
+    if(status != CL_SUCCESS) {
+      throw std::runtime_error("failure to create context");
+    }
+    command_queue = clCreateCommandQueue(context, device, 0, &status);
+    if(status != CL_SUCCESS) {
+      throw std::runtime_error("failure to create command queue");
+    }
     is_active = true;
   }
 
   void release() {
-    clReleaseCommandQueue(command_queue);
-    clReleaseContext(context);
+    cl_int status = clReleaseCommandQueue(command_queue);
+    if(status != CL_SUCCESS) {
+      throw std::runtime_error("failure to release command queue");
+    }
+    status = clReleaseContext(context);
+    if(status != CL_SUCCESS) {
+      throw std::runtime_error("failure to release context");
+    }
     is_active = false;
   }
 
@@ -93,6 +118,45 @@ class Context {
 
   ~Context() {
     if (is_active) release();
+  }
+};
+
+class Event {
+  cl_event event;
+public:
+
+  Event()
+  {}
+
+  cl_event &_cl() {
+    return event;
+  }
+
+  void wait() {
+    cl_int status = clWaitForEvents(1, &event);
+    if(status != CL_SUCCESS) {
+      throw std::runtime_error("failure in clWaitForEvents");
+    }
+  }
+
+  static void wait(std::vector<Event> &&events) {
+    for(auto &ev : events) {
+      ev.wait();
+    }
+  }
+
+  void release() {
+    cl_int status = clReleaseEvent(event);
+    if(status != CL_SUCCESS) {
+      throw std::runtime_error("failure to release an event");
+    }
+  }
+
+  template <typename... EVs>
+  static void release(std::vector<Event> &&events) {
+    for(auto &&ev : events) {
+      ev.wait();
+    }
   }
 };
 
@@ -113,23 +177,33 @@ class MemBuffer {
   bool is_active = false;
 
   void init() {
-    if (is_active) throw std::runtime_error("buffer is already active");
-    dev_ptr =
-        clCreateBuffer(context, Options, size * sizeof(ScalarT), NULL, NULL);
+    if (is_active) {
+      throw std::runtime_error("buffer is already active");
+    }
+    cl_int status;
+    dev_ptr = clCreateBuffer(context, Options, size * sizeof(ScalarT), NULL, &status);
+    if(status != CL_SUCCESS) {
+      throw std::runtime_error("failure to create buffer");
+    }
     is_active = true;
-    if (to_write)
-      clEnqueueWriteBuffer(context.queue(), dev_ptr, CL_TRUE, 0,
-                           size * sizeof(ScalarT), host_ptr, 0, NULL, NULL);
+    if (to_write) {
+      status = clEnqueueWriteBuffer(context.queue(), dev_ptr, CL_TRUE, 0, size * sizeof(ScalarT), host_ptr, 0, NULL, NULL);
+      if(status != CL_SUCCESS) {
+        throw std::runtime_error("failure in clEnqueueWriteBuffer");
+      }
+    }
   }
 
  public:
-  MemBuffer(Context &ctx, ScalarT *ptr, size_t size)
-      : context(ctx), host_ptr(ptr), size(size) {
+  MemBuffer(Context &ctx, ScalarT *ptr, size_t size):
+    context(ctx), host_ptr(ptr), size(size)
+  {
     init();
   }
 
-  MemBuffer(Context &ctx, size_t size, bool initialized = true)
-      : context(ctx), size(size) {
+  MemBuffer(Context &ctx, size_t size, bool initialized = true):
+    context(ctx), size(size)
+  {
     private_host_ptr = true;
     host_ptr = new_data<ScalarT>(size, initialized);
     init();
@@ -144,17 +218,30 @@ class MemBuffer {
   ScalarT *host() { return host_ptr; }
 
   void release() {
-    if (to_read)
-      clEnqueueReadBuffer(context.queue(), dev_ptr, CL_TRUE, 0,
-                          size * sizeof(ScalarT), host_ptr, 0, NULL, NULL);
-    if (!is_active) throw std::runtime_error("cannot release inactive buffer");
-    clReleaseMemObject(dev_ptr);
+    if (to_read) {
+      cl_int status;
+      status = clEnqueueReadBuffer(context.queue(), dev_ptr, CL_TRUE, 0, size * sizeof(ScalarT), host_ptr, 0, NULL, NULL);
+      if(status != CL_SUCCESS) {
+        throw std::runtime_error("failure in clEnqueueReadBuffer");
+      }
+    }
+    if (!is_active) {
+      throw std::runtime_error("cannot release inactive buffer");
+    }
+    cl_int status = clReleaseMemObject(dev_ptr);
+    if(status != CL_SUCCESS) {
+      throw std::runtime_error("failure to release memobject");
+    }
     is_active = false;
   }
 
   ~MemBuffer() {
-    if (is_active) release();
-    if (private_host_ptr) release_data(host_ptr);
+    if (is_active) {
+      release();
+    }
+    if (private_host_ptr) {
+      release_data(host_ptr);
+    }
   }
 };
 

--- a/bench/clwrap.hpp
+++ b/bench/clwrap.hpp
@@ -40,7 +40,7 @@ class Context {
   static cl_uint get_platform_count() {
     cl_uint num_platforms;
     cl_int status = clGetPlatformIDs(0, NULL, &num_platforms);
-    if(status != CL_SUCCESS) {
+    if (status != CL_SUCCESS) {
       throw std::runtime_error("failure in clGetPlatformIDs");
     }
     return num_platforms;
@@ -50,7 +50,7 @@ class Context {
     cl_uint num_platforms = get_platform_count();
     cl_platform_id platforms[num_platforms];
     cl_int status = clGetPlatformIDs(num_platforms, platforms, NULL);
-    if(status != CL_SUCCESS) {
+    if (status != CL_SUCCESS) {
       throw std::runtime_error("failure in clGetPlatformIDs");
     }
     cl_platform_id platform = platforms[platform_id];
@@ -59,8 +59,9 @@ class Context {
 
   static cl_uint get_device_count(cl_platform_id plat) {
     cl_uint num_devices;
-    cl_int status = clGetDeviceIDs(plat, CL_DEVICE_TYPE_ALL, 0, NULL, &num_devices);
-    if(status != CL_SUCCESS) {
+    cl_int status =
+        clGetDeviceIDs(plat, CL_DEVICE_TYPE_ALL, 0, NULL, &num_devices);
+    if (status != CL_SUCCESS) {
       throw std::runtime_error("failure in clGetDeviceIDs");
     }
     return num_devices;
@@ -69,8 +70,9 @@ class Context {
   static cl_device_id get_device_id(cl_platform_id plat, size_t device_id = 0) {
     cl_uint num_devices = get_device_count(plat);
     cl_device_id devices[num_devices];
-    cl_int status = clGetDeviceIDs(plat, CL_DEVICE_TYPE_ALL, num_devices, devices, NULL);
-    if(status != CL_SUCCESS) {
+    cl_int status =
+        clGetDeviceIDs(plat, CL_DEVICE_TYPE_ALL, num_devices, devices, NULL);
+    if (status != CL_SUCCESS) {
       throw std::runtime_error("failure in clGetDeviceIDs");
     }
     cl_device_id device = devices[device_id];
@@ -88,11 +90,11 @@ class Context {
     if (is_active) throw std::runtime_error("context is already active");
     cl_int status;
     context = clCreateContext(NULL, 1, &device, NULL, NULL, &status);
-    if(status != CL_SUCCESS) {
+    if (status != CL_SUCCESS) {
       throw std::runtime_error("failure to create context");
     }
     command_queue = clCreateCommandQueue(context, device, 0, &status);
-    if(status != CL_SUCCESS) {
+    if (status != CL_SUCCESS) {
       throw std::runtime_error("failure to create command queue");
     }
     is_active = true;
@@ -100,11 +102,11 @@ class Context {
 
   void release() {
     cl_int status = clReleaseCommandQueue(command_queue);
-    if(status != CL_SUCCESS) {
+    if (status != CL_SUCCESS) {
       throw std::runtime_error("failure to release command queue");
     }
     status = clReleaseContext(context);
-    if(status != CL_SUCCESS) {
+    if (status != CL_SUCCESS) {
       throw std::runtime_error("failure to release context");
     }
     is_active = false;
@@ -123,38 +125,35 @@ class Context {
 
 class Event {
   cl_event event;
-public:
 
-  Event()
-  {}
+ public:
+  Event() {}
 
-  cl_event &_cl() {
-    return event;
-  }
+  cl_event &_cl() { return event; }
 
   void wait() {
     cl_int status = clWaitForEvents(1, &event);
-    if(status != CL_SUCCESS) {
+    if (status != CL_SUCCESS) {
       throw std::runtime_error("failure in clWaitForEvents");
     }
   }
 
   static void wait(std::vector<Event> &&events) {
-    for(auto &ev : events) {
+    for (auto &ev : events) {
       ev.wait();
     }
   }
 
   void release() {
     cl_int status = clReleaseEvent(event);
-    if(status != CL_SUCCESS) {
+    if (status != CL_SUCCESS) {
       throw std::runtime_error("failure to release an event");
     }
   }
 
   template <typename... EVs>
   static void release(std::vector<Event> &&events) {
-    for(auto &&ev : events) {
+    for (auto &&ev : events) {
       ev.wait();
     }
   }
@@ -181,29 +180,30 @@ class MemBuffer {
       throw std::runtime_error("buffer is already active");
     }
     cl_int status;
-    dev_ptr = clCreateBuffer(context, Options, size * sizeof(ScalarT), NULL, &status);
-    if(status != CL_SUCCESS) {
+    dev_ptr =
+        clCreateBuffer(context, Options, size * sizeof(ScalarT), NULL, &status);
+    if (status != CL_SUCCESS) {
       throw std::runtime_error("failure to create buffer");
     }
     is_active = true;
     if (to_write) {
-      status = clEnqueueWriteBuffer(context.queue(), dev_ptr, CL_TRUE, 0, size * sizeof(ScalarT), host_ptr, 0, NULL, NULL);
-      if(status != CL_SUCCESS) {
+      status =
+          clEnqueueWriteBuffer(context.queue(), dev_ptr, CL_TRUE, 0,
+                               size * sizeof(ScalarT), host_ptr, 0, NULL, NULL);
+      if (status != CL_SUCCESS) {
         throw std::runtime_error("failure in clEnqueueWriteBuffer");
       }
     }
   }
 
  public:
-  MemBuffer(Context &ctx, ScalarT *ptr, size_t size):
-    context(ctx), host_ptr(ptr), size(size)
-  {
+  MemBuffer(Context &ctx, ScalarT *ptr, size_t size)
+      : context(ctx), host_ptr(ptr), size(size) {
     init();
   }
 
-  MemBuffer(Context &ctx, size_t size, bool initialized = true):
-    context(ctx), size(size)
-  {
+  MemBuffer(Context &ctx, size_t size, bool initialized = true)
+      : context(ctx), size(size) {
     private_host_ptr = true;
     host_ptr = new_data<ScalarT>(size, initialized);
     init();
@@ -220,8 +220,10 @@ class MemBuffer {
   void release() {
     if (to_read) {
       cl_int status;
-      status = clEnqueueReadBuffer(context.queue(), dev_ptr, CL_TRUE, 0, size * sizeof(ScalarT), host_ptr, 0, NULL, NULL);
-      if(status != CL_SUCCESS) {
+      status =
+          clEnqueueReadBuffer(context.queue(), dev_ptr, CL_TRUE, 0,
+                              size * sizeof(ScalarT), host_ptr, 0, NULL, NULL);
+      if (status != CL_SUCCESS) {
         throw std::runtime_error("failure in clEnqueueReadBuffer");
       }
     }
@@ -229,7 +231,7 @@ class MemBuffer {
       throw std::runtime_error("cannot release inactive buffer");
     }
     cl_int status = clReleaseMemObject(dev_ptr);
-    if(status != CL_SUCCESS) {
+    if (status != CL_SUCCESS) {
       throw std::runtime_error("failure to release memobject");
     }
     is_active = false;

--- a/bench/clwrap.hpp
+++ b/bench/clwrap.hpp
@@ -1,0 +1,161 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) 2016 Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename clwrap.cpp
+ *
+ **************************************************************************/
+
+#ifndef CLWRAP_HPP
+#define CLWRAP_HPP
+
+#include <stdexcept>
+
+#include <CL/cl.h>
+
+class Context {
+  cl_platform_id platform = NULL;
+  cl_device_id device = NULL;
+  cl_context context = NULL;
+  cl_command_queue command_queue = NULL;
+  bool is_active = false;
+
+  static cl_uint get_platform_count() {
+    cl_uint num_platforms;
+    clGetPlatformIDs(0, NULL, &num_platforms);
+    return num_platforms;
+  }
+
+  static cl_platform_id get_platform_id(size_t platform_id = 0) {
+    cl_uint num_platforms = get_platform_count();
+    cl_platform_id platforms[num_platforms];
+    clGetPlatformIDs(num_platforms, platforms, NULL);
+    cl_platform_id platform = platforms[platform_id];
+    return platform;
+  }
+
+  static cl_uint get_device_count(cl_platform_id plat) {
+    cl_uint num_devices;
+    clGetDeviceIDs(plat, CL_DEVICE_TYPE_ALL, 0, NULL, &num_devices);
+    return num_devices;
+  }
+
+  static cl_device_id get_device_id(cl_platform_id plat, size_t device_id = 0) {
+    cl_uint num_devices = get_device_count(plat);
+    cl_device_id devices[num_devices];
+    clGetDeviceIDs(plat, CL_DEVICE_TYPE_ALL, num_devices, devices, NULL);
+    cl_device_id device = devices[device_id];
+    return device;
+  }
+
+ public:
+  Context(size_t plat_id = 0, size_t dev_id = 0) {
+    platform = get_platform_id(plat_id);
+    device = get_device_id(platform, dev_id);
+    create();
+  }
+
+  void create() {
+    if (is_active) throw std::runtime_error("context is already active");
+    context = clCreateContext(NULL, 1, &device, NULL, NULL, NULL);
+    command_queue = clCreateCommandQueue(context, device, 0, NULL);
+    is_active = true;
+  }
+
+  void release() {
+    clReleaseCommandQueue(command_queue);
+    clReleaseContext(context);
+    is_active = false;
+  }
+
+  operator cl_context() const { return context; }
+
+  cl_command_queue *_queue() { return &command_queue; }
+
+  cl_command_queue queue() const { return command_queue; }
+
+  ~Context() {
+    if (is_active) release();
+  }
+};
+
+template <typename ScalarT, int Options = CL_MEM_READ_WRITE>
+class MemBuffer {
+ public:
+  static constexpr const bool to_write =
+      (Options == CL_MEM_READ_WRITE || Options == CL_MEM_WRITE_ONLY);
+  static constexpr const bool to_read =
+      (Options == CL_MEM_READ_WRITE || Options == CL_MEM_READ_ONLY);
+
+ private:
+  Context &context;
+  size_t size = 0;
+  cl_mem dev_ptr = NULL;
+  ScalarT *host_ptr = NULL;
+  bool private_host_ptr = false;
+  bool is_active = false;
+
+  void init() {
+    if (is_active) throw std::runtime_error("buffer is already active");
+    dev_ptr =
+        clCreateBuffer(context, Options, size * sizeof(ScalarT), NULL, NULL);
+    is_active = true;
+    if (to_write)
+      clEnqueueWriteBuffer(context.queue(), dev_ptr, CL_TRUE, 0,
+                           size * sizeof(ScalarT), host_ptr, 0, NULL, NULL);
+  }
+
+ public:
+  MemBuffer(Context &ctx, ScalarT *ptr, size_t size)
+      : context(ctx), host_ptr(ptr), size(size) {
+    init();
+  }
+
+  MemBuffer(Context &ctx, size_t size, bool initialized = true)
+      : context(ctx), size(size) {
+    private_host_ptr = true;
+    host_ptr = new_data<ScalarT>(size, initialized);
+    init();
+  }
+
+  ScalarT operator[](size_t i) const { return host_ptr[i]; }
+
+  ScalarT &operator[](size_t i) { return host_ptr[i]; }
+
+  cl_mem dev() { return dev_ptr; }
+
+  ScalarT *host() { return host_ptr; }
+
+  void release() {
+    if (to_read)
+      clEnqueueReadBuffer(context.queue(), dev_ptr, CL_TRUE, 0,
+                          size * sizeof(ScalarT), host_ptr, 0, NULL, NULL);
+    if (!is_active) throw std::runtime_error("cannot release inactive buffer");
+    clReleaseMemObject(dev_ptr);
+    is_active = false;
+  }
+
+  ~MemBuffer() {
+    if (is_active) release();
+    if (private_host_ptr) release_data(host_ptr);
+  }
+};
+
+#endif /* end of include guard: CLWRAP_HPP */

--- a/bench/syclblas_benchmark.cpp
+++ b/bench/syclblas_benchmark.cpp
@@ -29,8 +29,6 @@
 
 using namespace blas;
 
-#define UNPACK_PARAM using ScalarT = TypeParam;
-
 template <typename ExecutorType = SYCL>
 class SyclBlasBenchmarker {
   cl::sycl::queue q;
@@ -64,7 +62,7 @@ class SyclBlasBenchmarker {
   }
 
   BENCHMARK_FUNCTION(scal_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     ScalarT *v1 = new_data<ScalarT>(size);
     ScalarT alpha(2.4367453465);
     double flops;
@@ -81,7 +79,7 @@ class SyclBlasBenchmarker {
   }
 
   BENCHMARK_FUNCTION(axpy_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     ScalarT *v1 = new_data<ScalarT>(size);
     ScalarT *v2 = new_data<ScalarT>(size);
     ScalarT alpha(2.4367453465);
@@ -102,7 +100,7 @@ class SyclBlasBenchmarker {
   }
 
   BENCHMARK_FUNCTION(asum_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     ScalarT *v1 = new_data<ScalarT>(size);
     ScalarT vr;
     double flops;
@@ -121,7 +119,7 @@ class SyclBlasBenchmarker {
   }
 
   BENCHMARK_FUNCTION(nrm2_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     ScalarT *v1 = new_data<ScalarT>(size);
     ScalarT vr;
     double flops;
@@ -140,7 +138,7 @@ class SyclBlasBenchmarker {
   }
 
   BENCHMARK_FUNCTION(dot_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     ScalarT *v1 = new_data<ScalarT>(size);
     ScalarT *v2 = new_data<ScalarT>(size);
     ScalarT vr;
@@ -163,7 +161,7 @@ class SyclBlasBenchmarker {
   }
 
   BENCHMARK_FUNCTION(iamax_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     ScalarT *v1 = new_data<ScalarT>(size);
     IndVal<ScalarT> vI(std::numeric_limits<size_t>::max(), 0);
     double flops;
@@ -182,7 +180,7 @@ class SyclBlasBenchmarker {
   }
 
   BENCHMARK_FUNCTION(iamin_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     ScalarT *v1 = new_data<ScalarT>(size);
     IndVal<ScalarT> vI(std::numeric_limits<size_t>::max(), 0);
     double flops;
@@ -201,7 +199,7 @@ class SyclBlasBenchmarker {
   }
 
   BENCHMARK_FUNCTION(scal2op_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     ScalarT alpha(2.4367453465);
     ScalarT *v1 = new_data<ScalarT>(size);
     ScalarT *v2 = new_data<ScalarT>(size);
@@ -225,7 +223,7 @@ class SyclBlasBenchmarker {
   }
 
   BENCHMARK_FUNCTION(scal3op_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     ScalarT alpha(2.4367453465);
     ScalarT *v1 = new_data<ScalarT>(size);
     ScalarT *v2 = new_data<ScalarT>(size);
@@ -254,7 +252,7 @@ class SyclBlasBenchmarker {
   }
 
   BENCHMARK_FUNCTION(axpy3op_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     std::array<ScalarT, 3> alphas = {1.78426458744, 2.187346575843,
                                      3.78164387328};
     ScalarT *vsrc1 = new_data<ScalarT>(size);
@@ -296,7 +294,7 @@ class SyclBlasBenchmarker {
   }
 
   BENCHMARK_FUNCTION(blas1_bench) {
-    UNPACK_PARAM;
+    using ScalarT = TypeParam;
     ScalarT *v1 = new_data<ScalarT>(size);
     ScalarT *v2 = new_data<ScalarT>(size);
     ScalarT vr[4];

--- a/bench/syclblas_benchmark.cpp
+++ b/bench/syclblas_benchmark.cpp
@@ -356,11 +356,9 @@ BENCHMARK_REGISTER_FUNCTION("nrm2_double", nrm2_bench<double>);
 BENCHMARK_REGISTER_FUNCTION("dot_float", dot_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("dot_double", dot_bench<double>);
 
+// constant<float, imax> is not defined, so the float version will fail
 /* BENCHMARK_REGISTER_FUNCTION("iamax_float", iamax_bench<float>); */
 BENCHMARK_REGISTER_FUNCTION("iamax_double", iamax_bench<double>);
-
-/* BENCHMARK_REGISTER_FUNCTION("iamin_float", iamin_bench<float>); */
-/* BENCHMARK_REGISTER_FUNCTION("iamin_double", iamin_bench<double>); */
 
 BENCHMARK_REGISTER_FUNCTION("scal2op_float", scal2op_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("scal2op_double", scal2op_bench<double>);
@@ -371,6 +369,7 @@ BENCHMARK_REGISTER_FUNCTION("scal3op_double", scal3op_bench<double>);
 BENCHMARK_REGISTER_FUNCTION("axpy3op_float", axpy3op_bench<float>);
 BENCHMARK_REGISTER_FUNCTION("axpy3op_double", axpy3op_bench<double>);
 
+// constant<float, imax> is not defined, so the float version will fail
 /* BENCHMARK_REGISTER_FUNCTION("blas1_float", blas1_bench<float>); */
 BENCHMARK_REGISTER_FUNCTION("blas1_double", blas1_bench<double>);
 

--- a/bench/syclblas_benchmark.cpp
+++ b/bench/syclblas_benchmark.cpp
@@ -1,0 +1,379 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) 2016 Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename syclblas_benchmark.cpp
+ *
+ **************************************************************************/
+
+#include "blas_benchmark.hpp"
+
+#include <interface/blas1_interface_sycl.hpp>
+
+using namespace blas;
+
+#define UNPACK_PARAM using ScalarT = TypeParam;
+
+template <typename ExecutorType = SYCL>
+class SyclBlasBenchmarker {
+  cl::sycl::queue q;
+  Executor<ExecutorType> ex;
+
+ public:
+  SyclBlasBenchmarker()
+      : q(cl::sycl::default_selector(),
+          [=](cl::sycl::exception_list eL) {
+            for (auto &e : eL) {
+              try {
+                std::rethrow_exception(e);
+              } catch (cl::sycl::exception &e) {
+                std::cout << " E " << e.what() << std::endl;
+              } catch (...) {
+                std::cout << " An exception " << std::endl;
+              }
+            }
+          }),
+        ex(q) {}
+
+  template <typename ScalarT>
+  static cl::sycl::buffer<ScalarT, 1> mkbuffer(ScalarT *data, size_t len) {
+    return cl::sycl::buffer<ScalarT, 1>(data, len);
+  }
+
+  template <typename ScalarT>
+  static vector_view<ScalarT, cl::sycl::buffer<ScalarT>> mkvview(
+      cl::sycl::buffer<ScalarT, 1> &buf) {
+    return vector_view<ScalarT, cl::sycl::buffer<ScalarT>>(buf);
+  }
+
+  BENCHMARK_FUNCTION(scal_bench) {
+    UNPACK_PARAM;
+    ScalarT *v1 = new_data<ScalarT>(size);
+    ScalarT alpha(2.4367453465);
+    double flops;
+    {
+      auto buf1 = mkbuffer<ScalarT>(v1, size);
+      auto vvw1 = mkvview(buf1);
+      flops = benchmark<>::measure(no_reps, size * 1, [&]() {
+        _scal(ex, size, alpha, vvw1, 1);
+        q.wait_and_throw();
+      });
+    }
+    release_data(v1);
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(axpy_bench) {
+    UNPACK_PARAM;
+    ScalarT *v1 = new_data<ScalarT>(size);
+    ScalarT *v2 = new_data<ScalarT>(size);
+    ScalarT alpha(2.4367453465);
+    double flops;
+    {
+      auto buf1 = mkbuffer<ScalarT>(v1, size);
+      auto buf2 = mkbuffer<ScalarT>(v2, size);
+      auto vvw1 = mkvview(buf1);
+      auto vvw2 = mkvview(buf2);
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        _axpy(ex, size, alpha, vvw1, 1, vvw2, 1);
+        q.wait_and_throw();
+      });
+    }
+    release_data(v1);
+    release_data(v2);
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(asum_bench) {
+    UNPACK_PARAM;
+    ScalarT *v1 = new_data<ScalarT>(size);
+    ScalarT vr;
+    double flops;
+    {
+      auto buf1 = mkbuffer<ScalarT>(v1, size);
+      auto bufR = mkbuffer<ScalarT>(&vr, 1);
+      auto vvw1 = mkvview(buf1);
+      auto vvwR = mkvview(bufR);
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        _asum(ex, size, vvw1, 1, vvwR);
+        q.wait_and_throw();
+      });
+    }
+    release_data(v1);
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(nrm2_bench) {
+    UNPACK_PARAM;
+    ScalarT *v1 = new_data<ScalarT>(size);
+    ScalarT vr;
+    double flops;
+    {
+      auto buf1 = mkbuffer<ScalarT>(v1, size);
+      auto bufR = mkbuffer<ScalarT>(&vr, 1);
+      auto vvw1 = mkvview(buf1);
+      auto vvwR = mkvview(bufR);
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        _nrm2(ex, size, vvw1, 1, vvwR);
+        q.wait_and_throw();
+      });
+    }
+    release_data(v1);
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(dot_bench) {
+    UNPACK_PARAM;
+    ScalarT *v1 = new_data<ScalarT>(size);
+    ScalarT *v2 = new_data<ScalarT>(size);
+    ScalarT vr;
+    double flops;
+    {
+      auto buf1 = mkbuffer<ScalarT>(v1, size);
+      auto buf2 = mkbuffer<ScalarT>(v2, size);
+      auto bufR = mkbuffer<ScalarT>(&vr, 1);
+      auto vvw1 = mkvview(buf1);
+      auto vvw2 = mkvview(buf2);
+      auto vvwR = mkvview(bufR);
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        _dot(ex, size, vvw1, 1, vvw2, 1, vvwR);
+        q.wait_and_throw();
+      });
+    }
+    release_data(v1);
+    release_data(v2);
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(iamax_bench) {
+    UNPACK_PARAM;
+    ScalarT *v1 = new_data<ScalarT>(size);
+    IndVal<ScalarT> vI(std::numeric_limits<size_t>::max(), 0);
+    double flops;
+    {
+      auto buf1 = mkbuffer<ScalarT>(v1, size);
+      auto buf_i = mkbuffer<IndVal<ScalarT>>(&vI, 1);
+      auto vvw1 = mkvview(buf1);
+      auto vvw_i = mkvview(buf_i);
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        _iamax(ex, size, vvw1, 1, vvw_i);
+        q.wait_and_throw();
+      });
+    }
+    release_data(v1);
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(iamin_bench) {
+    UNPACK_PARAM;
+    ScalarT *v1 = new_data<ScalarT>(size);
+    IndVal<ScalarT> vI(std::numeric_limits<size_t>::max(), 0);
+    double flops;
+    {
+      auto buf1 = mkbuffer<ScalarT>(v1, size);
+      auto buf_i = mkbuffer<IndVal<ScalarT>>(&vI, 1);
+      auto vvw1 = mkvview(buf1);
+      auto vvw_i = mkvview(buf_i);
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        _iamin(ex, size, vvw1, 1, vvw_i);
+        q.wait_and_throw();
+      });
+    }
+    release_data(v1);
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(scal2op_bench) {
+    UNPACK_PARAM;
+    ScalarT alpha(2.4367453465);
+    ScalarT *v1 = new_data<ScalarT>(size);
+    ScalarT *v2 = new_data<ScalarT>(size);
+    double flops;
+    {
+      auto buf1 = mkbuffer<ScalarT>(v1, size);
+      auto buf2 = mkbuffer<ScalarT>(v2, size);
+
+      auto vvw1 = mkvview(buf1);
+      auto vvw2 = mkvview(buf2);
+
+      flops = benchmark<>::measure(no_reps, size * 2, [&]() {
+        _scal(ex, size, alpha, vvw1, 1);
+        _scal(ex, size, alpha, vvw2, 1);
+        q.wait_and_throw();
+      });
+    }
+    release_data(v1);
+    release_data(v2);
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(scal3op_bench) {
+    UNPACK_PARAM;
+    ScalarT alpha(2.4367453465);
+    ScalarT *v1 = new_data<ScalarT>(size);
+    ScalarT *v2 = new_data<ScalarT>(size);
+    ScalarT *v3 = new_data<ScalarT>(size);
+    double flops;
+    {
+      auto buf1 = mkbuffer<ScalarT>(v1, size);
+      auto buf2 = mkbuffer<ScalarT>(v2, size);
+      auto buf3 = mkbuffer<ScalarT>(v3, size);
+
+      auto vvw1 = mkvview(buf1);
+      auto vvw2 = mkvview(buf2);
+      auto vvw3 = mkvview(buf3);
+
+      flops = benchmark<>::measure(no_reps, size * 3, [&]() {
+        _scal(ex, size, alpha, vvw1, 1);
+        _scal(ex, size, alpha, vvw2, 1);
+        _scal(ex, size, alpha, vvw3, 1);
+        q.wait_and_throw();
+      });
+    }
+    release_data(v1);
+    release_data(v2);
+    release_data(v3);
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(axpy3op_bench) {
+    UNPACK_PARAM;
+    std::array<ScalarT, 3> alphas = {1.78426458744, 2.187346575843,
+                                     3.78164387328};
+    ScalarT *vsrc1 = new_data<ScalarT>(size);
+    ScalarT *vsrc2 = new_data<ScalarT>(size);
+    ScalarT *vsrc3 = new_data<ScalarT>(size);
+    ScalarT *vdst1 = new_data<ScalarT>(size);
+    ScalarT *vdst2 = new_data<ScalarT>(size);
+    ScalarT *vdst3 = new_data<ScalarT>(size);
+    double flops;
+    {
+      auto bufsrc1 = mkbuffer<ScalarT>(vsrc1, size);
+      auto bufsrc2 = mkbuffer<ScalarT>(vsrc2, size);
+      auto bufsrc3 = mkbuffer<ScalarT>(vsrc3, size);
+      auto bufdst1 = mkbuffer<ScalarT>(vdst1, size);
+      auto bufdst2 = mkbuffer<ScalarT>(vdst2, size);
+      auto bufdst3 = mkbuffer<ScalarT>(vdst3, size);
+
+      auto vvwsrc1 = mkvview(bufsrc1);
+      auto vvwsrc2 = mkvview(bufsrc2);
+      auto vvwsrc3 = mkvview(bufsrc3);
+      auto vvwdst1 = mkvview(bufdst1);
+      auto vvwdst2 = mkvview(bufdst2);
+      auto vvwdst3 = mkvview(bufdst3);
+
+      flops = benchmark<>::measure(no_reps, size * 3 * 2, [&]() {
+        _axpy(ex, size, alphas[0], vvwsrc1, 1, vvwdst1, 1);
+        _axpy(ex, size, alphas[1], vvwsrc2, 1, vvwdst2, 1);
+        _axpy(ex, size, alphas[2], vvwsrc3, 1, vvwdst3, 1);
+        q.wait_and_throw();
+      });
+    }
+    release_data(vsrc1);
+    release_data(vsrc2);
+    release_data(vsrc3);
+    release_data(vdst1);
+    release_data(vdst2);
+    release_data(vdst3);
+    return flops;
+  }
+
+  BENCHMARK_FUNCTION(blas1_bench) {
+    UNPACK_PARAM;
+    ScalarT *v1 = new_data<ScalarT>(size);
+    ScalarT *v2 = new_data<ScalarT>(size);
+    ScalarT vr[4];
+    IndVal<ScalarT> vImax(std::numeric_limits<size_t>::max(), 0);
+    /* IndVal<ScalarT> vImin(std::numeric_limits<size_t>::max(), 0); */
+    ScalarT alpha(3.135345123);
+    double flops;
+    {
+      auto buf1 = mkbuffer<ScalarT>(v1, size);
+      auto buf2 = mkbuffer<ScalarT>(v2, size);
+      auto bufr0 = mkbuffer<ScalarT>(&vr[0], 1);
+      auto bufr1 = mkbuffer<ScalarT>(&vr[1], 1);
+      auto bufr2 = mkbuffer<ScalarT>(&vr[2], 1);
+      auto bufr3 = mkbuffer<ScalarT>(&vr[3], 1);
+      auto buf_i1 = mkbuffer<IndVal<ScalarT>>(&vImax, 1);
+      /* auto buf_i2 = mkbuffer<IndVal<ScalarT>>(&vImin, 1); */
+
+      auto vvw1 = mkvview(buf1);
+      auto vvw2 = mkvview(buf2);
+      auto vvwr0 = mkvview(bufr0);
+      auto vvwr1 = mkvview(bufr1);
+      auto vvwr2 = mkvview(bufr2);
+      auto vvwr3 = mkvview(bufr3);
+      auto vvw_i1 = mkvview(buf_i1);
+      /* auto vvw_i2 = mkvview(buf_i2); */
+
+      flops = benchmark<>::measure(no_reps, size * 12, [&]() {
+        _axpy(ex, size, alpha, vvw1, 1, vvw2, 1);
+        _asum(ex, size, vvw2, 1, vvwr0);
+        _dot(ex, size, vvw1, 1, vvw2, 1, vvwr1);
+        _nrm2(ex, size, vvw2, 1, vvwr2);
+        _iamax(ex, size, vvw2, 1, vvw_i1);
+        /* _iamin(ex, size, vvw2, 1, vvw_i2); */
+        _dot(ex, size, vvw1, 1, vvw2, 1, vvwr3);
+        q.wait_and_throw();
+      });
+    }
+    release_data(v1);
+    release_data(v2);
+    return flops;
+  }
+};
+
+BENCHMARK_MAIN_BEGIN(1 << 1, 1 << 24, 10);
+SyclBlasBenchmarker<SYCL> blasbenchmark;
+
+BENCHMARK_REGISTER_FUNCTION("scal_float", scal_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("scal_double", scal_bench<double>);
+
+BENCHMARK_REGISTER_FUNCTION("axpy_float", axpy_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("axpy_double", axpy_bench<double>);
+
+BENCHMARK_REGISTER_FUNCTION("asum_float", asum_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("asum_double", asum_bench<double>);
+
+BENCHMARK_REGISTER_FUNCTION("nrm2_float", nrm2_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("nrm2_double", nrm2_bench<double>);
+
+BENCHMARK_REGISTER_FUNCTION("dot_float", dot_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("dot_double", dot_bench<double>);
+
+/* BENCHMARK_REGISTER_FUNCTION("iamax_float", iamax_bench<float>); */
+BENCHMARK_REGISTER_FUNCTION("iamax_double", iamax_bench<double>);
+
+/* BENCHMARK_REGISTER_FUNCTION("iamin_float", iamin_bench<float>); */
+/* BENCHMARK_REGISTER_FUNCTION("iamin_double", iamin_bench<double>); */
+
+BENCHMARK_REGISTER_FUNCTION("scal2op_float", scal2op_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("scal2op_double", scal2op_bench<double>);
+
+BENCHMARK_REGISTER_FUNCTION("scal3op_float", scal3op_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("scal3op_double", scal3op_bench<double>);
+
+BENCHMARK_REGISTER_FUNCTION("axpy3op_float", axpy3op_bench<float>);
+BENCHMARK_REGISTER_FUNCTION("axpy3op_double", axpy3op_bench<double>);
+
+/* BENCHMARK_REGISTER_FUNCTION("blas1_float", blas1_bench<float>); */
+BENCHMARK_REGISTER_FUNCTION("blas1_double", blas1_bench<double>);
+
+BENCHMARK_MAIN_END();


### PR DESCRIPTION
Here I have benchmarks for syclblas (BLAS1 only). Because clblas and clblast benchmarks have a lot in common with this one, I will use the comments from this pr to improve the others before proposing a further change. See #21, mehdi-goli#7.