### PR TITLE
Correct the spelling of 'make_sycl_iterator_buffer'

### DIFF
--- a/include/executors/executor_sycl.hpp
+++ b/include/executors/executor_sycl.hpp
@@ -421,10 +421,10 @@ class Executor<SYCL> {
     // Two accessors to local memory
     auto sharedSize = ((nWG < localSize) ? localSize : nWG);
     auto shMem1 =
-        blas::helper::make_sycl_iteator_buffer<typename LHS::value_type>(
+        blas::helper::make_sycl_iterator_buffer<typename LHS::value_type>(
             sharedSize);
     auto shMem2 =
-        blas::helper::make_sycl_iteator_buffer<typename LHS::value_type>(
+        blas::helper::make_sycl_iterator_buffer<typename LHS::value_type>(
             sharedSize);
     auto opShMem1 = LHS(shMem1, 1, sharedSize);
     auto opShMem2 = LHS(shMem2, 1, sharedSize);

--- a/include/interface/blas1_interface.hpp
+++ b/include/interface/blas1_interface.hpp
@@ -457,7 +457,7 @@ typename scalar_type<ContainerT0>::ScalarT _dot(Executor &ex, IndexType _N,
                                                 IncrementType _incy) {
   using T = typename scalar_type<ContainerT0>::ScalarT;
   auto res = std::vector<T>(1);
-  auto gpu_res = helper::make_sycl_iteator_buffer<T>(static_cast<IndexType>(1));
+  auto gpu_res = helper::make_sycl_iterator_buffer<T>(static_cast<IndexType>(1));
   _dot(ex, _N, _vx, _incx, _vy, _incy, gpu_res);
   gpu_res.copy_to_host(ex, res.data());
   return res[0];
@@ -476,7 +476,7 @@ IndexType _iamax(Executor &ex, IndexType _N, ContainerT _vx,
   using IndValTuple = IndexValueTuple<T>;
   std::vector<IndValTuple> rsT(1);
   auto gpu_res =
-      helper::make_sycl_iteator_buffer<IndValTuple>(static_cast<IndexType>(1));
+      helper::make_sycl_iterator_buffer<IndValTuple>(static_cast<IndexType>(1));
   _iamax(ex, _N, _vx, _incx, gpu_res);
   gpu_res.copy_to_host(ex, rsT.data());
   return rsT[0].get_index();
@@ -495,7 +495,7 @@ IndexType _iamin(Executor &ex, IndexType _N, ContainerT _vx,
   using IndValTuple = IndexValueTuple<T>;
   std::vector<IndValTuple> rsT(1);
   auto gpu_res =
-      helper::make_sycl_iteator_buffer<IndValTuple>(static_cast<IndexType>(1));
+      helper::make_sycl_iterator_buffer<IndValTuple>(static_cast<IndexType>(1));
   _iamin(ex, _N, _vx, _incx, gpu_res);
   gpu_res.copy_to_host(ex, rsT.data());
   return rsT[0].get_index();
@@ -515,7 +515,7 @@ typename scalar_type<ContainerT>::ScalarT _asum(Executor &ex, IndexType _N,
                                                 IncrementType _incx) {
   using T = typename scalar_type<ContainerT>::ScalarT;
   auto res = std::vector<T>(1, T(0));
-  auto gpu_res = helper::make_sycl_iteator_buffer<T>(static_cast<IndexType>(1));
+  auto gpu_res = helper::make_sycl_iterator_buffer<T>(static_cast<IndexType>(1));
   _asum(ex, _N, _vx, _incx, gpu_res);
   gpu_res.copy_to_host(ex, res.data());
   return res[0];
@@ -535,7 +535,7 @@ typename scalar_type<ContainerT>::ScalarT _nrm2(Executor &ex, IndexType _N,
                                                 IncrementType _incx) {
   using T = typename scalar_type<ContainerT>::ScalarT;
   auto res = std::vector<T>(1, T(0));
-  auto gpu_res = helper::make_sycl_iteator_buffer<T>(static_cast<IndexType>(1));
+  auto gpu_res = helper::make_sycl_iterator_buffer<T>(static_cast<IndexType>(1));
   _nrm2(ex, _N, _vx, _incx, gpu_res);
   gpu_res.copy_to_host(ex, res.data());
   return res[0];

--- a/include/interface/blas2_interface.hpp
+++ b/include/interface/blas2_interface.hpp
@@ -88,7 +88,7 @@ typename Executor::Return_Type _gemv_impl(
           ? (((scratchPadSize == 0) ? std::min(N, localSize) : 1) * nWG_col)
           : nWG_col;
 
-  auto valT1 = blas::helper::make_sycl_iteator_buffer<T>(M * scratchSize);
+  auto valT1 = blas::helper::make_sycl_iterator_buffer<T>(M * scratchSize);
   auto mat1 = make_matrix_view(ex, valT1, M, scratchSize, scratchSize, 0);
 
   if (mA.is_row_access()) {
@@ -158,7 +158,7 @@ typename Executor::Return_Type _trmv_impl(
   const IndexType globalSize = localSize * nWG_row * nWG_col;
 
   using T = typename scalar_type<ContainerT0>::ScalarT;
-  auto valT1 = blas::helper::make_sycl_iteator_buffer<T>(N * scratchSize);
+  auto valT1 = blas::helper::make_sycl_iterator_buffer<T>(N * scratchSize);
   auto mat1 = make_matrix_view(ex, valT1, N, scratchSize, scratchSize, 0);
 
   typename Executor::Return_Type ret;
@@ -280,12 +280,12 @@ typename Executor::Return_Type _symv_impl(
   const IndexType scratchSize_R =
       ((scratchPadSize == 0) ? std::min(N, localSize) : 1) * nWG_col_R;
 
-  auto valTR = blas::helper::make_sycl_iteator_buffer<T>(N * scratchSize_R);
+  auto valTR = blas::helper::make_sycl_iterator_buffer<T>(N * scratchSize_R);
   auto matR = make_matrix_view(ex, valTR, N, scratchSize_R, scratchSize_R, 0);
 
   const IndexType scratchSize_C = nWG_col_C;
 
-  auto valTC = blas::helper::make_sycl_iteator_buffer<T>(N * scratchSize_C);
+  auto valTC = blas::helper::make_sycl_iterator_buffer<T>(N * scratchSize_C);
   auto matC = make_matrix_view(ex, valTC, N, scratchSize_C, scratchSize_C, 0);
 
   if (mA.is_row_access()) {  // ROWS ACCESS

--- a/include/queue/helper.hpp
+++ b/include/queue/helper.hpp
@@ -6,7 +6,7 @@
 namespace blas {
 namespace helper {
 template <typename scalar_t, typename index_t>
-inline blas::buffer_iterator<scalar_t> make_sycl_iteator_buffer(scalar_t* data,
+inline blas::buffer_iterator<scalar_t> make_sycl_iterator_buffer(scalar_t* data,
                                                                 index_t size) {
   using buff_t =
       blas::buffer_t<scalar_t, 1, cl::sycl::default_allocator<scalar_t>>;
@@ -15,7 +15,7 @@ inline blas::buffer_iterator<scalar_t> make_sycl_iteator_buffer(scalar_t* data,
 }
 
 template <typename scalar_t, typename index_t>
-inline buffer_iterator<scalar_t> make_sycl_iteator_buffer(
+inline buffer_iterator<scalar_t> make_sycl_iterator_buffer(
     std::vector<scalar_t>& data, index_t size) {
   using buff_t =
       blas::buffer_t<scalar_t, 1, cl::sycl::default_allocator<scalar_t>>;
@@ -24,14 +24,14 @@ inline buffer_iterator<scalar_t> make_sycl_iteator_buffer(
 }
 
 template <typename scalar_t, typename index_t>
-inline blas::buffer_iterator<scalar_t> make_sycl_iteator_buffer(index_t size) {
+inline blas::buffer_iterator<scalar_t> make_sycl_iterator_buffer(index_t size) {
   using buff_t =
       blas::buffer_t<scalar_t, 1, cl::sycl::default_allocator<scalar_t>>;
   return blas::buffer_iterator<scalar_t>{buff_t{cl::sycl::range<1>{size}}};
 }
 
 template <typename scalar_t, typename index_t>
-inline blas::buffer_iterator<scalar_t> make_sycl_iteator_buffer(
+inline blas::buffer_iterator<scalar_t> make_sycl_iterator_buffer(
     blas::buffer_t<scalar_t, 1, cl::sycl::default_allocator<scalar_t>> buff_) {
   return blas::buffer_iterator<scalar_t>{buff_};
 }

--- a/test/unittest/blas1/blas1_asum_test.cpp
+++ b/test/unittest/blas1/blas1_asum_test.cpp
@@ -64,8 +64,8 @@ TYPED_TEST(BLAS_Test, asum_test) {
   SYCL_DEVICE_SELECTOR d;
   auto q = TestClass::make_queue(d);
   Executor<ExecutorType> ex(q);
-  auto gpu_vX = blas::helper::make_sycl_iteator_buffer<ScalarT>(vX, size);
-  auto gpu_vR = blas::helper::make_sycl_iteator_buffer<ScalarT>(size_t(1));
+  auto gpu_vX = blas::helper::make_sycl_iterator_buffer<ScalarT>(vX, size);
+  auto gpu_vR = blas::helper::make_sycl_iterator_buffer<ScalarT>(size_t(1));
   _asum(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vR);
   auto event = ex.copy_to_host(gpu_vR, vR.data(), 1);
   ex.wait(event);
@@ -104,9 +104,9 @@ TYPED_TEST(BLAS_Test, asum_test_auto_return) {
   auto q = TestClass::make_queue(d);
   Executor<ExecutorType> ex(q);
   {
-    auto gpu_vX = blas::helper::make_sycl_iteator_buffer<ScalarT>(vX, size);
+    auto gpu_vX = blas::helper::make_sycl_iterator_buffer<ScalarT>(vX, size);
     auto gpu_vR =
-        blas::helper::make_sycl_iteator_buffer<ScalarT>(vR, size_t(1));
+        blas::helper::make_sycl_iterator_buffer<ScalarT>(vR, size_t(1));
     _asum(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vR);
   }
   ASSERT_NEAR(res, vR[0], prec);
@@ -189,7 +189,7 @@ TYPED_TEST(BLAS_Test, asum_test_combined_vp_buffer) {
   auto q = TestClass::make_queue(d);
   Executor<ExecutorType> ex(q);
   auto gpu_vX = ex.template allocate<ScalarT>(size);
-  auto gpu_vR = blas::helper::make_sycl_iteator_buffer<ScalarT>(size_t(1));
+  auto gpu_vR = blas::helper::make_sycl_iterator_buffer<ScalarT>(size_t(1));
   ex.copy_to_device(vX.data(), gpu_vX, size);
   ex.copy_to_device(vR.data(), gpu_vR, 1);
   _asum(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vR);
@@ -233,7 +233,7 @@ TYPED_TEST(BLAS_Test, asum_test_combined_vp_buffer_return_buff) {
   auto q = TestClass::make_queue(d);
   Executor<ExecutorType> ex(q);
   auto gpu_vX = ex.template allocate<ScalarT>(size);
-  auto gpu_vR = blas::helper::make_sycl_iteator_buffer<ScalarT>(size_t(1));
+  auto gpu_vR = blas::helper::make_sycl_iterator_buffer<ScalarT>(size_t(1));
   ex.copy_to_device(vX.data(), gpu_vX, size);
   ex.copy_to_device(vR.data(), gpu_vR, 1);
   _asum(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vR);

--- a/test/unittest/blas1/blas1_axpy_test.cpp
+++ b/test/unittest/blas1/blas1_axpy_test.cpp
@@ -71,8 +71,8 @@ TYPED_TEST(BLAS_Test, axpy_test_buff) {
   SYCL_DEVICE_SELECTOR d;
   auto q = TestClass::make_queue(d);
   Executor<ExecutorType> ex(q);
-  auto gpu_vX = blas::helper::make_sycl_iteator_buffer<ScalarT>(vX, size);
-  auto gpu_vY = blas::helper::make_sycl_iteator_buffer<ScalarT>(vY, size);
+  auto gpu_vX = blas::helper::make_sycl_iterator_buffer<ScalarT>(vX, size);
+  auto gpu_vY = blas::helper::make_sycl_iterator_buffer<ScalarT>(vY, size);
   _axpy(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY, strd);
   auto event = ex.copy_to_host(gpu_vY, vY.data(), size);
   ex.wait(event);
@@ -126,7 +126,7 @@ TYPED_TEST(BLAS_Test, axpy_test) {
   SYCL_DEVICE_SELECTOR d;
   auto q = TestClass::make_queue(d);
   Executor<ExecutorType> ex(q);
-  auto gpu_vX = blas::helper::make_sycl_iteator_buffer<ScalarT>(vX, size);
+  auto gpu_vX = blas::helper::make_sycl_iterator_buffer<ScalarT>(vX, size);
   auto gpu_vY = ex.template allocate<ScalarT>(size);
   ex.copy_to_device(vY.data(), gpu_vY, size);
   _axpy(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY, strd);

--- a/test/unittest/blas1/blas1_copy_test.cpp
+++ b/test/unittest/blas1/blas1_copy_test.cpp
@@ -55,8 +55,8 @@ TYPED_TEST(BLAS_Test, copy_test) {
   SYCL_DEVICE_SELECTOR d;
   auto q = TestClass::make_queue(d);
   Executor<ExecutorType> ex(q);
-  auto gpu_vX = blas::helper::make_sycl_iteator_buffer<ScalarT>(vX, size);
-  auto gpu_vY = blas::helper::make_sycl_iteator_buffer<ScalarT>(size);
+  auto gpu_vX = blas::helper::make_sycl_iterator_buffer<ScalarT>(vX, size);
+  auto gpu_vY = blas::helper::make_sycl_iterator_buffer<ScalarT>(size);
   _copy(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vY, strd);
   auto event = ex.copy_to_host(gpu_vY, vY.data(), size);
   ex.wait(event);

--- a/test/unittest/blas1/blas1_dot_test.cpp
+++ b/test/unittest/blas1/blas1_dot_test.cpp
@@ -67,9 +67,9 @@ TYPED_TEST(BLAS_Test, dot_test) {
   SYCL_DEVICE_SELECTOR d;
   auto q = TestClass::make_queue(d);
   Executor<ExecutorType> ex(q);
-  auto gpu_vX = blas::helper::make_sycl_iteator_buffer<ScalarT>(vX, size);
-  auto gpu_vY = blas::helper::make_sycl_iteator_buffer<ScalarT>(vY, size);
-  auto gpu_vR = blas::helper::make_sycl_iteator_buffer<ScalarT>(size_t(1));
+  auto gpu_vX = blas::helper::make_sycl_iterator_buffer<ScalarT>(vX, size);
+  auto gpu_vY = blas::helper::make_sycl_iterator_buffer<ScalarT>(vY, size);
+  auto gpu_vR = blas::helper::make_sycl_iterator_buffer<ScalarT>(size_t(1));
   _dot(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vY, strd, gpu_vR);
   auto event = ex.copy_to_host(gpu_vR, vR.data(), 1);
   ex.wait(event);

--- a/test/unittest/blas1/blas1_iamax_test.cpp
+++ b/test/unittest/blas1/blas1_iamax_test.cpp
@@ -69,9 +69,9 @@ TYPED_TEST(BLAS_Test, iamax_test) {
   SYCL_DEVICE_SELECTOR d;
   auto q = TestClass::make_queue(d);
   Executor<ExecutorType> ex(q);
-  auto gpu_vX = blas::helper::make_sycl_iteator_buffer<ScalarT>(vX, size);
+  auto gpu_vX = blas::helper::make_sycl_iterator_buffer<ScalarT>(vX, size);
   auto gpu_vI =
-      blas::helper::make_sycl_iteator_buffer<IndexValueTuple<ScalarT>>(
+      blas::helper::make_sycl_iterator_buffer<IndexValueTuple<ScalarT>>(
           size_t(1));
   _iamax(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vI);
   auto event = ex.copy_to_host(gpu_vI, vI.data(), 1);

--- a/test/unittest/buffers/sycl_buffer_test.cpp
+++ b/test/unittest/buffers/sycl_buffer_test.cpp
@@ -63,7 +63,7 @@ TYPED_TEST(BLAS_Test, sycl_buffer_test) {
   SYCL_DEVICE_SELECTOR d;
   auto q = TestClass::make_queue(d);
   Executor<ExecutorType> ex(q);
-  auto a = blas::helper::make_sycl_iteator_buffer<ScalarT>(vX.data(), size);
+  auto a = blas::helper::make_sycl_iterator_buffer<ScalarT>(vX.data(), size);
   auto event = ex.copy_to_host((a + offset), vR.data(), size - offset);
   ex.wait(event);
 


### PR DESCRIPTION
This PR fixes a mild irritation that I had with the incorrect spelling of 'iterator' in the method 'make_sycl_iteator_buffer'. It is a trivial change that shouldn't affect anything.