### PR TITLE
Tiled axpy

### DIFF
--- a/include/interface/blas1_interface.hpp
+++ b/include/interface/blas1_interface.hpp
@@ -55,14 +55,31 @@ typename Executor::Return_Type _axpy(Executor &ex, IndexType _N, T _alpha,
                                      ContainerT1 &_vy, IncrementType _incy) {
   auto vx = make_vector_view(ex, _vx, _incx, _N);
   auto vy = make_vector_view(ex, _vy, _incy, _N);
+  cl::sycl::event ret;
 
-  std::cout << "vx size: " << vx.size() << std::endl;
-  std::cout << "vy size: " << vy.size() << std::endl;
+  auto tmp = make_vector_view()
 
-  auto scalOp = make_op<ScalarOp, prdOp2_struct>(_alpha, vx);
-  auto addOp = make_op<BinaryOp, addOp2_struct>(vy, scalOp);
-  auto assignOp = make_op<Assign>(vy, addOp);
-  auto ret = ex.execute(assignOp);
+                 std::cout
+             << "vx size: " << vx.size_ << std::endl;
+  std::cout << "vy size: " << vy.size_ << std::endl;
+
+  auto tile_size = 128;
+  auto tiles = (vx.size_ / tile_size) + 1;
+  for (int i = 0; i < tiles; i++) {
+    // Make on chip buffer ??
+    // Copy to on chip buffer ??
+    // Perfrom
+    auto scalOp = make_op<ScalarOp, prdOp2_struct>(_alpha, vx);
+    auto addOp = make_op<BinaryOp, addOp2_struct>(vy, scalOp);
+    auto assignOp = make_op<Assign>(vy, addOp);
+    ret = ex.execute(assignOp);
+    // Copy back into buffer.
+  }
+
+  // auto scalOp = make_op<ScalarOp, prdOp2_struct>(_alpha, vx);
+  // auto addOp = make_op<BinaryOp, addOp2_struct>(vy, scalOp);
+  // auto assignOp = make_op<Assign>(vy, addOp);
+  // auto ret = ex.execute(assignOp);
   return ret;
 }
 

--- a/include/interface/blas1_interface.hpp
+++ b/include/interface/blas1_interface.hpp
@@ -56,6 +56,9 @@ typename Executor::Return_Type _axpy(Executor &ex, IndexType _N, T _alpha,
   auto vx = make_vector_view(ex, _vx, _incx, _N);
   auto vy = make_vector_view(ex, _vy, _incy, _N);
 
+  std::cout << "vx size: " << vx.size() << std::endl;
+  std::cout << "vy size: " << vy.size() << std::endl;
+
   auto scalOp = make_op<ScalarOp, prdOp2_struct>(_alpha, vx);
   auto addOp = make_op<BinaryOp, addOp2_struct>(vy, scalOp);
   auto assignOp = make_op<Assign>(vy, addOp);

--- a/include/interface/blas1_interface.hpp
+++ b/include/interface/blas1_interface.hpp
@@ -48,7 +48,7 @@ namespace blas {
  * @param _vy  VectorView
  * @param _incy Increment in Y axis
  */
-template <int TileSize = 256, bool Tiled = true, typename Executor,
+template <size_t TileSize = 256, bool Tiled = true, typename Executor,
           typename ContainerT0, typename ContainerT1, typename T,
           typename IndexType, typename IncrementType>
 typename Executor::Return_Type _axpy(Executor &ex, IndexType _N, T _alpha,
@@ -60,7 +60,7 @@ typename Executor::Return_Type _axpy(Executor &ex, IndexType _N, T _alpha,
   //   - _N `mod` TileSize == 0
   //   - TileSize `mod` _incx == 0
   //   - _incx == _incy
-  //   - (sizeof(ElemT) * TileSize ) < _N (see SYCL copy bug)
+  //   - (sizeof(ElemT) * TileSize ) < _N (see ComputeCPP copy bug)
   // Otherwise, fall back to the "default" axpy
   if (Tiled && (_N % TileSize == 0) && (TileSize % _incx == 0) &&
       (_incx == _incy) && ((sizeof(T) * TileSize) < _N)) {
@@ -81,7 +81,7 @@ typename Executor::Return_Type _axpy(Executor &ex, IndexType _N, T _alpha,
     auto vy_tile_view =
         make_vector_view(ex, vy_tile_iterator_buffer, 1, TileSize);
 
-    for (int i = 0; i < _N; i += TileSize) {
+    for (size_t i = 0; i < _N; i += TileSize) {
       // Copy from _vx and _vy into vx_tile and vy_tile
       ret = ex.get_queue().submit([&](cl::sycl::handler &cgh) {
         auto vx_tile_acc =

--- a/include/queue/queue_sycl.hpp
+++ b/include/queue/queue_sycl.hpp
@@ -97,9 +97,10 @@ class Queue_Interface<SYCL> {
             cl::sycl::info::local_mem_type::local);
   }
   template <typename T>
-  inline T *allocate(size_t num_elements) const {
+  inline T *allocate(size_t num_elements,
+                     const cl::sycl::property_list &pList = {}) const {
     return static_cast<T *>(cl::sycl::codeplay::SYCLmalloc(
-        num_elements * sizeof(T), *pointerMapperPtr_));
+        num_elements * sizeof(T), *pointerMapperPtr_, pList));
   }
 
   template <typename T>
@@ -173,6 +174,7 @@ class Queue_Interface<SYCL> {
   template <cl::sycl::access::mode AcM = cl::sycl::access::mode::read_write,
             typename T>
   placeholder_accessor_t<T, AcM> get_range_access(T *vptr) {
+    std::cout << "get_range_access of T vptr" << std::endl;
     auto buff_t = get_buffer(vptr);
     auto offset = get_offset(vptr);
     return placeholder_accessor_t<T, AcM>(
@@ -188,6 +190,7 @@ class Queue_Interface<SYCL> {
   template <cl::sycl::access::mode AcM = cl::sycl::access::mode::read_write,
             typename T>
   placeholder_accessor_t<T, AcM> get_range_access(buffer_iterator<T> buff) {
+    std::cout << "get_range_access of buffer_iterator" << std::endl;
     return blas::get_range_accessor<AcM>(buff);
   }
 

--- a/include/queue/sycl_iterator.hpp
+++ b/include/queue/sycl_iterator.hpp
@@ -69,6 +69,8 @@ class buffer_iterator {
 
   scalar_t* operator->() = delete;
 
+  const buff_t& get_buffer() const { return m_buffer; }
+
  private:
   std::ptrdiff_t m_offset;
   buff_t m_buffer;

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -180,24 +180,6 @@ class BLAS_Test<blas_test_args<ScalarT_, MetadataT_, ExecutorType_>>
 
   template <typename DataType,
             typename value_type = typename DataType::value_type>
-  static void set_const(DataType &vec, size_t _N, value_type c) {
-    for (size_t i = 0; i < _N; ++i) {
-      vec[i] = c;
-    }
-  }
-
-  template <typename DataType,
-            typename value_type = typename DataType::value_type>
-  static void set_monotonic(DataType &vec, size_t _N, value_type increment) {
-    value_type v = value_type(0);
-    for (size_t i = 0; i < _N; ++i) {
-      vec[i] = v;
-      v += increment;
-    }
-  }
-
-  template <typename DataType,
-            typename value_type = typename DataType::value_type>
   static void print_cont(const DataType &vec, size_t _N,
                          std::string name = "vector") {
     std::cout << name << ": ";

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -180,6 +180,24 @@ class BLAS_Test<blas_test_args<ScalarT_, MetadataT_, ExecutorType_>>
 
   template <typename DataType,
             typename value_type = typename DataType::value_type>
+  static void set_const(DataType &vec, size_t _N, value_type c) {
+    for (size_t i = 0; i < _N; ++i) {
+      vec[i] = c;
+    }
+  }
+
+  template <typename DataType,
+            typename value_type = typename DataType::value_type>
+  static void set_monotonic(DataType &vec, size_t _N, value_type increment) {
+    value_type v = value_type(0);
+    for (size_t i = 0; i < _N; ++i) {
+      vec[i] = v;
+      v += increment;
+    }
+  }
+
+  template <typename DataType,
+            typename value_type = typename DataType::value_type>
   static void print_cont(const DataType &vec, size_t _N,
                          std::string name = "vector") {
     std::cout << name << ": ";

--- a/test/unittest/blas1/blas1_axpy_test.cpp
+++ b/test/unittest/blas1/blas1_axpy_test.cpp
@@ -26,7 +26,6 @@
 typedef ::testing::Types<blas_test_float<>, blas_test_double<> > BlasTypes;
 
 TYPED_TEST_CASE(BLAS_Test, BlasTypes);
-
 REGISTER_SIZE(::RANDOM_SIZE, axpy_test_buff)
 REGISTER_STRD(::RANDOM_STRD, axpy_test_buff)
 REGISTER_PREC(float, 1e-4, axpy_test_buff)
@@ -81,7 +80,6 @@ TYPED_TEST(BLAS_Test, axpy_test_buff) {
 }
 
 TYPED_TEST_CASE(BLAS_Test, BlasTypes);
-
 REGISTER_SIZE(::RANDOM_SIZE, axpy_test)
 REGISTER_STRD(::RANDOM_STRD, axpy_test)
 REGISTER_PREC(float, 1e-4, axpy_test)
@@ -137,6 +135,7 @@ TYPED_TEST(BLAS_Test, axpy_test) {
   ex.template deallocate<ScalarT>(gpu_vY);
 }
 
+TYPED_TEST_CASE(BLAS_Test, BlasTypes);
 REGISTER_SIZE(::RANDOM_SIZE, axpy_test_vpr)
 REGISTER_STRD(::RANDOM_STRD, axpy_test_vpr)
 REGISTER_PREC(float, 1e-4, axpy_test_vpr)
@@ -183,6 +182,188 @@ TYPED_TEST(BLAS_Test, axpy_test_vpr) {
   ex.copy_to_device(vX.data(), gpu_vX, size);
   ex.copy_to_device(vY.data(), gpu_vY, size);
   _axpy(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY, strd);
+  auto event = ex.copy_to_host(gpu_vY, vY.data(), size);
+  ex.wait(event);
+
+  // check that both results are the same
+  for (size_t i = 0; i < size; ++i) {
+    ASSERT_NEAR(vZ[i], vY[i], prec);
+  }
+
+  ex.template deallocate<ScalarT>(gpu_vX);
+  ex.template deallocate<ScalarT>(gpu_vY);
+}
+
+// Tests specifically for the tiled variant of axpy
+// The tests are specifically set up to use parameters that will trigger the
+// 'tiled' codepath of the axpy operation. It would be better to overload the
+// axpy interface to allow the user to specify tiled/not manually, but this
+// would require some interface overloading work that isn't currently scheduled
+// or planned for.
+// Currently, tests using the virtual pointer provided by the computecpp-sdk
+// will fail, as there is a bug in theruntime that incorrectly calculates sizes
+// during copies when a buffer is reinterpreted from an untyped buffer
+// (SYCLE-270). Tests using the virtual pointer, DISABLED_axpy_test_tiled, and
+// DISABLED_axpy_test_vpr_tiled, are disabled as they are currently expected to
+// fail because of said bug.
+
+TYPED_TEST_CASE(BLAS_Test, BlasTypes);
+REGISTER_SIZE(256, axpy_test_buff_tiled)
+REGISTER_STRD(1, axpy_test_buff_tiled)
+REGISTER_PREC(float, 1e-4, axpy_test_buff_tiled)
+REGISTER_PREC(double, 1e-6, axpy_test_buff_tiled)
+REGISTER_PREC(std::complex<float>, 1e-4, axpy_test_buff_tiled)
+REGISTER_PREC(std::complex<double>, 1e-6, axpy_test_buff_tiled)
+
+TYPED_TEST(BLAS_Test, axpy_test_buff_tiled) {
+  using ScalarT = typename TypeParam::scalar_t;
+  using ExecutorType = typename TypeParam::executor_t;
+  using TestClass = BLAS_Test<TypeParam>;
+  using test = class axpy_test_buff_tiled;
+
+  size_t size = TestClass::template test_size<test>();
+  long strd = TestClass::template test_strd<test>();
+  ScalarT prec = TestClass::template test_prec<test>();
+
+  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
+  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
+  // setting alpha to some value
+  ScalarT alpha(1.54);
+  // creating three vectors: vX, vY and vZ.
+  // the for loop will compute axpy for vX, vY
+  std::vector<ScalarT> vX(size);
+  std::vector<ScalarT> vY(size);
+  std::vector<ScalarT> vZ(size, 0);
+  TestClass::set_rand(vX, size);
+  TestClass::set_rand(vY, size);
+
+  // compute axpy in a for loop and put the result into vZ
+  for (size_t i = 0; i < size; ++i) {
+    if (i % strd == 0) {
+      vZ[i] = alpha * vX[i] + vY[i];
+    } else {
+      vZ[i] = vY[i];
+    }
+  }
+
+  SYCL_DEVICE_SELECTOR d;
+  auto q = TestClass::make_queue(d);
+  Executor<ExecutorType> ex(q);
+  auto gpu_vX = blas::helper::make_sycl_iterator_buffer<ScalarT>(vX, size);
+  auto gpu_vY = blas::helper::make_sycl_iterator_buffer<ScalarT>(vY, size);
+  _axpy<8>(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY, strd);
+  auto event = ex.copy_to_host(gpu_vY, vY.data(), size);
+  ex.wait(event);
+
+  // check that both results are the same
+  for (size_t i = 0; i < size; ++i) {
+    ASSERT_NEAR(vZ[i], vY[i], prec);
+  }
+}
+
+TYPED_TEST_CASE(BLAS_Test, BlasTypes);
+REGISTER_SIZE(256, DISABLED_axpy_test_tiled)
+REGISTER_STRD(1, DISABLED_axpy_test_tiled)
+REGISTER_PREC(float, 1e-4, DISABLED_axpy_test_tiled)
+REGISTER_PREC(double, 1e-6, DISABLED_axpy_test_tiled)
+REGISTER_PREC(std::complex<float>, 1e-4, DISABLED_axpy_test_tiled)
+REGISTER_PREC(std::complex<double>, 1e-6, DISABLED_axpy_test_tiled)
+
+TYPED_TEST(BLAS_Test, DISABLED_axpy_test_tiled) {
+  using ScalarT = typename TypeParam::scalar_t;
+  using ExecutorType = typename TypeParam::executor_t;
+  using TestClass = BLAS_Test<TypeParam>;
+  using test = class DISABLED_axpy_test_tiled;
+
+  size_t size = TestClass::template test_size<test>();
+  long strd = TestClass::template test_strd<test>();
+  ScalarT prec = TestClass::template test_prec<test>();
+
+  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
+  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
+  // setting alpha to some value
+  ScalarT alpha(1.54);
+  // creating three vectors: vX, vY and vZ.
+  // the for loop will compute axpy for vX, vY
+  std::vector<ScalarT> vX(size);
+  std::vector<ScalarT> vY(size);
+  std::vector<ScalarT> vZ(size, 0);
+  TestClass::set_rand(vX, size);
+  TestClass::set_rand(vY, size);
+
+  // compute axpy in a for loop and put the result into vZ
+  for (size_t i = 0; i < size; ++i) {
+    if (i % strd == 0) {
+      vZ[i] = alpha * vX[i] + vY[i];
+    } else {
+      vZ[i] = vY[i];
+    }
+  }
+
+  SYCL_DEVICE_SELECTOR d;
+  auto q = TestClass::make_queue(d);
+  Executor<ExecutorType> ex(q);
+  auto gpu_vX = blas::helper::make_sycl_iterator_buffer<ScalarT>(vX, size);
+  auto gpu_vY = ex.template allocate<ScalarT>(size);
+  ex.copy_to_device(vY.data(), gpu_vY, size);
+  _axpy<8>(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY, strd);
+  auto event = ex.copy_to_host(gpu_vY, vY.data(), size);
+  ex.wait(event);
+
+  // check that both results are the same
+  for (size_t i = 0; i < size; ++i) {
+    ASSERT_NEAR(vZ[i], vY[i], prec);
+  }
+  ex.template deallocate<ScalarT>(gpu_vY);
+}
+
+TYPED_TEST_CASE(BLAS_Test, BlasTypes);
+REGISTER_SIZE(256, DISABLED_axpy_test_vpr_tiled)
+REGISTER_STRD(1, DISABLED_axpy_test_vpr_tiled)
+REGISTER_PREC(float, 1e-4, DISABLED_axpy_test_vpr_tiled)
+REGISTER_PREC(double, 1e-6, DISABLED_axpy_test_vpr_tiled)
+REGISTER_PREC(std::complex<float>, 1e-4, DISABLED_axpy_test_vpr_tiled)
+REGISTER_PREC(std::complex<double>, 1e-6, DISABLED_axpy_test_vpr_tiled)
+
+TYPED_TEST(BLAS_Test, DISABLED_axpy_test_vpr_tiled) {
+  using ScalarT = typename TypeParam::scalar_t;
+  using ExecutorType = typename TypeParam::executor_t;
+  using TestClass = BLAS_Test<TypeParam>;
+  using test = class DISABLED_axpy_test_vpr_tiled;
+
+  size_t size = TestClass::template test_size<test>();
+  long strd = TestClass::template test_strd<test>();
+  ScalarT prec = TestClass::template test_prec<test>();
+
+  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
+  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
+  // setting alpha to some value
+  ScalarT alpha(1.54);
+  // creating three vectors: vX, vY and vZ.
+  // the for loop will compute axpy for vX, vY
+  std::vector<ScalarT> vX(size);
+  std::vector<ScalarT> vY(size);
+  std::vector<ScalarT> vZ(size, 0);
+  TestClass::set_rand(vX, size);
+  TestClass::set_rand(vY, size);
+
+  // compute axpy in a for loop and put the result into vZ
+  for (size_t i = 0; i < size; ++i) {
+    if (i % strd == 0) {
+      vZ[i] = alpha * vX[i] + vY[i];
+    } else {
+      vZ[i] = vY[i];
+    }
+  }
+
+  SYCL_DEVICE_SELECTOR d;
+  auto q = TestClass::make_queue(d);
+  Executor<ExecutorType> ex(q);
+  auto gpu_vX = ex.template allocate<ScalarT>(size);
+  auto gpu_vY = ex.template allocate<ScalarT>(size);
+  ex.copy_to_device(vX.data(), gpu_vX, size);
+  ex.copy_to_device(vY.data(), gpu_vY, size);
+  _axpy<8>(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY, strd);
   auto event = ex.copy_to_host(gpu_vY, vY.data(), size);
   ex.wait(event);
 

--- a/test/unittest/blas1/blas1_axpy_test.cpp
+++ b/test/unittest/blas1/blas1_axpy_test.cpp
@@ -23,10 +23,7 @@
  *
  **************************************************************************/
 #include "blas_test.hpp"
-typedef ::testing::Types<blas_test_float<>,
-                         blas_test_double<>
-                         >
-    BlasTypes;
+typedef ::testing::Types<blas_test_float<>, blas_test_double<> > BlasTypes;
 
 TYPED_TEST_CASE(BLAS_Test, BlasTypes);
 

--- a/test/unittest/blas1/blas1_axpy_test.cpp
+++ b/test/unittest/blas1/blas1_axpy_test.cpp
@@ -201,11 +201,11 @@ TYPED_TEST(BLAS_Test, axpy_test_vpr) {
 // would require some interface overloading work that isn't currently scheduled
 // or planned for.
 // Currently, tests using the virtual pointer provided by the computecpp-sdk
-// will fail, as there is a bug in theruntime that incorrectly calculates sizes
-// during copies when a buffer is reinterpreted from an untyped buffer
-// (SYCLE-270). Tests using the virtual pointer, DISABLED_axpy_test_tiled, and
-// DISABLED_axpy_test_vpr_tiled, are disabled as they are currently expected to
-// fail because of said bug.
+// will fail, as there is a bug in the ComputeCpp runtime that incorrectly
+// calculates sizes during copies when a buffer is reinterpreted from an untyped
+// buffer (SYCLE-270). Tests using the virtual pointer,
+// DISABLED_axpy_test_tiled, and DISABLED_axpy_test_vpr_tiled, are disabled as
+// they are currently expected to fail because of said bug.
 
 TYPED_TEST_CASE(BLAS_Test, BlasTypes);
 REGISTER_SIZE(256, axpy_test_buff_tiled)
@@ -222,6 +222,8 @@ TYPED_TEST(BLAS_Test, axpy_test_buff_tiled) {
   using test = class axpy_test_buff_tiled;
 
   size_t size = TestClass::template test_size<test>();
+  constexpr const size_t tile_size =
+      8;  // use a constant tile size that we know works.
   long strd = TestClass::template test_strd<test>();
   ScalarT prec = TestClass::template test_prec<test>();
 
@@ -251,7 +253,8 @@ TYPED_TEST(BLAS_Test, axpy_test_buff_tiled) {
   Executor<ExecutorType> ex(q);
   auto gpu_vX = blas::helper::make_sycl_iterator_buffer<ScalarT>(vX, size);
   auto gpu_vY = blas::helper::make_sycl_iterator_buffer<ScalarT>(vY, size);
-  _axpy<8>(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY, strd);
+  _axpy<tile_size>(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY,
+                   strd);
   auto event = ex.copy_to_host(gpu_vY, vY.data(), size);
   ex.wait(event);
 
@@ -276,6 +279,8 @@ TYPED_TEST(BLAS_Test, DISABLED_axpy_test_tiled) {
   using test = class DISABLED_axpy_test_tiled;
 
   size_t size = TestClass::template test_size<test>();
+  constexpr const size_t tile_size =
+      8;  // use a constant tile size that we know works.
   long strd = TestClass::template test_strd<test>();
   ScalarT prec = TestClass::template test_prec<test>();
 
@@ -306,7 +311,8 @@ TYPED_TEST(BLAS_Test, DISABLED_axpy_test_tiled) {
   auto gpu_vX = blas::helper::make_sycl_iterator_buffer<ScalarT>(vX, size);
   auto gpu_vY = ex.template allocate<ScalarT>(size);
   ex.copy_to_device(vY.data(), gpu_vY, size);
-  _axpy<8>(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY, strd);
+  _axpy<tile_size>(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY,
+                   strd);
   auto event = ex.copy_to_host(gpu_vY, vY.data(), size);
   ex.wait(event);
 
@@ -332,6 +338,8 @@ TYPED_TEST(BLAS_Test, DISABLED_axpy_test_vpr_tiled) {
   using test = class DISABLED_axpy_test_vpr_tiled;
 
   size_t size = TestClass::template test_size<test>();
+  constexpr const size_t tile_size =
+      8;  // use a constant tile size that we know works.
   long strd = TestClass::template test_strd<test>();
   ScalarT prec = TestClass::template test_prec<test>();
 
@@ -363,7 +371,8 @@ TYPED_TEST(BLAS_Test, DISABLED_axpy_test_vpr_tiled) {
   auto gpu_vY = ex.template allocate<ScalarT>(size);
   ex.copy_to_device(vX.data(), gpu_vX, size);
   ex.copy_to_device(vY.data(), gpu_vY, size);
-  _axpy<8>(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY, strd);
+  _axpy<tile_size>(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY,
+                   strd);
   auto event = ex.copy_to_host(gpu_vY, vY.data(), size);
   ex.wait(event);
 


### PR DESCRIPTION
This PR adds a variant of axpy that supports "tiling". If the conditions are correct, the axpy implementation will attempt to use "tiles" in order to compute sub-ranges of the axpy calculation. At present, the tiles use the default address space, but in future this can be changed to specific address spaces (e.g. private memory) in order to improve performance on specific platforms.