### PR TITLE
Add example applications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,5 @@ message(STATUS "${COMPUTECPP_DEVICE_COMPILER_FLAGS}")
 include_directories(${SYCLBLAS_INCLUDE} ${COMPUTECPP_INCLUDE_DIRECTORY} ${BLAS_INCLUDE_DIRS})
 
 add_subdirectory(test)
+
+add_subdirectory(example)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.2.2)
+
+project(syclblas_example)
+
+set(SYCLBLAS_EXAMPLE ${CMAKE_CURRENT_SOURCE_DIR})
+set(SYCLBLAS_EXAMPLE_INCLUDE "${SYCLBLAS_EXAMPLE}/include")
+
+if(SYCL_DEVICE)
+  add_definitions(-DSYCL_DEVICE=${SYCL_DEVICE})
+endif(SYCL_DEVICE)
+
+file(GLOB SYCLBLAS_EXAMPLE_SRCS ./*.cpp)
+
+foreach(example ${SYCLBLAS_EXAMPLE_SRCS})
+
+  message(STATUS " Getting ${example} ")
+
+  get_filename_component(SOURCE_NAME ${example} NAME_WE)
+  message(STATUS " Adding ${SOURCE_NAME} ")
+
+#   include_directories(${COMPUTECPP_INCLUDE_DIRECTORY})
+
+  add_executable(${SOURCE_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp  )
+  target_compile_options(${SOURCE_NAME} PUBLIC ${HOST_COMPILER_OPTIONS})
+  target_link_libraries(${SOURCE_NAME} PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+
+  add_sycl_to_target(${SOURCE_NAME} ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_NAME}.cpp )
+
+endforeach()

--- a/example/blas1_copy.cpp
+++ b/example/blas1_copy.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+
+#include "queue/sycl_iterator.hpp"
+#include <interface/blas1_interface.hpp>
+#include <interface/blas2_interface.hpp>
+#include <interface/blas3_interface.hpp>
+
+using namespace blas;
+
+int main(int argc, char const *argv[]) {
+  using ScalarT = float;
+  std::cout << "Example building, cmake working" << std::endl;
+
+  size_t size = 128;
+  long strd = 8;
+
+  std::cout << "size == " << size << std::endl;
+  std::cout << "strd == " << strd << std::endl;
+
+  // create two vectors: vX and vY
+  std::vector<ScalarT> vX(size);
+  std::vector<ScalarT> vY(size, 0);
+
+  // initialise the vector
+  ScalarT left(-1), right(1);
+  for (size_t i = 0; i < size; ++i) {
+    vX[i] = rand() % int((right - left) * 8) * 0.125 - right;
+  }
+
+  cl::sycl::default_selector d;
+  auto q = cl::sycl::queue(d, [=](cl::sycl::exception_list eL) {
+    for (auto &e : eL) {
+      try {
+        std::rethrow_exception(e);
+      } catch (cl::sycl::exception &e) {
+        std::cout << "E " << e.what() << std::endl;
+      } catch (std::exception &e) {
+        std::cout << "Standard Exception " << e.what() << std::endl;
+      } catch (...) {
+        std::cout << " An exception " << std::endl;
+      }
+    }
+  });
+
+  Executor<SYCL> ex(q);
+
+  auto gpu_vX = blas::helper::make_sycl_iteator_buffer<ScalarT>(vX, size);
+  auto gpu_vY = blas::helper::make_sycl_iteator_buffer<ScalarT>(size);
+
+  _copy(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vY, strd);
+  ex.copy_to_host(gpu_vY, vY.data());
+  // check that vX and vY are the same
+  for (size_t i = 0; i < size; ++i) {
+    if (i % strd == 0) {
+      assert(vX[i] == vY[i]);
+    } else {
+      assert(0 == vY[i]);
+    }
+  }
+
+  std::cout << "Finished execution" << std::endl;
+
+  return 0;
+}

--- a/example/blas1_copy.cpp
+++ b/example/blas1_copy.cpp
@@ -47,7 +47,16 @@ int main(int argc, char const *argv[]) {
   auto gpu_vX = blas::helper::make_sycl_iteator_buffer<ScalarT>(vX, size);
   auto gpu_vY = blas::helper::make_sycl_iteator_buffer<ScalarT>(size);
 
-  _copy(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vY, strd);
+  try {
+    _copy(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vY, strd);
+  } catch (cl::sycl::exception &e) {
+    std::cout << "E " << e.what() << std::endl;
+  } catch (std::exception &e) {
+    std::cout << "Standard Exception " << e.what() << std::endl;
+  } catch (...) {
+    std::cout << " An exception " << std::endl;
+  }
+
   ex.copy_to_host(gpu_vY, vY.data());
   // check that vX and vY are the same
   for (size_t i = 0; i < size; ++i) {

--- a/example/blas1_copy.cpp
+++ b/example/blas1_copy.cpp
@@ -42,10 +42,16 @@ int main(int argc, char const *argv[]) {
     }
   });
 
+  std::cout << "Built selector and queue" << std::endl;
+
   Executor<SYCL> ex(q);
+
+  std::cout << "Built executor" << std::endl;
 
   auto gpu_vX = blas::helper::make_sycl_iteator_buffer<ScalarT>(vX, size);
   auto gpu_vY = blas::helper::make_sycl_iteator_buffer<ScalarT>(size);
+
+  std::cout << "Built iterator buffers for vX and vY" << std::endl;
 
   try {
     _copy(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vY, strd);
@@ -57,10 +63,17 @@ int main(int argc, char const *argv[]) {
     std::cout << " An exception " << std::endl;
   }
 
+  std::cout << "Copy command run" << std::endl;
+
   ex.copy_to_host(gpu_vY, vY.data());
+
+  std::cout << "Copied data to host" << std::endl;
   // check that vX and vY are the same
   for (size_t i = 0; i < size; ++i) {
     if (i % strd == 0) {
+      std::cout << "checking: vX[" << i << "] == vY[" << i << "]";
+      std::cout << " with values: [" << vX[i] << ", " << vY[i] << "]"
+                << std::endl;
       assert(vX[i] == vY[i]);
     } else {
       assert(0 == vY[i]);


### PR DESCRIPTION
This PR adds a number of example applications that demonstrate usage of the sycl-blas. This addition is mainly motivated by wanting a smaller target for debugging and tweaking, rather than the (rather involved) test suite. 