### PR TITLE
Global variable and method cleanup

### DIFF
--- a/gbench/clblast/blas3/gemm.cpp
+++ b/gbench/clblast/blas3/gemm.cpp
@@ -26,7 +26,6 @@
 #include "range.hpp"
 #include "utils.hpp"
 
-
 template <typename scalar_t>
 void BM_Gemm(benchmark::State& state) {
   // Standard test setup.
@@ -52,8 +51,8 @@ void BM_Gemm(benchmark::State& state) {
   double n_d = static_cast<double>(n);
   double k_d = static_cast<double>(k);
   state.counters["n_fl_ops"] = 2.0 * m_d * n_d * k_d;
-  state.counters["bytes_processed"] = (m_d * k_d + k_d * n_d + m_d * n_d)
-                                      * sizeof(scalar_t);
+  state.counters["bytes_processed"] =
+      (m_d * k_d + k_d * n_d + m_d * n_d) * sizeof(scalar_t);
 
   // Create data
   // Scalars
@@ -74,7 +73,7 @@ void BM_Gemm(benchmark::State& state) {
   // performance reasons), so may need to be revisited.
   auto layout = clblast::Layout::kColMajor;
 
-  ExecutorType* ex = getExecutor().get();
+  ExecutorType* ex = Global::executorInstancePtr.get();
 
   // Device matrices
   MemBuffer<scalar_t> a_gpu(ex, a.data(), static_cast<size_t>(m * k));
@@ -85,8 +84,8 @@ void BM_Gemm(benchmark::State& state) {
   auto blas_method_def = [&]() {
     Event event;
     clblast::Gemm<scalar_t>(layout, a_tr, b_tr, m, n, k, alpha, a_gpu.dev(), 0,
-                           lda, b_gpu.dev(), 0, ldb, beta, c_gpu.dev(), 0, ldc,
-                           ex->_queue(), &event._cl());
+                            lda, b_gpu.dev(), 0, ldb, beta, c_gpu.dev(), 0, ldc,
+                            ex->_queue(), &event._cl());
     event.wait();
     return event;
   };
@@ -113,30 +112,28 @@ void BM_Gemm(benchmark::State& state) {
 
     state.counters["total_overall_time"] += overall_time;
     state.counters["best_overall_time"] =
-      std::min<double>(state.counters["best_overall_time"], overall_time);
+        std::min<double>(state.counters["best_overall_time"], overall_time);
 
     state.ResumeTiming();
   }
 
   state.counters["avg_event_time"] =
       state.counters["total_event_time"] / state.iterations();
-  state.counters["avg_overall_time"] = state.counters["total_overall_time"]
-       / state.iterations();
+  state.counters["avg_overall_time"] =
+      state.counters["total_overall_time"] / state.iterations();
 };
 
 static void gemm_args(benchmark::internal::Benchmark* b) {
   // Matrix dimensions bounds
   constexpr const int dim_min = 2 << 5;
-  constexpr const int dim_max  = 2 << 10;
+  constexpr const int dim_max = 2 << 10;
   // Matrix dimensions multiplier
   constexpr const int dim_mult = 2;
 
-  auto gemm_range = nd_range(
-      value_range({"n", "t"}), value_range({"n", "t"}),
-      size_range(dim_min, dim_max, dim_mult),
-      size_range(dim_min, dim_max, dim_mult),
-      size_range(dim_min, dim_max, dim_mult));
-
+  auto gemm_range = nd_range(value_range({"n", "t"}), value_range({"n", "t"}),
+                             size_range(dim_min, dim_max, dim_mult),
+                             size_range(dim_min, dim_max, dim_mult),
+                             size_range(dim_min, dim_max, dim_mult));
 
   do {
     auto p = gemm_range.yield();
@@ -147,7 +144,7 @@ static void gemm_args(benchmark::internal::Benchmark* b) {
     int n = std::get<4>(p);
     b->Args({t1, t2, m, k, n});
 
-  } while ( ! gemm_range.finished());
+  } while (!gemm_range.finished());
 }
 
 BENCHMARK_TEMPLATE(BM_Gemm, float)

--- a/gbench/clblast/main.cpp
+++ b/gbench/clblast/main.cpp
@@ -5,7 +5,7 @@ namespace Private {
 ExecutorPtr ex;
 }  // namespace Private
 
-ExecutorPtr getExecutor() { return Private::ex; }
+ExecutorPtr Global::executorInstancePtr;
 
 int main(int argc, char** argv) {
   cli_device_selector cds(argc, argv);
@@ -14,7 +14,7 @@ int main(int argc, char** argv) {
   benchmark::Initialize(&argc, argv);
 
   Context ctx(oclds);
-  Private::ex = std::make_shared<ExecutorType>(std::move(ctx));
+  Global::executorInstancePtr = std::unique_ptr<ExecutorType>(&ctx);
 
   benchmark::RunSpecifiedBenchmarks();
 }

--- a/gbench/clblast/utils.hpp
+++ b/gbench/clblast/utils.hpp
@@ -7,8 +7,11 @@
 #include <clblast.h>
 
 typedef Context ExecutorType;
-typedef std::shared_ptr<ExecutorType> ExecutorPtr;
-ExecutorPtr getExecutor();
+typedef std::unique_ptr<ExecutorType> ExecutorPtr;
+
+namespace Global {
+extern ExecutorPtr executorInstancePtr;
+}
 
 namespace benchmark {
 namespace utils {
@@ -101,7 +104,7 @@ inline void warmup(F func, Args &&... args) {
  * (both overall and event time, returned in nanoseconds in a tuple of double)
  */
 template <typename F, typename... Args>
-static std::tuple<double, double> timef(F func, Args&&... args) {
+static std::tuple<double, double> timef(F func, Args &&... args) {
   auto start = std::chrono::system_clock::now();
   auto event = func(std::forward<Args>(args)...);
   auto end = std::chrono::system_clock::now();

--- a/gbench/syclblas/blas1/asum.cpp
+++ b/gbench/syclblas/blas1/asum.cpp
@@ -32,7 +32,7 @@ void BM_Asum(benchmark::State& state) {
   const index_t size = static_cast<index_t>(state.range(0));
   state.counters["size"] = size;
 
-  SyclExecutorType ex = *getExecutor();
+  SyclExecutorType ex = *Global::executorInstancePtr;
 
   // Create data
   std::vector<scalar_t> v1 = benchmark::utils::random_data<scalar_t>(size);

--- a/gbench/syclblas/blas1/axpy.cpp
+++ b/gbench/syclblas/blas1/axpy.cpp
@@ -32,7 +32,7 @@ void BM_Axpy(benchmark::State& state) {
   const index_t size = static_cast<index_t>(state.range(0));
   state.counters["size"] = size;
 
-  SyclExecutorType ex = *getExecutor();
+  SyclExecutorType ex = *Global::executorInstancePtr;
 
   // Create data
   std::vector<scalar_t> v1 = benchmark::utils::random_data<scalar_t>(size);

--- a/gbench/syclblas/blas1/axpy3op.cpp
+++ b/gbench/syclblas/blas1/axpy3op.cpp
@@ -32,11 +32,11 @@ void BM_Axpy3op(benchmark::State& state) {
   const index_t size = static_cast<index_t>(state.range(0));
   state.counters["size"] = size;
 
-  SyclExecutorType ex = *getExecutor();
+  SyclExecutorType ex = *Global::executorInstancePtr;
 
   // Create data
   std::array<scalar_t, 3> alphas = {1.78426458744, 2.187346575843,
-                                   3.78164387328};
+                                    3.78164387328};
   std::vector<scalar_t> vsrc1 = benchmark::utils::random_data<scalar_t>(size);
   std::vector<scalar_t> vsrc2 = benchmark::utils::random_data<scalar_t>(size);
   std::vector<scalar_t> vsrc3 = benchmark::utils::random_data<scalar_t>(size);

--- a/gbench/syclblas/blas1/blas1.cpp
+++ b/gbench/syclblas/blas1/blas1.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+/**************************************************************************
  *
  *  @license
  *  Copyright (C) 2016 Codeplay Software Limited
@@ -32,7 +32,7 @@ void BM_Blas1(benchmark::State& state) {
   const index_t size = static_cast<index_t>(state.range(0));
   state.counters["size"] = size;
 
-  SyclExecutorType ex = *getExecutor();
+  SyclExecutorType ex = *Global::executorInstancePtr;
 
   // Create data
   std::vector<scalar_t> v1 = benchmark::utils::random_data<scalar_t>(size);

--- a/gbench/syclblas/blas1/dot.cpp
+++ b/gbench/syclblas/blas1/dot.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+/**************************************************************************
  *
  *  @license
  *  Copyright (C) 2016 Codeplay Software Limited
@@ -31,7 +31,7 @@ void BM_Dot(benchmark::State& state) {
   const index_t size = static_cast<index_t>(state.range(0));
   state.counters["size"] = size;
 
-  SyclExecutorType ex = *getExecutor();
+  SyclExecutorType ex = *Global::executorInstancePtr;
 
   // Create data
   std::vector<scalar_t> v1 = benchmark::utils::random_data<scalar_t>(size);

--- a/gbench/syclblas/blas1/iamax.cpp
+++ b/gbench/syclblas/blas1/iamax.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+/**************************************************************************
  *
  *  @license
  *  Copyright (C) 2016 Codeplay Software Limited
@@ -31,7 +31,7 @@ void BM_Iamax(benchmark::State& state) {
   const index_t size = static_cast<index_t>(state.range(0));
   state.counters["size"] = size;
 
-  SyclExecutorType ex = *getExecutor();
+  SyclExecutorType ex = *Global::executorInstancePtr;
 
   // Create data
   std::vector<scalar_t> v1 = benchmark::utils::random_data<scalar_t>(size);

--- a/gbench/syclblas/blas1/iamin.cpp
+++ b/gbench/syclblas/blas1/iamin.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+/**************************************************************************
  *
  *  @license
  *  Copyright (C) 2016 Codeplay Software Limited
@@ -31,7 +31,7 @@ void BM_Iamin(benchmark::State& state) {
   const index_t size = static_cast<index_t>(state.range(0));
   state.counters["size"] = size;
 
-  SyclExecutorType ex = *getExecutor();
+  SyclExecutorType ex = *Global::executorInstancePtr;
 
   // Create data
   std::vector<scalar_t> v1 = benchmark::utils::random_data<scalar_t>(size);

--- a/gbench/syclblas/blas1/nrm2.cpp
+++ b/gbench/syclblas/blas1/nrm2.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+/**************************************************************************
  *
  *  @license
  *  Copyright (C) 2016 Codeplay Software Limited
@@ -31,7 +31,7 @@ void BM_Nrm2(benchmark::State& state) {
   const index_t size = static_cast<index_t>(state.range(0));
   state.counters["size"] = size;
 
-  SyclExecutorType ex = *getExecutor();
+  SyclExecutorType ex = *Global::executorInstancePtr;
 
   // Create data
   std::vector<scalar_t> v1 = benchmark::utils::random_data<scalar_t>(size);

--- a/gbench/syclblas/blas1/scal.cpp
+++ b/gbench/syclblas/blas1/scal.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+/**************************************************************************
  *
  *  @license
  *  Copyright (C) 2016 Codeplay Software Limited
@@ -31,7 +31,7 @@ void BM_Scal(benchmark::State& state) {
   const index_t size = static_cast<index_t>(state.range(0));
   state.counters["size"] = size;
 
-  SyclExecutorType ex = *getExecutor();
+  SyclExecutorType ex = *Global::executorInstancePtr;
 
   // Create data
   std::vector<scalar_t> v1 = benchmark::utils::random_data<scalar_t>(size);

--- a/gbench/syclblas/blas1/scal2op.cpp
+++ b/gbench/syclblas/blas1/scal2op.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+/**************************************************************************
  *
  *  @license
  *  Copyright (C) 2016 Codeplay Software Limited
@@ -31,7 +31,7 @@ void BM_Scal2op(benchmark::State& state) {
   const index_t size = static_cast<index_t>(state.range(0));
   state.counters["size"] = size;
 
-  SyclExecutorType ex = *getExecutor();
+  SyclExecutorType ex = *Global::executorInstancePtr;
 
   // Create data
   std::vector<scalar_t> v1 = benchmark::utils::random_data<scalar_t>(size);

--- a/gbench/syclblas/blas1/scal3op.cpp
+++ b/gbench/syclblas/blas1/scal3op.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+/**************************************************************************
  *
  *  @license
  *  Copyright (C) 2016 Codeplay Software Limited
@@ -31,7 +31,7 @@ void BM_Scal3op(benchmark::State& state) {
   const index_t size = static_cast<index_t>(state.range(0));
   state.counters["size"] = size;
 
-  SyclExecutorType ex = *getExecutor();
+  SyclExecutorType ex = *Global::executorInstancePtr;
 
   // Create data
   std::vector<scalar_t> v1 = benchmark::utils::random_data<scalar_t>(size);

--- a/gbench/syclblas/blas2/gemv.cpp
+++ b/gbench/syclblas/blas2/gemv.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+/**************************************************************************
  *
  *  @license
  *  Copyright (C) 2016 Codeplay Software Limited
@@ -43,7 +43,7 @@ void BM_Gemv(benchmark::State& state) {
   state.counters["m"] = m;
   state.counters["n"] = n;
 
-  SyclExecutorType ex = *getExecutor();
+  SyclExecutorType ex = *Global::executorInstancePtr;
 
   // Create data
   // Scalars
@@ -58,7 +58,8 @@ void BM_Gemv(benchmark::State& state) {
 
   auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(a_m, m * n);
   auto v_b_gpu = blas::make_sycl_iterator_buffer<scalar_t>(b_v, vlen);
-  auto v_c_gpu = blas::make_sycl_iterator_buffer<scalar_t>(c_v_gpu_result, rlen);
+  auto v_c_gpu =
+      blas::make_sycl_iterator_buffer<scalar_t>(c_v_gpu_result, rlen);
 
   // Warmup
   for (int i = 0; i < 10; i++) {

--- a/gbench/syclblas/main.cpp
+++ b/gbench/syclblas/main.cpp
@@ -1,17 +1,16 @@
 #include "cli_device_selector.hpp"
 #include "utils.hpp"
 
-namespace Private {
 // Create a shared pointer to a sycl blas executor, so that we don't keep
 // reconstructing it each time (which is slow). Although this won't be
 // cleaned up if RunSpecifiedBenchmarks exits badly, that's okay, as those
 // are presumably exceptional circumstances.
-ExecutorPtr ex;
 std::unique_ptr<cli_device_selector> cdsp;
 void free_device_selector() { cdsp.reset(); }
-}  // namespace Private
 
-ExecutorPtr getExecutor() { return Private::ex; }
+// Declare the executorInstancePtr (it is already `extern` declared in utils.hpp
+// but it must be explicitly declared at least once.)
+ExecutorPtr Global::executorInstancePtr;
 
 int main(int argc, char** argv) {
   // Initialise the command line device selector in a unique pointer so that we
@@ -20,60 +19,29 @@ int main(int argc, char** argv) {
   // if the flag `--help` is passed), the cds will not be freed before the sycl
   // runtime tries to exit, leading to an exception, as the cds will still hold
   // some sycl objects.
-  Private::cdsp =
+  cdsp =
       std::unique_ptr<cli_device_selector>(new cli_device_selector(argc, argv));
-  std::atexit(Private::free_device_selector);
+  std::atexit(free_device_selector);
 
   // Initialise googlebench
   benchmark::Initialize(&argc, argv);
 
   // Create a queue from the device selector - do this after initialising
   // googlebench, as otherwise we may not be able to delete the queue before we
-  // exit (if Initialise calls exit(0))
+  // exit (if Initialise calls exit(0)), and dump some information about it
   cl::sycl::queue q = cl::sycl::queue(
-      *Private::cdsp.get(), {cl::sycl::property::queue::enable_profiling()});
-
-  // Print out some information about the device that we're running on.
-  std::cout
-      << "Device vendor: "
-      << q.get_device().template get_info<cl::sycl::info::device::vendor>()
-      << std::endl;
-  std::cout << "Device name: "
-            << q.get_device().template get_info<cl::sycl::info::device::name>()
-            << std::endl;
-  std::cout << "Device type: ";
-  switch (
-      q.get_device().template get_info<cl::sycl::info::device::device_type>()) {
-    case cl::sycl::info::device_type::cpu:
-      std::cout << "cpu";
-      break;
-    case cl::sycl::info::device_type::gpu:
-      std::cout << "gpu";
-      break;
-    case cl::sycl::info::device_type::accelerator:
-      std::cout << "accelerator";
-      break;
-    case cl::sycl::info::device_type::custom:
-      std::cout << "custom";
-      break;
-    case cl::sycl::info::device_type::automatic:
-      std::cout << "automatic";
-      break;
-    case cl::sycl::info::device_type::host:
-      std::cout << "host";
-      break;
-    case cl::sycl::info::device_type::all:
-      std::cout << "all";
-      break;
-    default:
-      std::cout << "unknown";
-      break;
-  };
-  std::cout << std::endl;
+      *cdsp.get(), {cl::sycl::property::queue::enable_profiling()});
+  benchmark::utils::print_queue_information(q);
 
   // Create a sycl blas executor from the queue
-  Private::ex = std::make_shared<SyclExecutorType>(q);
+  Global::executorInstancePtr = std::unique_ptr<SyclExecutorType>(
+      new SyclExecutorType(q));  // std::make_unique<SyclExecutorType>(q);
   benchmark::RunSpecifiedBenchmarks();
-  // Delete the sycl blas executor.
-  Private::ex.reset();
+
+  // We need to explicitly reset/delete the executor instance pointer so that
+  // the executor (and the the queue) is properly deleted before the sycl
+  // runtime shuts down. If we don't, the runtime will complain about objects
+  // not being properly destroyed, and the benchmark will exit without a
+  // successful return code
+  Global::executorInstancePtr.reset();
 }

--- a/gbench/syclblas/utils.hpp
+++ b/gbench/syclblas/utils.hpp
@@ -12,8 +12,12 @@
 // `main.cpp`
 typedef blas::Executor<blas::PolicyHandler<blas::codeplay_policy>>
     SyclExecutorType;
-typedef std::shared_ptr<SyclExecutorType> ExecutorPtr;
-ExecutorPtr getExecutor();
+typedef std::unique_ptr<SyclExecutorType> ExecutorPtr;
+
+// Declare the global executor pointer
+namespace Global {
+extern ExecutorPtr executorInstancePtr;
+}
 
 namespace benchmark {
 namespace utils {
@@ -69,6 +73,45 @@ template <typename EventT, typename... OtherEvents>
 inline cl_ulong time_events(EventT first_event, OtherEvents... next_events) {
   return time_events<EventT>(
       blas::concatenate_vectors(first_event, next_events...));
+}
+
+inline void print_queue_information(cl::sycl::queue q) {
+  std::cerr
+      << "Device vendor: "
+      << q.get_device().template get_info<cl::sycl::info::device::vendor>()
+      << std::endl;
+  std::cerr << "Device name: "
+            << q.get_device().template get_info<cl::sycl::info::device::name>()
+            << std::endl;
+  std::cerr << "Device type: ";
+  switch (
+      q.get_device().template get_info<cl::sycl::info::device::device_type>()) {
+    case cl::sycl::info::device_type::cpu:
+      std::cerr << "cpu";
+      break;
+    case cl::sycl::info::device_type::gpu:
+      std::cerr << "gpu";
+      break;
+    case cl::sycl::info::device_type::accelerator:
+      std::cerr << "accelerator";
+      break;
+    case cl::sycl::info::device_type::custom:
+      std::cerr << "custom";
+      break;
+    case cl::sycl::info::device_type::automatic:
+      std::cerr << "automatic";
+      break;
+    case cl::sycl::info::device_type::host:
+      std::cerr << "host";
+      break;
+    case cl::sycl::info::device_type::all:
+      std::cerr << "all";
+      break;
+    default:
+      std::cerr << "unknown";
+      break;
+  };
+  std::cerr << std::endl;
 }
 
 }  // namespace utils


### PR DESCRIPTION
Replace shared pointers with unique pointers, and replace global `getter` with a namespace guarded instance (unique) pointer. 

(Note, there are also some clang-format induced changes here.)