### PR TITLE
Set `COMPUTECPP_USER_FLAGS`

### DIFF
--- a/cmake/Modules/ConfigureSYCLBLAS.cmake
+++ b/cmake/Modules/ConfigureSYCLBLAS.cmake
@@ -1,7 +1,7 @@
 
 # We add some flags to workaround OpenCL platform bugs, see ComputeCpp documentation
 # COMPUTECPP_USER_FLAGS are used when calling add_sycl_to_target
-set(COMPUTECPP_USER_FLAGS -no-serial-memop -Xclang -cl-mad-enable -O3)
+list(APPEND COMPUTECPP_USER_FLAGS -no-serial-memop -Xclang -cl-mad-enable -O3)
 
 # Check to see if we've disabled double support in the tests
 option(NO_DOUBLE_SUPPORT "Disable double support when testing." off)

--- a/cmake/Modules/ConfigureSYCLBLAS.cmake
+++ b/cmake/Modules/ConfigureSYCLBLAS.cmake
@@ -1,8 +1,7 @@
 
 # We add some flags to workaround OpenCL platform bugs, see ComputeCpp documentation
-set(COMPUTECPP_DEVICE_COMPILER_FLAGS
-    "${COMPUTECPP_DEVICE_COMPILER_FLAGS} -no-serial-memop -Xclang -cl-mad-enable -O3")
-message(STATUS "${COMPUTECPP_DEVICE_COMPILER_FLAGS}")
+# COMPUTECPP_USER_FLAGS are used when calling add_sycl_to_target
+set(COMPUTECPP_USER_FLAGS -no-serial-memop -Xclang -cl-mad-enable -O3)
 
 # Check to see if we've disabled double support in the tests
 option(NO_DOUBLE_SUPPORT "Disable double support when testing." off)


### PR DESCRIPTION
Set `COMPUTECPP_USER_FLAGS` instead of `COMPUTECPP_DEVICE_COMPILER_FLAGS`, as required by `FindComputeCpp.cmake`. This is required because of this change to ComputeCpp SDK: https://github.com/codeplaysoftware/computecpp-sdk/pull/149