### PR TITLE
Bugfixes and tweaks to benchmarking framework

### DIFF
--- a/bench/clblast/clblast_benchmark_level2.cpp
+++ b/bench/clblast/clblast_benchmark_level2.cpp
@@ -32,8 +32,9 @@
 
 BENCHMARK_NAME_FORMAT(clblast_level_2) {
   std::ostringstream fname;
-  fname << benchmark<>::typestr<ElemT>() << "_" << name() << "_" << std::get<0>(params)
-        << "_" << std::get<1>(params) << "_" << std::get<2>(params);
+  fname << benchmark<>::typestr<ElemT>() << "_" << name() << "_"
+        << std::get<0>(params) << "_" << std::get<1>(params) << "_"
+        << std::get<2>(params);
   return fname.str();
 
   return fname.str();
@@ -49,7 +50,8 @@ BENCHMARK(gemv, clblast_level_2) {
   size_t vlen = t_str[0] == 'n' ? n : m;
   size_t rlen = t_str[0] == 'n' ? m : n;
 
-  size_t n_fl_ops = m * n * 2;
+  size_t n_fl_ops =
+      static_cast<size_t>(m) * static_cast<size_t>(n) * static_cast<size_t>(2);
 
   size_t lda = m;
   long incX = 1;
@@ -59,7 +61,6 @@ BENCHMARK(gemv, clblast_level_2) {
   // in errors otherwise. It may be that this is incorrect (especially for
   // performance reasons), so may need to be revisited.
   auto layout = clblast::Layout::kColMajor;
-
 
   // specify the transposition.
   clblast::Transpose a_transpose;

--- a/bench/clblast/clblast_benchmark_level3.cpp
+++ b/bench/clblast/clblast_benchmark_level3.cpp
@@ -32,9 +32,10 @@
 
 BENCHMARK_NAME_FORMAT(clblast_level_3) {
   std::ostringstream fname;
-  fname << benchmark<>::typestr<ElemT>() << "_" << name() << "_" << std::get<0>(params)
-        << "_" << std::get<1>(params) << "_" << std::get<2>(params) << "_"
-        << std::get<3>(params) << "_" << std::get<4>(params);
+  fname << benchmark<>::typestr<ElemT>() << "_" << name() << "_"
+        << std::get<0>(params) << "_" << std::get<1>(params) << "_"
+        << std::get<2>(params) << "_" << std::get<3>(params) << "_"
+        << std::get<4>(params);
   return fname.str();
 }
 
@@ -61,7 +62,8 @@ BENCHMARK(gemm, clblast_level_3) {
   const size_t k = std::get<3>(params);
   const size_t n = std::get<4>(params);
 
-  size_t n_fl_ops = (2 * m * n * k);
+  size_t n_fl_ops = (static_cast<size_t>(2) * static_cast<size_t>(m) *
+                     static_cast<size_t>(n) * static_cast<size_t>(k));
 
   size_t lda = t_a[0] == 'n' ? m : k;
   size_t ldb = t_b[0] == 'n' ? k : n;

--- a/bench/common/blas_benchmark.hpp
+++ b/bench/common/blas_benchmark.hpp
@@ -138,6 +138,14 @@ struct benchmark {
 
     // convert the time to flop/s based on the number of fl_ops that the
     // function performs
+    std::cout << "n_fl_ops: " << FlopsT(n_fl_ops) << std::endl;
+    std::cout << "n_fl_ops * numReps: " << FlopsT(n_fl_ops)*numReps << std::endl;
+    std::cout << "std::chrono::duration_cast<std::chrono::duration<double>>(dur).count(): " << std::chrono::duration_cast<std::chrono::duration<double>>(dur)
+               .count() << std::endl;
+    std::cout << "Overall: " << (FlopsT(n_fl_ops) * numReps) /
+           std::chrono::duration_cast<std::chrono::duration<double>>(dur)
+               .count() << std::endl;
+
     return (FlopsT(n_fl_ops) * numReps) /
            std::chrono::duration_cast<std::chrono::duration<double>>(dur)
                .count();
@@ -304,12 +312,12 @@ int main_impl(Range<ParamT>* range_param, const unsigned reps, Ex ex,
     run_benchmark(b, range_param, reps, ex, output);
   }
 
-#ifndef NO_DOUBLE_SUPPORT
-  auto dbenchmarks = benchmark_suite<double, Ex, ParamT>();
-  for (auto b : dbenchmarks) {
-    run_benchmark(b, range_param, reps, ex, output);
-  }
-#endif
+// #ifndef NO_DOUBLE_SUPPORT
+//   auto dbenchmarks = benchmark_suite<double, Ex, ParamT>();
+//   for (auto b : dbenchmarks) {
+//     run_benchmark(b, range_param, reps, ex, output);
+//   }
+// #endif
 
   return 0;
 }

--- a/bench/common/blas_benchmark.hpp
+++ b/bench/common/blas_benchmark.hpp
@@ -50,14 +50,12 @@
 
 /**
  * @fn type_string
- * @brief Generate a string describing the type T. Currently only supports `float` and `double`.
- * 
- * This function uses C++ template specialisation to dispatch the correct variant of `type_string`. 
- * e.g. calling: 
- *    `type_string<Float>()`
- * will return "float", while calling: 
- *    `type_string<Int>()`
- * will return "unknown"
+ * @brief Generate a string describing the type T. Currently only supports
+ * `float` and `double`.
+ *
+ * This function uses C++ template specialisation to dispatch the correct
+ * variant of `type_string`. e.g. calling: `type_string<Float>()` will return
+ * "float", while calling: `type_string<Int>()` will return "unknown"
  */
 template <typename T>
 const inline std::string& type_string() {
@@ -106,11 +104,25 @@ struct benchmark {
 
   /**
    * @fn random_scalar
-   * @brief Generates a random scalar value, using an arbitrary low quality algorithm.
+   * @brief Generates a random scalar value, using an arbitrary low quality
+   * algorithm.
    */
   template <typename ScalarT>
   static ScalarT random_scalar() {
     return 1e-3 * ((rand() % 2000) - 1000);
+  }
+
+  /**
+   * @fn timef
+   * @brief Calculates the time spent executing the function func
+   */
+  template <typename F, typename... Args>
+  static TimeT timef(F func, Args&&... args) {
+    auto start = ClockT::now();
+
+    func(std::forward<Args>(args)...);
+
+    return std::chrono::duration_cast<TimeT>(ClockT::now() - start);
   }
 
   /**
@@ -129,23 +141,11 @@ struct benchmark {
     }
 
     for (size_t reps = 0; reps < numReps; reps++) {
-      auto start = ClockT::now();
-
-      func(std::forward<Args>(args)...);
-
-      dur += std::chrono::duration_cast<TimeT>(ClockT::now() - start);
+      dur += benchmark<>::timef(func, std::forward<Args>(args)...);
     }
 
     // convert the time to flop/s based on the number of fl_ops that the
     // function performs
-    std::cout << "n_fl_ops: " << FlopsT(n_fl_ops) << std::endl;
-    std::cout << "n_fl_ops * numReps: " << FlopsT(n_fl_ops)*numReps << std::endl;
-    std::cout << "std::chrono::duration_cast<std::chrono::duration<double>>(dur).count(): " << std::chrono::duration_cast<std::chrono::duration<double>>(dur)
-               .count() << std::endl;
-    std::cout << "Overall: " << (FlopsT(n_fl_ops) * numReps) /
-           std::chrono::duration_cast<std::chrono::duration<double>>(dur)
-               .count() << std::endl;
-
     return (FlopsT(n_fl_ops) * numReps) /
            std::chrono::duration_cast<std::chrono::duration<double>>(dur)
                .count();
@@ -157,9 +157,10 @@ struct benchmark {
 
   /**
    * @fn typestr
-   * @brief Print the type of a given type T. Currently only supports `float` and `double`.
+   * @brief Print the type of a given type T. Currently only supports `float`
+   * and `double`.
    */
-  template<typename T>
+  template <typename T>
   static std::string typestr() {
     return type_string<T>();
   }
@@ -312,12 +313,12 @@ int main_impl(Range<ParamT>* range_param, const unsigned reps, Ex ex,
     run_benchmark(b, range_param, reps, ex, output);
   }
 
-// #ifndef NO_DOUBLE_SUPPORT
-//   auto dbenchmarks = benchmark_suite<double, Ex, ParamT>();
-//   for (auto b : dbenchmarks) {
-//     run_benchmark(b, range_param, reps, ex, output);
-//   }
-// #endif
+  // #ifndef NO_DOUBLE_SUPPORT
+  //   auto dbenchmarks = benchmark_suite<double, Ex, ParamT>();
+  //   for (auto b : dbenchmarks) {
+  //     run_benchmark(b, range_param, reps, ex, output);
+  //   }
+  // #endif
 
   return 0;
 }

--- a/bench/common/blas_benchmark.hpp
+++ b/bench/common/blas_benchmark.hpp
@@ -313,12 +313,12 @@ int main_impl(Range<ParamT>* range_param, const unsigned reps, Ex ex,
     run_benchmark(b, range_param, reps, ex, output);
   }
 
-  // #ifndef NO_DOUBLE_SUPPORT
-  //   auto dbenchmarks = benchmark_suite<double, Ex, ParamT>();
-  //   for (auto b : dbenchmarks) {
-  //     run_benchmark(b, range_param, reps, ex, output);
-  //   }
-  // #endif
+  #ifndef NO_DOUBLE_SUPPORT
+    auto dbenchmarks = benchmark_suite<double, Ex, ParamT>();
+    for (auto b : dbenchmarks) {
+      run_benchmark(b, range_param, reps, ex, output);
+    }
+  #endif
 
   return 0;
 }

--- a/bench/common/range.hpp
+++ b/bench/common/range.hpp
@@ -80,7 +80,8 @@ class SizeRange : public Range<T> {
     // Ranges are *inclusive*
     bool _finished = v > high;
     // act like a resettable latch - this allows us to iterate over a range
-    // again once we've finished it - particularly useful for multidimensional ranges
+    // again once we've finished it - particularly useful for multidimensional
+    // ranges
     if (_finished) {
       v = low;
     }
@@ -107,9 +108,10 @@ class ValueRange : public Range<T> {
   bool finished() {
     bool _finished = iter >= vals.end();
     // act like a resettable latch - this allows us to iterate over a range
-    // again once we've finished it - particularly useful for multidimensional ranges
+    // again once we've finished it - particularly useful for multidimensional
+    // ranges
     if (_finished) {
-      iter = vals.begin(); 
+      iter = vals.begin();
     }
     return _finished;
   }
@@ -123,8 +125,8 @@ class ConcatRange : public Range<typename Range1::elem_t> {
   Range1 r1;
   Range2 r2;
 
-  // cache this - as otherwise it'll reset! 
-  bool r1_finished = false; 
+  // cache this - as otherwise it'll reset!
+  bool r1_finished = false;
 
  public:
   typedef typename Range1::elem_t elem_t;
@@ -134,24 +136,24 @@ class ConcatRange : public Range<typename Range1::elem_t> {
 
   // override the behaviour of r1 - we don't want it to act as a
   // resettable latch - we want it to, instead, stop when it's done
-  // so that we can move on to r2. 
-  elem_t yield() { 
-    if(r1_finished) { 
+  // so that we can move on to r2.
+  elem_t yield() {
+    if (r1_finished) {
       return r2.yield();
-    }else{
-      auto v = r1.yield(); 
+    } else {
+      auto v = r1.yield();
       r1_finished = r1.finished();
-      return v; 
+      return v;
     }
   }
 
-  // Overall, though, we *do* want to look like a resettable latch, 
+  // Overall, though, we *do* want to look like a resettable latch,
   // so reset our r1_finished value so we can start again.
-  bool finished() { 
-    if(r2.finished()) { 
+  bool finished() {
+    if (r2.finished()) {
       r1_finished = false;
       return true;
-    }else {
+    } else {
       return false;
     }
   }
@@ -312,8 +314,6 @@ ConcatRange<Range1, Range2> concat_ranges(Range1 r1, Range2 r2) {
   return ConcatRange<Range1, Range2>(r1, r2);
 }
 
-
-
 namespace default_ranges {
 
 auto level_1 = size_range(1 << 1, 1 << 24, 1 << 1);
@@ -325,9 +325,9 @@ auto level_3 = concat_ranges(
     nd_range(value_range({"n", "t", "c"}), value_range({"n", "t", "c"}),
              size_range(512, 4096, 2), size_range(512, 4096, 2),
              size_range(512, 4096, 2)),
-    value_range({std::make_tuple("n", "n", 8192, 8192, 8192),
-                 std::make_tuple("t", "n", 8192, 8192, 8192),
-                 std::make_tuple("n", "t", 8192, 8192, 8192)}));
+    value_range({std::make_tuple("n", "n", 8192, 128, 8192),
+                 std::make_tuple("t", "n", 8192, 128, 8192),
+                 std::make_tuple("n", "t", 8192, 128, 8192)}));
 
 }  // namespace default_ranges
 

--- a/bench/common/range.hpp
+++ b/bench/common/range.hpp
@@ -263,12 +263,20 @@ Range5D<Range1, Range2, Range3, Range4, Range5> nd_range(Range1 r1, Range2 r2,
 namespace default_ranges {
 auto level_1 = size_range(1 << 1, 1 << 24, 1 << 1);
 
-auto level_2 = nd_range(value_range({"n", "t", "c"}), size_range(2, 2 << 14, 2),
-                        size_range(2, 2 << 14, 2));
+// auto level_2 = nd_range(value_range({"n", "t", "c"}), size_range(2, 2 << 14, 2),
+//                         size_range(2, 2 << 14, 2));
+auto level_2 = nd_range(value_range({"n", "t", "c"}), size_range(128, 32768, 2),
+                        size_range(128, 32768, 2));
+
+// auto level_3 = nd_range(value_range({"n", "t", "c"}),
+//                         value_range({"n", "t", "c"}), size_range(2, 2 << 10, 2),
+//                         size_range(2, 2 << 10, 2), size_range(2, 2 << 10, 2));
+
 
 auto level_3 = nd_range(value_range({"n", "t", "c"}),
-                        value_range({"n", "t", "c"}), size_range(2, 2 << 10, 2),
-                        size_range(2, 2 << 10, 2), size_range(2, 2 << 10, 2));
+                        value_range({"n", "t", "c"}), size_range(512, 32768, 2),
+                        size_range(512, 32768, 2), size_range(512, 32768, 2));
+
 
 }  // namespace default_ranges
 

--- a/bench/common/range.hpp
+++ b/bench/common/range.hpp
@@ -263,15 +263,8 @@ Range5D<Range1, Range2, Range3, Range4, Range5> nd_range(Range1 r1, Range2 r2,
 namespace default_ranges {
 auto level_1 = size_range(1 << 1, 1 << 24, 1 << 1);
 
-// auto level_2 = nd_range(value_range({"n", "t", "c"}), size_range(2, 2 << 14, 2),
-//                         size_range(2, 2 << 14, 2));
 auto level_2 = nd_range(value_range({"n", "t", "c"}), size_range(128, 32768, 2),
                         size_range(128, 32768, 2));
-
-// auto level_3 = nd_range(value_range({"n", "t", "c"}),
-//                         value_range({"n", "t", "c"}), size_range(2, 2 << 10, 2),
-//                         size_range(2, 2 << 10, 2), size_range(2, 2 << 10, 2));
-
 
 auto level_3 = nd_range(value_range({"n", "t", "c"}),
                         value_range({"n", "t", "c"}), size_range(512, 32768, 2),

--- a/bench/common/range.hpp
+++ b/bench/common/range.hpp
@@ -77,7 +77,9 @@ class SizeRange : public Range<T> {
     return r;   // return
   }
   bool finished() {
-    bool _finished = v > high;
+    bool _finished = v >= high;
+    // act like a resettable latch - this allows us to iterate over a range
+    // again once we've finished it - particularly useful for multidimensional ranges
     if (_finished) {
       v = low;
     }
@@ -103,10 +105,54 @@ class ValueRange : public Range<T> {
   T yield() { return *iter++; }
   bool finished() {
     bool _finished = iter >= vals.end();
+    // act like a resettable latch - this allows us to iterate over a range
+    // again once we've finished it - particularly useful for multidimensional ranges
     if (_finished) {
-      iter = vals.begin();
+      iter = vals.begin(); 
     }
     return _finished;
+  }
+};
+
+/**
+ * Class of ranges where we concatenate two ranges.
+ */
+template <typename Range1, typename Range2>
+class ConcatRange : public Range<typename Range1::elem_t> {
+  Range1 r1;
+  Range2 r2;
+
+  // cache this - as otherwise it'll reset! 
+  bool r1_finished = false; 
+
+ public:
+  typedef typename Range1::elem_t elem_t;
+  ConcatRange(Range1 _r1, Range2 _r2) : r1(_r1), r2(_r2){};
+
+  elem_t peek() { return r1_finished ? r2.peek() : r1.peek(); }
+
+  // override the behaviour of r1 - we don't want it to act as a
+  // resettable latch - we want it to, instead, stop when it's done
+  // so that we can move on to r2. 
+  elem_t yield() { 
+    if(r1_finished) { 
+      return r2.yield();
+    }else{
+      auto v = r1.yield(); 
+      r1_finished = r1.finished();
+      return v; 
+    }
+  }
+
+  // Overall, though, we *do* want to look like a resettable latch, 
+  // so reset our r1_finished value so we can start again.
+  bool finished() { 
+    if(r2.finished()) { 
+      r1_finished = false;
+      return true;
+    }else {
+      return false;
+    }
   }
 };
 
@@ -260,16 +306,27 @@ Range5D<Range1, Range2, Range3, Range4, Range5> nd_range(Range1 r1, Range2 r2,
   return Range5D<Range1, Range2, Range3, Range4, Range5>(r1, r2, r3, r4, r5);
 }
 
+template <typename Range1, typename Range2>
+ConcatRange<Range1, Range2> concat_ranges(Range1 r1, Range2 r2) {
+  return ConcatRange<Range1, Range2>(r1, r2);
+}
+
+
+
 namespace default_ranges {
+
 auto level_1 = size_range(1 << 1, 1 << 24, 1 << 1);
 
-auto level_2 = nd_range(value_range({"n", "t", "c"}), size_range(128, 8192, 2),
-                        size_range(128, 8192, 2));
+auto level_2 = nd_range(value_range({"n", "t", "c"}), size_range(128, 4096, 2),
+                        size_range(128, 4096, 2));
 
-auto level_3 = nd_range(value_range({"n", "t", "c"}),
-                        value_range({"n", "t", "c"}), size_range(512, 8192, 2),
-                        size_range(512, 8192, 2), size_range(512, 8192, 2));
-
+auto level_3 = concat_ranges(
+    nd_range(value_range({"n", "t", "c"}), value_range({"n", "t", "c"}),
+             size_range(512, 4096, 2), size_range(512, 4096, 2),
+             size_range(512, 4096, 2)),
+    value_range({std::make_tuple("n", "n", 52900, 3136, 3),
+                 std::make_tuple("n", "n", 13225, 147, 64),
+                 std::make_tuple("n", "n", 147, 13225, 64)}));
 
 }  // namespace default_ranges
 

--- a/bench/common/range.hpp
+++ b/bench/common/range.hpp
@@ -263,12 +263,12 @@ Range5D<Range1, Range2, Range3, Range4, Range5> nd_range(Range1 r1, Range2 r2,
 namespace default_ranges {
 auto level_1 = size_range(1 << 1, 1 << 24, 1 << 1);
 
-auto level_2 = nd_range(value_range({"n", "t", "c"}), size_range(128, 32768, 2),
-                        size_range(128, 32768, 2));
+auto level_2 = nd_range(value_range({"n", "t", "c"}), size_range(128, 8192, 2),
+                        size_range(128, 8192, 2));
 
 auto level_3 = nd_range(value_range({"n", "t", "c"}),
-                        value_range({"n", "t", "c"}), size_range(512, 32768, 2),
-                        size_range(512, 32768, 2), size_range(512, 32768, 2));
+                        value_range({"n", "t", "c"}), size_range(512, 8192, 2),
+                        size_range(512, 8192, 2), size_range(512, 8192, 2));
 
 
 }  // namespace default_ranges

--- a/bench/common/range.hpp
+++ b/bench/common/range.hpp
@@ -77,7 +77,8 @@ class SizeRange : public Range<T> {
     return r;   // return
   }
   bool finished() {
-    bool _finished = v >= high;
+    // Ranges are *inclusive*
+    bool _finished = v > high;
     // act like a resettable latch - this allows us to iterate over a range
     // again once we've finished it - particularly useful for multidimensional ranges
     if (_finished) {
@@ -324,9 +325,9 @@ auto level_3 = concat_ranges(
     nd_range(value_range({"n", "t", "c"}), value_range({"n", "t", "c"}),
              size_range(512, 4096, 2), size_range(512, 4096, 2),
              size_range(512, 4096, 2)),
-    value_range({std::make_tuple("n", "n", 52900, 3136, 3),
-                 std::make_tuple("n", "n", 13225, 147, 64),
-                 std::make_tuple("n", "n", 147, 13225, 64)}));
+    value_range({std::make_tuple("n", "n", 8192, 8192, 8192),
+                 std::make_tuple("t", "n", 8192, 8192, 8192),
+                 std::make_tuple("n", "t", 8192, 8192, 8192)}));
 
 }  // namespace default_ranges
 

--- a/bench/syclblas/syclblas_benchmark_level2.cpp
+++ b/bench/syclblas/syclblas_benchmark_level2.cpp
@@ -31,8 +31,9 @@ using namespace blas;
 
 BENCHMARK_NAME_FORMAT(syclblas_level_2) {
   std::ostringstream fname;
-  fname << benchmark<>::typestr<ElemT>() << "_" << name() << "_" << std::get<0>(params)
-        << "_" << std::get<1>(params) << "_" << std::get<2>(params);
+  fname << benchmark<>::typestr<ElemT>() << "_" << name() << "_"
+        << std::get<0>(params) << "_" << std::get<1>(params) << "_"
+        << std::get<2>(params);
   return fname.str();
 }
 
@@ -47,7 +48,8 @@ BENCHMARK(gemv, syclblas_level_2) {
   IndexType vlen = t_str[0] == 'n' ? n : m;
   IndexType rlen = t_str[0] == 'n' ? m : n;
 
-  size_t n_fl_ops = m * n * 2;
+  size_t n_fl_ops =
+      static_cast<size_t>(m) * static_cast<size_t>(n) * static_cast<size_t>(2);
 
   IndexType lda = m;
   long incX = 1;

--- a/bench/syclblas/syclblas_benchmark_level3.cpp
+++ b/bench/syclblas/syclblas_benchmark_level3.cpp
@@ -25,23 +25,24 @@
 
 #include "../common/blas_benchmark.hpp"
 
+#include <cstdint>
 #include <interface/blas1_interface.hpp>
 #include <interface/blas3_interface.hpp>
-#include <cstdint>
 
 using namespace blas;
 
 BENCHMARK_NAME_FORMAT(syclblas_level_3) {
   std::ostringstream fname;
-  fname << benchmark<>::typestr<ElemT>() << "_" << name() << "_" << std::get<0>(params)
-        << "_" << std::get<1>(params) << "_" << std::get<2>(params) << "_"
-        << std::get<3>(params) << "_" << std::get<4>(params);
+  fname << benchmark<>::typestr<ElemT>() << "_" << name() << "_"
+        << std::get<0>(params) << "_" << std::get<1>(params) << "_"
+        << std::get<2>(params) << "_" << std::get<3>(params) << "_"
+        << std::get<4>(params);
   return fname.str();
 }
 
 BENCHMARK(gemm, syclblas_level_3) {
   using ScalarT = ElemT;
-  using IndexType = unsigned int; 
+  using IndexType = unsigned int;
 
   char const *t_a = std::get<0>(params);
   char const *t_b = std::get<1>(params);
@@ -49,20 +50,8 @@ BENCHMARK(gemm, syclblas_level_3) {
   const IndexType k = std::get<3>(params);
   const IndexType n = std::get<4>(params);
 
-  size_t _m = (size_t) m; 
-  size_t _n = (size_t) n; 
-  size_t _k = (size_t) k; 
-
-  size_t n_fl_ops = (2 * _m * _n * _k);
-  std::cout << "m * n = " << (_m*_n) << std::endl;
-  std::cout << "n * k = " << (_n*_k) << std::endl;
-  std::cout << "m * k = " << (_m*_k) << std::endl;
-  std::cout << "m * n * k = " << (_m*_n*_k) << std::endl;
-  unsigned long n_fl_ops_ul = (2 * _m * _n * _k);
-  uint64_t n_fl_ops_i64 = (2 * _m * _n * _k);
-  std::cout << "n_fl_ops (size_t) = " << n_fl_ops << std::endl;
-  std::cout << "n_fl_ops_ul (unsigned long) = " << n_fl_ops_ul << std::endl;
-  std::cout << "n_fl_ops_i64 (uint64_t) = " << n_fl_ops_i64 << std::endl;
+  size_t n_fl_ops = (static_cast<size_t>(2) * static_cast<size_t>(m) *
+                     static_cast<size_t>(n) * static_cast<size_t>(k));
 
   IndexType lda = t_a[0] == 'n' ? m : k;
   IndexType ldb = t_b[0] == 'n' ? k : n;

--- a/bench/syclblas/syclblas_benchmark_level3.cpp
+++ b/bench/syclblas/syclblas_benchmark_level3.cpp
@@ -27,6 +27,7 @@
 
 #include <interface/blas1_interface.hpp>
 #include <interface/blas3_interface.hpp>
+#include <cstdint>
 
 using namespace blas;
 
@@ -48,7 +49,20 @@ BENCHMARK(gemm, syclblas_level_3) {
   const IndexType k = std::get<3>(params);
   const IndexType n = std::get<4>(params);
 
-  size_t n_fl_ops = (2 * m * n * k);
+  size_t _m = (size_t) m; 
+  size_t _n = (size_t) n; 
+  size_t _k = (size_t) k; 
+
+  size_t n_fl_ops = (2 * _m * _n * _k);
+  std::cout << "m * n = " << (_m*_n) << std::endl;
+  std::cout << "n * k = " << (_n*_k) << std::endl;
+  std::cout << "m * k = " << (_m*_k) << std::endl;
+  std::cout << "m * n * k = " << (_m*_n*_k) << std::endl;
+  unsigned long n_fl_ops_ul = (2 * _m * _n * _k);
+  uint64_t n_fl_ops_i64 = (2 * _m * _n * _k);
+  std::cout << "n_fl_ops (size_t) = " << n_fl_ops << std::endl;
+  std::cout << "n_fl_ops_ul (unsigned long) = " << n_fl_ops_ul << std::endl;
+  std::cout << "n_fl_ops_i64 (uint64_t) = " << n_fl_ops_i64 << std::endl;
 
   IndexType lda = t_a[0] == 'n' ? m : k;
   IndexType ldb = t_b[0] == 'n' ? k : n;

--- a/bench/syclblas/syclblas_benchmark_level3.cpp
+++ b/bench/syclblas/syclblas_benchmark_level3.cpp
@@ -25,7 +25,6 @@
 
 #include "../common/blas_benchmark.hpp"
 
-#include <cstdint>
 #include <interface/blas1_interface.hpp>
 #include <interface/blas3_interface.hpp>
 


### PR DESCRIPTION
This PR fixes a bug with the calculation of flop/s, where the initial flop calculation would overflow, causing a zero value to be reported. Additionally, it introduces some new functionality (such as the ability to concatenate ranges), as well as some automated formatting of various benchmark files. 