### PR TITLE
Renaming member functions for `nd_item` and `nd_range` for  SYCL 1.2.1 spec

### DIFF
--- a/include/executors/executor_sycl.hpp
+++ b/include/executors/executor_sycl.hpp
@@ -179,9 +179,9 @@ struct tree<using_shared_mem::disabled, tree_t, sharedMemT> {
   static void eval(tree_t &tree,
                    shared_mem<sharedMemT, using_shared_mem::disabled> scratch,
                    cl::sycl::nd_item<1> index) {
-    if ((index.get_global(0) < tree.getSize())) {  // FIXME:: this should move
+    if ((index.get_global_id(0) < tree.getSize())) {  // FIXME:: this should move
                                                    // to the tree not the root
-      //  printf("Index %ld\n", index.get_global(0));
+      //  printf("Index %ld\n", index.get_global_id(0));
       tree.eval(index);
     }
   }
@@ -527,8 +527,8 @@ class Executor<SYCL> {
     return execute_tree<
         Choose_policy<Gemm::version == 19, using_shared_mem::enabled,
                       using_shared_mem::disabled>::type>(
-        q_interface.sycl_queue(), gemm_tree, rng.get_local()[0],
-        rng.get_global()[0], Gemm::scratch_size);
+        q_interface.sycl_queue(), gemm_tree, rng.get_local_range()[0],
+        rng.get_global_range()[0], Gemm::scratch_size);
   }
 };
 

--- a/include/operations/blas1_trees.hpp
+++ b/include/operations/blas1_trees.hpp
@@ -122,7 +122,7 @@ struct Join {
   }
 
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
   void bind(cl::sycl::handler &h) {
     l.bind(h);
@@ -155,7 +155,7 @@ struct Assign {
   }
 
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
 };
 
@@ -186,7 +186,7 @@ struct DobleAssign {
   }
 
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
   inline void bind(cl::sycl::handler &h) {
     l1.bind(h);
@@ -214,7 +214,7 @@ struct ScalarOp {
   }
 
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
   inline void bind(cl::sycl::handler &h) { r.bind(h); }
 };
@@ -234,7 +234,7 @@ struct UnaryOp {
   value_type eval(IndexType i) { return Operator::eval(r.eval(i)); }
 
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
   void bind(cl::sycl::handler &h) { r.bind(h); }
 };
@@ -258,7 +258,7 @@ struct BinaryOp {
   value_type eval(IndexType i) { return Operator::eval(l.eval(i), r.eval(i)); }
 
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
   void bind(cl::sycl::handler &h) {
     l.bind(h);
@@ -282,7 +282,7 @@ struct TupleOp {
   value_type eval(IndexType i) { return value_type(i, r.eval(i)); }
 
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
   void bind(cl::sycl::handler &h) { r.bind(h); }
 };
@@ -333,11 +333,11 @@ struct AssignReduction {
     return val;
   }
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
   template <typename sharedT>
   value_type eval(sharedT scratch, cl::sycl::nd_item<1> ndItem) {
-    IndexType localid = ndItem.get_local(0);
+    IndexType localid = ndItem.get_local_id(0);
     IndexType localSz = ndItem.get_local_range(0);
     IndexType groupid = ndItem.get_group(0);
 

--- a/include/operations/blas2_trees.hpp
+++ b/include/operations/blas2_trees.hpp
@@ -62,7 +62,7 @@ struct PrdRowMatVct {
   }
 
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
   IndexType getSize() { return r1.getSizeR(); }
 
@@ -112,7 +112,7 @@ struct PrdRowMatVctMult {
 
   template <typename sharedT>
   value_type eval(sharedT scratch, cl::sycl::nd_item<1> ndItem) {
-    IndexType localid = ndItem.get_local(0);
+    IndexType localid = ndItem.get_local_id(0);
     IndexType localSz = ndItem.get_local_range(0);
     IndexType groupid = ndItem.get_group(0);
 
@@ -199,10 +199,10 @@ struct PrdRowMatVctMultShm {
 
   template <typename sharedT>
   value_type eval(sharedT scratch, cl::sycl::nd_item<1> ndItem) {
-    IndexType localid = ndItem.get_local(0);
+    IndexType localid = ndItem.get_local_id(0);
     IndexType localSz = ndItem.get_local_range(0);
     IndexType groupid = ndItem.get_group(0);
-    IndexType groupSz = ndItem.get_num_groups(0);
+    IndexType groupSz = ndItem.get_group_range(0);
 
     IndexType dimR = r1.getSizeR();
     IndexType dimC = r1.getSizeC();
@@ -286,7 +286,7 @@ struct AddPrdRowMatVctMultShm {
   }
 
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
 
   IndexType getSize() { return r1.getSizeR(); }
@@ -348,7 +348,7 @@ struct RedRowMatVct {
 #endif  // ORIGINAL_CODE
 
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
 
 #if BLAS_EXPERIMENTAL
@@ -356,12 +356,12 @@ struct RedRowMatVct {
   value_type eval(sharedT scratch, cl::sycl::nd_item<1> ndItem) {
     IndexType Pieces = 2;
 
-    IndexType localid = ndItem.get_local(0);
+    IndexType localid = ndItem.get_local_id(0);
     IndexType localSz = ndItem.get_local_range(0);
     IndexType groupid = ndItem.get_group(0);
-    IndexType groupSz = ndItem.get_num_groups(0);
-    IndexType globalid = ndItem.get_global(0);
-    IndexType globalSz = ndItem.get_global_range(0);
+    IndexType groupSz = ndItem.get_group_range(0);
+    IndexType globalid = ndItem.get_global_id(0);
+    IndexType globalSz = ndItem.get_global_id_range(0);
 
     IndexType dimR = r1.getSizeR();
     IndexType dimC = r1.getSizeC();
@@ -413,7 +413,7 @@ struct RedRowMatVct {
 
 #if BLAS_EXPERIMENTAL
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
 #endif  // BLAS_EXPERIMENTAL
   IndexType getSize() { return r1.getSizeR(); }
@@ -454,7 +454,7 @@ struct ModifRank1 {
   }
 
   value_type eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
 
   IndexType getSize() { return r1.getSize(); }

--- a/include/operations/blas3_trees.hpp
+++ b/include/operations/blas3_trees.hpp
@@ -115,7 +115,7 @@ class ReferenceGemmFactory {
     auto A = _A.getData().get_pointer().get();
     auto B = _B.getData().get_pointer().get();
     auto C = _C.getData().get_pointer().get();
-    IndexType item_id = id.get_global(0);
+    IndexType item_id = id.get_global_id(0);
     //  printf("B[%ld]= %f\n", item_id, B[item_id]);
     if (item_id >= m * n) {
       return;
@@ -431,8 +431,8 @@ class GemmFactory {
     auto A = _A.getData().get_pointer().get();
     auto B = _B.getData().get_pointer().get();
     auto C = _C.getData().get_pointer().get();
-    const auto wg_id = id.get_group(0);
-    const auto item_id = id.get_local(0);
+    const auto wg_id = id.get_group_range(0);
+    const auto item_id = id.get_local_id(0);
     const auto tile_size = tl_rows * tl_cols;
     const auto tile_id = wg_id / tile_size;
     const auto tile_local_id = wg_id % tile_size;
@@ -444,7 +444,7 @@ class GemmFactory {
 
     /*  printf(" g_id %ld, tile_size %ld, tile_id %ld, tile_local_id %ld,
       tiles_per_col %ld, tile_row %ld, tile_col %ld, wg_row %ld, wg_col %ld\n",
-      id.get_global(0), tile_size, tile_id, tile_local_id, tiles_per_col,
+      id.get_global_id(0), tile_size, tile_id, tile_local_id, tiles_per_col,
       tile_row, tile_col, wg_row, wg_col );*/
     if (wg_row >= m || wg_col >= n) {
       return;

--- a/include/views/view_sycl.hpp
+++ b/include/views/view_sycl.hpp
@@ -275,7 +275,7 @@ struct vector_view<ScalarT_, PaccessorT<ScalarT_>, IndexType_, IncrementType_> {
   }
 
   ScalarT &eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
 
   /**** PRINTING ****/
@@ -460,7 +460,7 @@ struct matrix_view<ScalarT_, PaccessorT<ScalarT_>, IndexType_> {
   }
 
   inline ScalarT &eval(cl::sycl::nd_item<1> ndItem) {
-    return eval(ndItem.get_global(0));
+    return eval(ndItem.get_global_id(0));
   }
 
   void bind(cl::sycl::handler &h) { h.require(data_); }


### PR DESCRIPTION
This PR performs the following renamings to update the SYCL-BLAS for version 1.2.1 of the SYCL spec:
-  nd_item::get_local -> nd_item::get_local_id
-   nd_item::get_global -> nd_item::get_global_id
-  nd_range::get_local -> nd_range::get_local_range
-  nd_range::get_global -> nd_range::get_global_range