### PR TITLE
Add GEMM transposed tests to unit test and remove invalid logging code

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ function mak {
 
 function tst {
     pushd build/test
-    ctest -VV --timeout 600
+    ctest -VV --timeout 1200
     popd
 }
 

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@ mkdir build
 cd build
 cmake .. -DCOMPUTECPP_PACKAGE_ROOT_DIR=$1 -DCMAKE_BUILD_TYPE=Release -DVERBOSE=TRUE
 make
-make test
+ctest -VV

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 mkdir build
 cd build
-cmake .. -DCOMPUTECPP_PACKAGE_ROOT_DIR=$1 -DCMAKE_BUILD_TYPE=Release -DOPENBLAS_ROOT=/tmp/OpenBLAS/build
+cmake .. -DCOMPUTECPP_PACKAGE_ROOT_DIR=$1 -DCMAKE_BUILD_TYPE=Release -DVERBOSE=TRUE
 make
 make test

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -75,24 +75,26 @@ struct option_prec;
 
 // Wraps the above arguments into one template parameter.
 // We will treat template-specialized blas_templ_struct as a single class
-template <class ScalarT_, class ExecutorType_>
+template <class ScalarT_, class MetadataT_, class ExecutorType_>
 struct blas_templ_struct {
   using scalar_t = ScalarT_;
+  using metadata_t = MetadataT_;
   using executor_t = ExecutorType_;
 };
 // A "using" shortcut for the struct
-template <class ScalarT_, class ExecutorType_ = SYCL>
-using blas_test_args = blas_templ_struct<ScalarT_, ExecutorType_>;
+template <class ScalarT_, class MetadataT_ = void, class ExecutorType_ = SYCL>
+using blas_test_args = blas_templ_struct<ScalarT_, MetadataT_, ExecutorType_>;
 
 // the test class itself
 template <class B>
 class BLAS_Test;
 
-template <class ScalarT_, class ExecutorType_>
-class BLAS_Test<blas_test_args<ScalarT_, ExecutorType_>>
+template <class ScalarT_, class MetadataT_, class ExecutorType_>
+class BLAS_Test<blas_test_args<ScalarT_, MetadataT_, ExecutorType_>>
     : public ::testing::Test {
  public:
   using ScalarT = ScalarT_;
+  using MetadataT = MetadataT_;
   using ExecutorType = ExecutorType_;
 
   BLAS_Test() = default;

--- a/test/unittest/blas1_rotg_test.cpp
+++ b/test/unittest/blas1_rotg_test.cpp
@@ -41,9 +41,6 @@ TYPED_TEST(BLAS_Test, rotg_test) {
   using TestClass = BLAS_Test<TypeParam>;
   using test = class rotg_test;
 
-  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
-  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
-
   size_t size = TestClass::template test_size<test>();
   long strd = TestClass::template test_strd<test>();
   ScalarT prec = TestClass::template test_prec<test>();

--- a/test/unittest/blas2_gemv_test.cpp
+++ b/test/unittest/blas2_gemv_test.cpp
@@ -50,8 +50,6 @@ TYPED_TEST(BLAS_Test, gemv_test) {
   ScalarT alpha = ScalarT(1);
   ScalarT beta = ScalarT(1);
 
-  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
-  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
   // Input matrix
   std::vector<ScalarT> a_m(m * n);
   // Input Vector

--- a/test/unittest/blas2_ger_test.cpp
+++ b/test/unittest/blas2_ger_test.cpp
@@ -48,8 +48,6 @@ TYPED_TEST(BLAS_Test, ger_test) {
   ScalarT prec = TestClass::template test_prec<test>();
   ScalarT alpha = ScalarT(3);
 
-  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
-  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
   // Input matrix
   std::vector<ScalarT> a_v(m);
   // Input Vector

--- a/test/unittest/blas3_gemm_test.cpp
+++ b/test/unittest/blas3_gemm_test.cpp
@@ -25,7 +25,6 @@
 
 #include "blas_test.hpp"
 
-
 class Normal {
   public:
   static constexpr char const* str = "n";

--- a/test/unittest/blas3_gemm_test.cpp
+++ b/test/unittest/blas3_gemm_test.cpp
@@ -32,6 +32,7 @@ TYPED_TEST_CASE(BLAS_Test, BlasTypes);
 
 template <typename TypeParam> 
 void _gemm_test_impl(typename TypeParam::scalar_t prec, const char* ta_str, const char* tb_str) { 
+  DEBUG_PRINT(std::cout << "gemm test with transpositions: A: "<<ta_str<< ", B: " << tb_str << std::endl);
   using ScalarT = typename TypeParam::scalar_t;
   using ExecutorType = typename TypeParam::executor_t;
   using TestClass = BLAS_Test<TypeParam>;

--- a/test/unittest/sycl_buffer_test.cpp
+++ b/test/unittest/sycl_buffer_test.cpp
@@ -45,6 +45,7 @@ TYPED_TEST(BLAS_Test, sycl_buffer_test) {
   size_t size = TestClass::template test_size<test>();
   std::ptrdiff_t offset = TestClass::template test_strd<test>();
   ScalarT prec = TestClass::template test_prec<test>();
+  size_t strd = TestClass::template test_strd<test>();
 
   DEBUG_PRINT(std::cout << "size == " << size << std::endl);
   DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);


### PR DESCRIPTION
This PR implements the nine possible transposed/other variants for gemm, as well as removing code in logging macros which is invalid when compiled in debug mode. 

The `gemm` tests use a function `_gemm_test_impl`, which implementes the generic functionality common to each test. The individual variants are expressed using the `_GEMM_TEST` macro, which instantiates a test based on the `_gemm_test_impl` function. 