### PR TITLE
Move test for double support to test library, and add cmake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,30 @@ set(COMPUTECPP_DEVICE_COMPILER_FLAGS
     "${COMPUTECPP_DEVICE_COMPILER_FLAGS} -no-serial-memop -sycl-compress-name")
 message(STATUS "${COMPUTECPP_DEVICE_COMPILER_FLAGS}")
 
+# Check to see if we've disabled double support in the tests
+option(NO_DOUBLE_SUPPORT "Disable double support when testing." off)
+if(NO_DOUBLE_SUPPORT)
+  # Define NO_DOUBLE_SUPPORT for the host cxx compiler
+  add_definitions(-DNO_DOUBLE_SUPPORT)
+  # Set the computecpp device compiler flags to also define NO_DOUBLE_SUPPORT 
+  list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -DNO_DOUBLE_SUPPORT)
+endif()
+
+# If the user has specified a specific workgroup size for tests, pass that on to the compiler
+if(WGSIZE)
+  add_definitions(-DWGSIZE=${WGSIZE})
+  list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -DWGSIZE=${WGSIZE})
+endif()
+
+# If the user has specified that we should use naive gemm, enable that
+option(NAIVEGEMM "Default to naive GEMM implementations" off)
+if(NAIVEGEMM)
+  add_definitions(-DNAIVEGEMM)
+  list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -DNAIVEGEMM)
+endif()
+
 include_directories(${SYCLBLAS_INCLUDE} ${COMPUTECPP_INCLUDE_DIRECTORY} ${BLAS_INCLUDE_DIRS})
+
+
 
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,16 +48,16 @@ if(NO_DOUBLE_SUPPORT)
 endif()
 
 # If the user has specified a specific workgroup size for tests, pass that on to the compiler
-if(WGSIZE)
-  add_definitions(-DWGSIZE=${WGSIZE})
-  list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -DWGSIZE=${WGSIZE})
+if(WG_SIZE)
+  add_definitions(-DWG_SIZE=${WG_SIZE})
+  list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -DWG_SIZE=${WG_SIZE})
 endif()
 
 # If the user has specified that we should use naive gemm, enable that
-option(NAIVEGEMM "Default to naive GEMM implementations" off)
-if(NAIVEGEMM)
-  add_definitions(-DNAIVEGEMM)
-  list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -DNAIVEGEMM)
+option(NAIVE_GEMM "Default to naive GEMM implementations" off)
+if(NAIVE_GEMM)
+  add_definitions(-DNAIVE_GEMM)
+  list(APPEND COMPUTECPP_DEVICE_COMPILER_FLAGS -DNAIVE_GEMM)
 endif()
 
 include_directories(${SYCLBLAS_INCLUDE} ${COMPUTECPP_INCLUDE_DIRECTORY} ${BLAS_INCLUDE_DIRS})

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -81,9 +81,26 @@ struct blas_templ_struct {
   using metadata_t = MetadataT_;
   using executor_t = ExecutorType_;
 };
-// A "using" shortcut for the struct
+
+// "Using" shortcuts for the struct, with #ifndef guard for double
+
+// A "default" using shortcut
 template <class ScalarT_, class MetadataT_ = void, class ExecutorType_ = SYCL>
 using blas_test_args = blas_templ_struct<ScalarT_, MetadataT_, ExecutorType_>;
+
+// specialisation for float
+template <class MetadataT_ = void, class ExecutorType_ = SYCL>
+using blas_test_float = blas_templ_struct<float, MetadataT_, ExecutorType_>;
+
+// specialisation (with define guard) for double
+// #define NO_DOUBLE_SUPPORT
+#ifndef NO_DOUBLE_SUPPORT
+  template <class MetadataT_ = void, class ExecutorType_ = SYCL>
+  using blas_test_double = blas_templ_struct<double, MetadataT_, ExecutorType_>;
+#else 
+  template <class MetadataT_ = void, class ExecutorType_ = SYCL>
+  using blas_test_double = ::testing::internal::None;
+#endif
 
 // the test class itself
 template <class B>

--- a/test/unittest/blas1_asum_test.cpp
+++ b/test/unittest/blas1_asum_test.cpp
@@ -25,11 +25,9 @@
 
 #include "blas_test.hpp"
 
-typedef ::testing::Types<blas_test_args<float>
-#ifndef NO_DOUBLE_SUPPORT
-                         ,
-                         blas_test_args<double>
-#endif
+
+typedef ::testing::Types<blas_test_float<>,
+                         blas_test_double<>
                          >
     BlasTypes;
 

--- a/test/unittest/blas1_axpy_test.cpp
+++ b/test/unittest/blas1_axpy_test.cpp
@@ -23,11 +23,8 @@
  *
  **************************************************************************/
 #include "blas_test.hpp"
-typedef ::testing::Types<blas_test_args<float>
-#ifndef NO_DOUBLE_SUPPORT
-                         ,
-                         blas_test_args<double>
-#endif
+typedef ::testing::Types<blas_test_float<>,
+                         blas_test_double<>
                          >
     BlasTypes;
 

--- a/test/unittest/blas1_copy_test.cpp
+++ b/test/unittest/blas1_copy_test.cpp
@@ -25,11 +25,8 @@
 
 #include "blas_test.hpp"
 
-typedef ::testing::Types<blas_test_args<float>
-#ifndef NO_DOUBLE_SUPPORT
-                         ,
-                         blas_test_args<double>
-#endif
+typedef ::testing::Types<blas_test_float<>,
+                         blas_test_double<>
                          >
     BlasTypes;
 

--- a/test/unittest/blas1_dot_test.cpp
+++ b/test/unittest/blas1_dot_test.cpp
@@ -24,11 +24,8 @@
  **************************************************************************/
 
 #include "blas_test.hpp"
-typedef ::testing::Types<blas_test_args<float>
-#ifndef NO_DOUBLE_SUPPORT
-                         ,
-                         blas_test_args<double>
-#endif
+typedef ::testing::Types<blas_test_float<>,
+                         blas_test_double<>
                          >
     BlasTypes;
 

--- a/test/unittest/blas1_iamax_test.cpp
+++ b/test/unittest/blas1_iamax_test.cpp
@@ -24,11 +24,8 @@
  **************************************************************************/
 
 #include "blas_test.hpp"
-typedef ::testing::Types<blas_test_args<float>
-#ifndef NO_DOUBLE_SUPPORT
-                         ,
-                         blas_test_args<double>
-#endif
+typedef ::testing::Types<blas_test_float<>,
+                         blas_test_double<>
                          >
     BlasTypes;
 

--- a/test/unittest/blas1_iamin_test.cpp
+++ b/test/unittest/blas1_iamin_test.cpp
@@ -25,11 +25,8 @@
 
 #include "blas_test.hpp"
 
-typedef ::testing::Types<blas_test_args<float>
-#ifndef NO_DOUBLE_SUPPORT
-                         ,
-                         blas_test_args<double>
-#endif
+typedef ::testing::Types<blas_test_float<>,
+                         blas_test_double<>
                          >
     BlasTypes;
 

--- a/test/unittest/blas1_nrm2_test.cpp
+++ b/test/unittest/blas1_nrm2_test.cpp
@@ -25,11 +25,8 @@
 
 #include "blas_test.hpp"
 
-typedef ::testing::Types<blas_test_args<float>
-#ifndef NO_DOUBLE_SUPPORT
-                         ,
-                         blas_test_args<double>
-#endif
+typedef ::testing::Types<blas_test_float<>,
+                         blas_test_double<>
                          >
     BlasTypes;
 

--- a/test/unittest/blas1_rotg_test.cpp
+++ b/test/unittest/blas1_rotg_test.cpp
@@ -25,11 +25,8 @@
 
 #include "blas_test.hpp"
 
-typedef ::testing::Types<blas_test_args<float>
-#ifndef NO_DOUBLE_SUPPORT
-                         ,
-                         blas_test_args<double>
-#endif
+typedef ::testing::Types<blas_test_float<>,
+                         blas_test_double<>
                          >
     BlasTypes;
 

--- a/test/unittest/blas1_scal_test.cpp
+++ b/test/unittest/blas1_scal_test.cpp
@@ -25,11 +25,8 @@
 
 #include "blas_test.hpp"
 
-typedef ::testing::Types<blas_test_args<float>
-#ifndef NO_DOUBLE_SUPPORT
-                         ,
-                         blas_test_args<double>
-#endif
+typedef ::testing::Types<blas_test_float<>,
+                         blas_test_double<>
                          >
     BlasTypes;
 

--- a/test/unittest/blas1_swap_test.cpp
+++ b/test/unittest/blas1_swap_test.cpp
@@ -25,11 +25,8 @@
 
 #include "blas_test.hpp"
 
-typedef ::testing::Types<blas_test_args<float>
-#ifndef NO_DOUBLE_SUPPORT
-                         ,
-                         blas_test_args<double>
-#endif
+typedef ::testing::Types<blas_test_float<>,
+                         blas_test_double<>
                          >
     BlasTypes;
 

--- a/test/unittest/blas2_gemv_test.cpp
+++ b/test/unittest/blas2_gemv_test.cpp
@@ -25,11 +25,8 @@
 
 #include "blas_test.hpp"
 
-typedef ::testing::Types<blas_test_args<float>
-#ifndef NO_DOUBLE_SUPPORT
-                         ,
-                         blas_test_args<double>
-#endif
+typedef ::testing::Types<blas_test_float<>,
+                         blas_test_double<>
                          >
     BlasTypes;
 

--- a/test/unittest/blas2_ger_test.cpp
+++ b/test/unittest/blas2_ger_test.cpp
@@ -25,11 +25,8 @@
 
 #include "blas_test.hpp"
 
-typedef ::testing::Types<blas_test_args<float>
-#ifndef NO_DOUBLE_SUPPORT
-                         ,
-                         blas_test_args<double>
-#endif
+typedef ::testing::Types<blas_test_float<>,
+                         blas_test_double<>
                          >
     BlasTypes;
 

--- a/test/unittest/blas3_gemm_test.cpp
+++ b/test/unittest/blas3_gemm_test.cpp
@@ -50,33 +50,30 @@ struct MatrixFormats {
 };
 
 typedef ::testing::Types<
-    blas_test_args<float, MatrixFormats<Normal, Normal>>,
+    blas_test_float<MatrixFormats<Normal, Normal>>,
 
-    blas_test_args<float, MatrixFormats<Transposed, Normal>>,
-    blas_test_args<float, MatrixFormats<Normal, Transposed>>,
-    blas_test_args<float, MatrixFormats<Transposed, Transposed>>,
+    blas_test_float<MatrixFormats<Transposed, Normal>>,
+    blas_test_float<MatrixFormats<Normal, Transposed>>,
+    blas_test_float<MatrixFormats<Transposed, Transposed>>,
 
-    blas_test_args<float, MatrixFormats<Conjugate, Normal>>,
-    blas_test_args<float, MatrixFormats<Normal, Conjugate>>,
-    blas_test_args<float, MatrixFormats<Conjugate, Conjugate>>,
+    blas_test_float<MatrixFormats<Conjugate, Normal>>,
+    blas_test_float<MatrixFormats<Normal, Conjugate>>,
+    blas_test_float<MatrixFormats<Conjugate, Conjugate>>,
 
-    blas_test_args<float, MatrixFormats<Transposed, Conjugate>>,
-    blas_test_args<float, MatrixFormats<Conjugate, Transposed>>
-#ifndef NO_DOUBLE_SUPPORT
-    ,
-    blas_test_args<double, MatrixFormats<Normal, Normal>>,
+    blas_test_float<MatrixFormats<Transposed, Conjugate>>,
+    blas_test_float<MatrixFormats<Conjugate, Transposed>>,
+    blas_test_double<MatrixFormats<Normal, Normal>>,
 
-    blas_test_args<double, MatrixFormats<Transposed, Normal>>,
-    blas_test_args<double, MatrixFormats<Normal, Transposed>>,
-    blas_test_args<double, MatrixFormats<Transposed, Transposed>>,
+    blas_test_double<MatrixFormats<Transposed, Normal>>,
+    blas_test_double<MatrixFormats<Normal, Transposed>>,
+    blas_test_double<MatrixFormats<Transposed, Transposed>>,
 
-    blas_test_args<double, MatrixFormats<Conjugate, Normal>>,
-    blas_test_args<double, MatrixFormats<Normal, Conjugate>>,
-    blas_test_args<double, MatrixFormats<Conjugate, Conjugate>>,
+    blas_test_double<MatrixFormats<Conjugate, Normal>>,
+    blas_test_double<MatrixFormats<Normal, Conjugate>>,
+    blas_test_double<MatrixFormats<Conjugate, Conjugate>>,
 
-    blas_test_args<double, MatrixFormats<Transposed, Conjugate>>,
-    blas_test_args<double, MatrixFormats<Conjugate, Transposed>>
-#endif
+    blas_test_double<MatrixFormats<Transposed, Conjugate>>,
+    blas_test_double<MatrixFormats<Conjugate, Transposed>>
     >
     BlasTypes;
 


### PR DESCRIPTION
This PR moves the test for double support from the definition site of each test, to the internal definition, and adds a cmake option to disable tests with double precision floats. 