### PR TITLE
Travis fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,14 @@ RUN apt-get -yq update
 
 # Utilities
 RUN apt-get install -yq --allow-downgrades --allow-remove-essential            \
-    --allow-change-held-packages git wget apt-utils cmake unzip                \
+    --allow-change-held-packages git wget python-pip apt-utils cmake unzip                \
     libboost-all-dev software-properties-common python-software-properties libcompute-dev
 
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 
 RUN apt-get -yq update
+
+RUN pip install enum34
 
 # Clang 6.0
 RUN if [ "${c_compiler}" = 'clang-6.0' ]; then apt-get install -yq             \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENV SYCL_IMPL=${impl}
 ENV TARGET=${target}
 
 CMD cd /sycl-blas && \
-    export CMAKE_ARGS='-DCOMPUTECPP_USER_FLAGS="-fsycl-split-modules=20;-mllvm;-inline-threshold=10000;-no-serial-memop" -DSYCL_BLAS_ALWAYS_INLINE=OFF' && \
+    export CMAKE_ARGS='-DCOMPUTECPP_USER_FLAGS=-fsycl-split-modules=20;-mllvm;-inline-threshold=10000;-no-serial-memop -DSYCL_BLAS_ALWAYS_INLINE=OFF' && \
     if [ "${SYCL_IMPL}" = 'triSYCL' ]; then \
       ./build.sh --trisycl -DTRISYCL_INCLUDE_DIR=/tmp/triSYCL-master/include; \
     elif [ "${SYCL_IMPL}" = 'COMPUTECPP' ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENV SYCL_IMPL=${impl}
 ENV TARGET=${target}
 
 CMD cd /sycl-blas && \
-    export CMAKE_ARGS='-DCOMPUTECPP_USER_FLAGS=-fsycl-split-modules=20;-mllvm;-inline-threshold=10000;-no-serial-memop -DSYCL_BLAS_ALWAYS_INLINE=OFF' && \
+    export CMAKE_ARGS='-DCOMPUTECPP_USER_FLAGS=-fsycl-split-modules=20;-mllvm;-inline-threshold=10000;-no-serial-memop -DSYCL_BLAS_ALWAYS_INLINE=OFF -DBLAS_ENABLE_STATIC_LIBRARY=ON' && \
     if [ "${SYCL_IMPL}" = 'triSYCL' ]; then \
       ./build.sh --trisycl -DTRISYCL_INCLUDE_DIR=/tmp/triSYCL-master/include; \
     elif [ "${SYCL_IMPL}" = 'COMPUTECPP' ]; then \

--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,7 @@ trap display_help ERR
 
 # Get the absolute path of the ComputeCpp_DIR, from arg $1
 if [ -z "$1" ]
-  then 
+  then
   echo "No ComputeCPP Package specified."
   exit 1
 else

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script runs the SYCL-BLAS tests using the provided Dockerfile.
+# The intention is to provide a seamless alternative to .travis.yml, so that developers can locally test changes in a (somewhat) platform-agnostic manner without the usual delay that happens with travis.
+export IMPL=COMPUTECPP
+export CXX_COMPILER=g++-7
+export CC_COMPILER=gcc-7
+export TARGET=opencl
+export GIT_SLUG="AdamHarries/sycl-blas"
+export GIT_BRANCH="master"
+
+
+docker build --build-arg c_compiler=${CC_COMPILER} \
+    --build-arg cxx_compiler=${CXX_COMPILER} \
+    --build-arg git_branch=${GIT_BRANCH} \
+    --build-arg git_slug=${GIT_SLUG} \
+    --build-arg impl=${IMPL} \
+    --build-arg target=${TARGET} \
+    -t sycl-blas .
+
+docker run sycl-blas

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -6,7 +6,7 @@ export IMPL=COMPUTECPP
 export CXX_COMPILER=g++-7
 export CC_COMPILER=gcc-7
 export TARGET=opencl
-export GIT_SLUG="AdamHarries/sycl-blas"
+export GIT_SLUG="codeplaysoftware/sycl-blas"
 export GIT_BRANCH="master"
 
 

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 
 # This script runs the SYCL-BLAS tests using the provided Dockerfile.
-# The intention is to provide a seamless alternative to .travis.yml, so that developers can locally test changes in a (somewhat) platform-agnostic manner without the usual delay that happens with travis.
-   - IMPL=COMPUTECPP CXX_COMPILER=clang++-6.0 CC_COMPILER=clang-6.0 TARGET=opencl
+# The intention is to provide a seamless alternative to .travis.yml, so that
+# developers can locally test changes in a (somewhat) platform-agnostic manner
+# without the usual delay that travis testing entails.
+#
+# By default, this script will compile the SYCL-BLAS with g++-7. Other compilers
+# can be enabled by changing the `CXX_COMPILER` and `CC_COMPILER` environment
+# variables, e.g.:
+#   export CXX_COMPILER=clang++-6.0
+#   export CC_COMPILER=clang-6.0
+# Targets and git "slug" are also equally configurable. By default, the target
+# is OpenCL, and the git repository cloned is codeplay's sycl blas master.
 
 export IMPL=COMPUTECPP
-# export CXX_COMPILER=g++-7
-export CXX_COMPILER=clang++-6.0
-# export CC_COMPILER=gcc-7
-export CC_COMPILER=clang-6.0
+export CXX_COMPILER=g++-7
+export CC_COMPILER=gcc-7
 export TARGET=opencl
 export GIT_SLUG="codeplaysoftware/sycl-blas"
 export GIT_BRANCH="master"

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -2,9 +2,13 @@
 
 # This script runs the SYCL-BLAS tests using the provided Dockerfile.
 # The intention is to provide a seamless alternative to .travis.yml, so that developers can locally test changes in a (somewhat) platform-agnostic manner without the usual delay that happens with travis.
+   - IMPL=COMPUTECPP CXX_COMPILER=clang++-6.0 CC_COMPILER=clang-6.0 TARGET=opencl
+
 export IMPL=COMPUTECPP
-export CXX_COMPILER=g++-7
-export CC_COMPILER=gcc-7
+# export CXX_COMPILER=g++-7
+export CXX_COMPILER=clang++-6.0
+# export CC_COMPILER=gcc-7
+export CC_COMPILER=clang-6.0
 export TARGET=opencl
 export GIT_SLUG="codeplaysoftware/sycl-blas"
 export GIT_BRANCH="master"


### PR DESCRIPTION
This PR adds a dependency on python-pip and enum34 to the Dockerfile, so that we can consistently and correctly build the new "library" version of the sycl-blas on Travis. 

This fix also revealed a bug when passing COMPUTECPP_USER_FLAGS via CMAKE_ARGS, which this PR also fixes. 

Finally, this PR also adds "run_docker.sh", which provides a simple wrapper script around docker with some "sensible defaults", to make local testing of travis configurations easy and fast. 