### PR TITLE
Added/updated tests for BLAS2 functions

### DIFF
--- a/external/cblas/cblas.h
+++ b/external/cblas/cblas.h
@@ -1,0 +1,577 @@
+/* CBlas header, downloaded from http://www.netlib.org/blas/#_cblas */
+
+#ifndef CBLAS_H
+#define CBLAS_H
+#include <stddef.h>
+
+/*
+ * Enumerated and derived types
+ */
+#define CBLAS_INDEX size_t  /* this may vary between platforms */
+
+enum CBLAS_ORDER {CblasRowMajor=101, CblasColMajor=102};
+enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113};
+enum CBLAS_UPLO {CblasUpper=121, CblasLower=122};
+enum CBLAS_DIAG {CblasNonUnit=131, CblasUnit=132};
+enum CBLAS_SIDE {CblasLeft=141, CblasRight=142};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * ===========================================================================
+ * Prototypes for level 1 BLAS functions (complex are recast as routines)
+ * ===========================================================================
+ */
+float  cblas_sdsdot(const int N, const float alpha, const float *X,
+                    const int incX, const float *Y, const int incY);
+double cblas_dsdot(const int N, const float *X, const int incX, const float *Y,
+                   const int incY);
+float  cblas_sdot(const int N, const float  *X, const int incX,
+                  const float  *Y, const int incY);
+double cblas_ddot(const int N, const double *X, const int incX,
+                  const double *Y, const int incY);
+
+/*
+ * Functions having prefixes Z and C only
+ */
+void   cblas_cdotu_sub(const int N, const void *X, const int incX,
+                       const void *Y, const int incY, void *dotu);
+void   cblas_cdotc_sub(const int N, const void *X, const int incX,
+                       const void *Y, const int incY, void *dotc);
+
+void   cblas_zdotu_sub(const int N, const void *X, const int incX,
+                       const void *Y, const int incY, void *dotu);
+void   cblas_zdotc_sub(const int N, const void *X, const int incX,
+                       const void *Y, const int incY, void *dotc);
+
+
+/*
+ * Functions having prefixes S D SC DZ
+ */
+float  cblas_snrm2(const int N, const float *X, const int incX);
+float  cblas_sasum(const int N, const float *X, const int incX);
+
+double cblas_dnrm2(const int N, const double *X, const int incX);
+double cblas_dasum(const int N, const double *X, const int incX);
+
+float  cblas_scnrm2(const int N, const void *X, const int incX);
+float  cblas_scasum(const int N, const void *X, const int incX);
+
+double cblas_dznrm2(const int N, const void *X, const int incX);
+double cblas_dzasum(const int N, const void *X, const int incX);
+
+
+/*
+ * Functions having standard 4 prefixes (S D C Z)
+ */
+CBLAS_INDEX cblas_isamax(const int N, const float  *X, const int incX);
+CBLAS_INDEX cblas_idamax(const int N, const double *X, const int incX);
+CBLAS_INDEX cblas_icamax(const int N, const void   *X, const int incX);
+CBLAS_INDEX cblas_izamax(const int N, const void   *X, const int incX);
+
+/*
+ * ===========================================================================
+ * Prototypes for level 1 BLAS routines
+ * ===========================================================================
+ */
+
+/*
+ * Routines with standard 4 prefixes (s, d, c, z)
+ */
+void cblas_sswap(const int N, float *X, const int incX,
+                 float *Y, const int incY);
+void cblas_scopy(const int N, const float *X, const int incX,
+                 float *Y, const int incY);
+void cblas_saxpy(const int N, const float alpha, const float *X,
+                 const int incX, float *Y, const int incY);
+
+void cblas_dswap(const int N, double *X, const int incX,
+                 double *Y, const int incY);
+void cblas_dcopy(const int N, const double *X, const int incX,
+                 double *Y, const int incY);
+void cblas_daxpy(const int N, const double alpha, const double *X,
+                 const int incX, double *Y, const int incY);
+
+void cblas_cswap(const int N, void *X, const int incX,
+                 void *Y, const int incY);
+void cblas_ccopy(const int N, const void *X, const int incX,
+                 void *Y, const int incY);
+void cblas_caxpy(const int N, const void *alpha, const void *X,
+                 const int incX, void *Y, const int incY);
+
+void cblas_zswap(const int N, void *X, const int incX,
+                 void *Y, const int incY);
+void cblas_zcopy(const int N, const void *X, const int incX,
+                 void *Y, const int incY);
+void cblas_zaxpy(const int N, const void *alpha, const void *X,
+                 const int incX, void *Y, const int incY);
+
+
+/*
+ * Routines with S and D prefix only
+ */
+void cblas_srotg(float *a, float *b, float *c, float *s);
+void cblas_srotmg(float *d1, float *d2, float *b1, const float b2, float *P);
+void cblas_srot(const int N, float *X, const int incX,
+                float *Y, const int incY, const float c, const float s);
+void cblas_srotm(const int N, float *X, const int incX,
+                float *Y, const int incY, const float *P);
+
+void cblas_drotg(double *a, double *b, double *c, double *s);
+void cblas_drotmg(double *d1, double *d2, double *b1, const double b2, double *P);
+void cblas_drot(const int N, double *X, const int incX,
+                double *Y, const int incY, const double c, const double  s);
+void cblas_drotm(const int N, double *X, const int incX,
+                double *Y, const int incY, const double *P);
+
+
+/*
+ * Routines with S D C Z CS and ZD prefixes
+ */
+void cblas_sscal(const int N, const float alpha, float *X, const int incX);
+void cblas_dscal(const int N, const double alpha, double *X, const int incX);
+void cblas_cscal(const int N, const void *alpha, void *X, const int incX);
+void cblas_zscal(const int N, const void *alpha, void *X, const int incX);
+void cblas_csscal(const int N, const float alpha, void *X, const int incX);
+void cblas_zdscal(const int N, const double alpha, void *X, const int incX);
+
+/*
+ * ===========================================================================
+ * Prototypes for level 2 BLAS
+ * ===========================================================================
+ */
+
+/*
+ * Routines with standard 4 prefixes (S, D, C, Z)
+ */
+void cblas_sgemv(const enum CBLAS_ORDER order,
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const float alpha, const float *A, const int lda,
+                 const float *X, const int incX, const float beta,
+                 float *Y, const int incY);
+void cblas_sgbmv(const enum CBLAS_ORDER order,
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const int KL, const int KU, const float alpha,
+                 const float *A, const int lda, const float *X,
+                 const int incX, const float beta, float *Y, const int incY);
+void cblas_strmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const float *A, const int lda,
+                 float *X, const int incX);
+void cblas_stbmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const int K, const float *A, const int lda,
+                 float *X, const int incX);
+void cblas_stpmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const float *Ap, float *X, const int incX);
+void cblas_strsv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const float *A, const int lda, float *X,
+                 const int incX);
+void cblas_stbsv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const int K, const float *A, const int lda,
+                 float *X, const int incX);
+void cblas_stpsv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const float *Ap, float *X, const int incX);
+
+void cblas_dgemv(const enum CBLAS_ORDER order,
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const double alpha, const double *A, const int lda,
+                 const double *X, const int incX, const double beta,
+                 double *Y, const int incY);
+void cblas_dgbmv(const enum CBLAS_ORDER order,
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const int KL, const int KU, const double alpha,
+                 const double *A, const int lda, const double *X,
+                 const int incX, const double beta, double *Y, const int incY);
+void cblas_dtrmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const double *A, const int lda,
+                 double *X, const int incX);
+void cblas_dtbmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const int K, const double *A, const int lda,
+                 double *X, const int incX);
+void cblas_dtpmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const double *Ap, double *X, const int incX);
+void cblas_dtrsv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const double *A, const int lda, double *X,
+                 const int incX);
+void cblas_dtbsv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const int K, const double *A, const int lda,
+                 double *X, const int incX);
+void cblas_dtpsv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const double *Ap, double *X, const int incX);
+
+void cblas_cgemv(const enum CBLAS_ORDER order,
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const void *alpha, const void *A, const int lda,
+                 const void *X, const int incX, const void *beta,
+                 void *Y, const int incY);
+void cblas_cgbmv(const enum CBLAS_ORDER order,
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const int KL, const int KU, const void *alpha,
+                 const void *A, const int lda, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
+void cblas_ctrmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const void *A, const int lda,
+                 void *X, const int incX);
+void cblas_ctbmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const int K, const void *A, const int lda,
+                 void *X, const int incX);
+void cblas_ctpmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const void *Ap, void *X, const int incX);
+void cblas_ctrsv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const void *A, const int lda, void *X,
+                 const int incX);
+void cblas_ctbsv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const int K, const void *A, const int lda,
+                 void *X, const int incX);
+void cblas_ctpsv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const void *Ap, void *X, const int incX);
+
+void cblas_zgemv(const enum CBLAS_ORDER order,
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const void *alpha, const void *A, const int lda,
+                 const void *X, const int incX, const void *beta,
+                 void *Y, const int incY);
+void cblas_zgbmv(const enum CBLAS_ORDER order,
+                 const enum CBLAS_TRANSPOSE TransA, const int M, const int N,
+                 const int KL, const int KU, const void *alpha,
+                 const void *A, const int lda, const void *X,
+                 const int incX, const void *beta, void *Y, const int incY);
+void cblas_ztrmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const void *A, const int lda,
+                 void *X, const int incX);
+void cblas_ztbmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const int K, const void *A, const int lda,
+                 void *X, const int incX);
+void cblas_ztpmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const void *Ap, void *X, const int incX);
+void cblas_ztrsv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const void *A, const int lda, void *X,
+                 const int incX);
+void cblas_ztbsv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const int K, const void *A, const int lda,
+                 void *X, const int incX);
+void cblas_ztpsv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_DIAG Diag,
+                 const int N, const void *Ap, void *X, const int incX);
+
+
+/*
+ * Routines with S and D prefixes only
+ */
+void cblas_ssymv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const int N, const float alpha, const float *A,
+                 const int lda, const float *X, const int incX,
+                 const float beta, float *Y, const int incY);
+void cblas_ssbmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const int N, const int K, const float alpha, const float *A,
+                 const int lda, const float *X, const int incX,
+                 const float beta, float *Y, const int incY);
+void cblas_sspmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const int N, const float alpha, const float *Ap,
+                 const float *X, const int incX,
+                 const float beta, float *Y, const int incY);
+void cblas_sger(const enum CBLAS_ORDER order, const int M, const int N,
+                const float alpha, const float *X, const int incX,
+                const float *Y, const int incY, float *A, const int lda);
+void cblas_ssyr(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                const int N, const float alpha, const float *X,
+                const int incX, float *A, const int lda);
+void cblas_sspr(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                const int N, const float alpha, const float *X,
+                const int incX, float *Ap);
+void cblas_ssyr2(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                const int N, const float alpha, const float *X,
+                const int incX, const float *Y, const int incY, float *A,
+                const int lda);
+void cblas_sspr2(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                const int N, const float alpha, const float *X,
+                const int incX, const float *Y, const int incY, float *A);
+
+void cblas_dsymv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const int N, const double alpha, const double *A,
+                 const int lda, const double *X, const int incX,
+                 const double beta, double *Y, const int incY);
+void cblas_dsbmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const int N, const int K, const double alpha, const double *A,
+                 const int lda, const double *X, const int incX,
+                 const double beta, double *Y, const int incY);
+void cblas_dspmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const int N, const double alpha, const double *Ap,
+                 const double *X, const int incX,
+                 const double beta, double *Y, const int incY);
+void cblas_dger(const enum CBLAS_ORDER order, const int M, const int N,
+                const double alpha, const double *X, const int incX,
+                const double *Y, const int incY, double *A, const int lda);
+void cblas_dsyr(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                const int N, const double alpha, const double *X,
+                const int incX, double *A, const int lda);
+void cblas_dspr(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                const int N, const double alpha, const double *X,
+                const int incX, double *Ap);
+void cblas_dsyr2(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                const int N, const double alpha, const double *X,
+                const int incX, const double *Y, const int incY, double *A,
+                const int lda);
+void cblas_dspr2(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                const int N, const double alpha, const double *X,
+                const int incX, const double *Y, const int incY, double *A);
+
+
+/*
+ * Routines with C and Z prefixes only
+ */
+void cblas_chemv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const int N, const void *alpha, const void *A,
+                 const int lda, const void *X, const int incX,
+                 const void *beta, void *Y, const int incY);
+void cblas_chbmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const int N, const int K, const void *alpha, const void *A,
+                 const int lda, const void *X, const int incX,
+                 const void *beta, void *Y, const int incY);
+void cblas_chpmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const int N, const void *alpha, const void *Ap,
+                 const void *X, const int incX,
+                 const void *beta, void *Y, const int incY);
+void cblas_cgeru(const enum CBLAS_ORDER order, const int M, const int N,
+                 const void *alpha, const void *X, const int incX,
+                 const void *Y, const int incY, void *A, const int lda);
+void cblas_cgerc(const enum CBLAS_ORDER order, const int M, const int N,
+                 const void *alpha, const void *X, const int incX,
+                 const void *Y, const int incY, void *A, const int lda);
+void cblas_cher(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                const int N, const float alpha, const void *X, const int incX,
+                void *A, const int lda);
+void cblas_chpr(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                const int N, const float alpha, const void *X,
+                const int incX, void *A);
+void cblas_cher2(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo, const int N,
+                const void *alpha, const void *X, const int incX,
+                const void *Y, const int incY, void *A, const int lda);
+void cblas_chpr2(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo, const int N,
+                const void *alpha, const void *X, const int incX,
+                const void *Y, const int incY, void *Ap);
+
+void cblas_zhemv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const int N, const void *alpha, const void *A,
+                 const int lda, const void *X, const int incX,
+                 const void *beta, void *Y, const int incY);
+void cblas_zhbmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const int N, const int K, const void *alpha, const void *A,
+                 const int lda, const void *X, const int incX,
+                 const void *beta, void *Y, const int incY);
+void cblas_zhpmv(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                 const int N, const void *alpha, const void *Ap,
+                 const void *X, const int incX,
+                 const void *beta, void *Y, const int incY);
+void cblas_zgeru(const enum CBLAS_ORDER order, const int M, const int N,
+                 const void *alpha, const void *X, const int incX,
+                 const void *Y, const int incY, void *A, const int lda);
+void cblas_zgerc(const enum CBLAS_ORDER order, const int M, const int N,
+                 const void *alpha, const void *X, const int incX,
+                 const void *Y, const int incY, void *A, const int lda);
+void cblas_zher(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                const int N, const double alpha, const void *X, const int incX,
+                void *A, const int lda);
+void cblas_zhpr(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo,
+                const int N, const double alpha, const void *X,
+                const int incX, void *A);
+void cblas_zher2(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo, const int N,
+                const void *alpha, const void *X, const int incX,
+                const void *Y, const int incY, void *A, const int lda);
+void cblas_zhpr2(const enum CBLAS_ORDER order, const enum CBLAS_UPLO Uplo, const int N,
+                const void *alpha, const void *X, const int incX,
+                const void *Y, const int incY, void *Ap);
+
+/*
+ * ===========================================================================
+ * Prototypes for level 3 BLAS
+ * ===========================================================================
+ */
+
+/*
+ * Routines with standard 4 prefixes (S, D, C, Z)
+ */
+void cblas_sgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
+                 const int K, const float alpha, const float *A,
+                 const int lda, const float *B, const int ldb,
+                 const float beta, float *C, const int ldc);
+void cblas_ssymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const int M, const int N,
+                 const float alpha, const float *A, const int lda,
+                 const float *B, const int ldb, const float beta,
+                 float *C, const int ldc);
+void cblas_ssyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const float alpha, const float *A, const int lda,
+                 const float beta, float *C, const int ldc);
+void cblas_ssyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const float alpha, const float *A, const int lda,
+                  const float *B, const int ldb, const float beta,
+                  float *C, const int ldc);
+void cblas_strmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N,
+                 const float alpha, const float *A, const int lda,
+                 float *B, const int ldb);
+void cblas_strsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N,
+                 const float alpha, const float *A, const int lda,
+                 float *B, const int ldb);
+
+void cblas_dgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
+                 const int K, const double alpha, const double *A,
+                 const int lda, const double *B, const int ldb,
+                 const double beta, double *C, const int ldc);
+void cblas_dsymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const int M, const int N,
+                 const double alpha, const double *A, const int lda,
+                 const double *B, const int ldb, const double beta,
+                 double *C, const int ldc);
+void cblas_dsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const double alpha, const double *A, const int lda,
+                 const double beta, double *C, const int ldc);
+void cblas_dsyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const double alpha, const double *A, const int lda,
+                  const double *B, const int ldb, const double beta,
+                  double *C, const int ldc);
+void cblas_dtrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N,
+                 const double alpha, const double *A, const int lda,
+                 double *B, const int ldb);
+void cblas_dtrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N,
+                 const double alpha, const double *A, const int lda,
+                 double *B, const int ldb);
+
+void cblas_cgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
+                 const int K, const void *alpha, const void *A,
+                 const int lda, const void *B, const int ldb,
+                 const void *beta, void *C, const int ldc);
+void cblas_csymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const int M, const int N,
+                 const void *alpha, const void *A, const int lda,
+                 const void *B, const int ldb, const void *beta,
+                 void *C, const int ldc);
+void cblas_csyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const void *alpha, const void *A, const int lda,
+                 const void *beta, void *C, const int ldc);
+void cblas_csyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const void *alpha, const void *A, const int lda,
+                  const void *B, const int ldb, const void *beta,
+                  void *C, const int ldc);
+void cblas_ctrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N,
+                 const void *alpha, const void *A, const int lda,
+                 void *B, const int ldb);
+void cblas_ctrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N,
+                 const void *alpha, const void *A, const int lda,
+                 void *B, const int ldb);
+
+void cblas_zgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
+                 const int K, const void *alpha, const void *A,
+                 const int lda, const void *B, const int ldb,
+                 const void *beta, void *C, const int ldc);
+void cblas_zsymm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const int M, const int N,
+                 const void *alpha, const void *A, const int lda,
+                 const void *B, const int ldb, const void *beta,
+                 void *C, const int ldc);
+void cblas_zsyrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const void *alpha, const void *A, const int lda,
+                 const void *beta, void *C, const int ldc);
+void cblas_zsyr2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const void *alpha, const void *A, const int lda,
+                  const void *B, const int ldb, const void *beta,
+                  void *C, const int ldc);
+void cblas_ztrmm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N,
+                 const void *alpha, const void *A, const int lda,
+                 void *B, const int ldb);
+void cblas_ztrsm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_DIAG Diag, const int M, const int N,
+                 const void *alpha, const void *A, const int lda,
+                 void *B, const int ldb);
+
+
+/*
+ * Routines with prefixes C and Z only
+ */
+void cblas_chemm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const int M, const int N,
+                 const void *alpha, const void *A, const int lda,
+                 const void *B, const int ldb, const void *beta,
+                 void *C, const int ldc);
+void cblas_cherk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const float alpha, const void *A, const int lda,
+                 const float beta, void *C, const int ldc);
+void cblas_cher2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const void *alpha, const void *A, const int lda,
+                  const void *B, const int ldb, const float beta,
+                  void *C, const int ldc);
+
+void cblas_zhemm(const enum CBLAS_ORDER Order, const enum CBLAS_SIDE Side,
+                 const enum CBLAS_UPLO Uplo, const int M, const int N,
+                 const void *alpha, const void *A, const int lda,
+                 const void *B, const int ldb, const void *beta,
+                 void *C, const int ldc);
+void cblas_zherk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                 const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                 const double alpha, const void *A, const int lda,
+                 const double beta, void *C, const int ldc);
+void cblas_zher2k(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo,
+                  const enum CBLAS_TRANSPOSE Trans, const int N, const int K,
+                  const void *alpha, const void *A, const int lda,
+                  const void *B, const int ldb, const double beta,
+                  void *C, const int ldc);
+
+void cblas_xerbla(int p, const char *rout, const char *form, ...);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/test/system_reference_blas.hpp
+++ b/test/system_reference_blas.hpp
@@ -26,56 +26,143 @@
 #ifndef SYSTEM_REFERENCE_BLAS_HPP
 #define SYSTEM_REFERENCE_BLAS_HPP
 
-#define ENABLE_SYSTEM_GEMV(_type, _system_name)                              \
-  namespace reference_blas {                                                 \
-  extern "C" void _system_name(const char *, const int *, const int *,       \
-                               const _type *, const _type *, const int *,    \
-                               const _type *, const int *, const _type *,    \
-                               _type *, const int *);                        \
-  void gemv(const char *trans, int m, int n, _type alpha, const _type a[],   \
-            int lda, const _type b[], int incX, _type beta, _type c[],       \
-            int incY) {                                                      \
-    _system_name(trans, &m, &n, &alpha, a, &lda, b, &incX, &beta, c, &incY); \
-  }                                                                          \
-  }  // namespace reference_blas
+#include "cblas.h"
+#include <iostream>
 
-ENABLE_SYSTEM_GEMV(float, sgemv_)
-ENABLE_SYSTEM_GEMV(double, dgemv_)
+namespace {
+CBLAS_TRANSPOSE c_trans(char x) {
+  switch (x) {
+    case 't':
+    case 'T':
+      return CblasTrans;
+    case 'n':
+    case 'N':
+      return CblasNoTrans;
+    case 'c':
+    case 'C':
+      return CblasConjTrans;
+    default:
+      std::cerr << "Transpose value " << x << " is invalid.\n";
+      abort();
+  }
+}
 
-#undef ENABLE_SYSTEM_GEMV
+CBLAS_UPLO c_uplo(char x) {
+  switch (x) {
+    case 'u':
+    case 'U':
+      return CblasUpper;
+    case 'l':
+    case 'L':
+      return CblasLower;
+    default:
+      std::cerr << "Uplo value " << x << " is invalid.\n";
+      abort();
+  }
+}
 
-#define ENABLE_SYSTEM_GER(_type, _system_name)                            \
-  namespace reference_blas {                                              \
-  extern "C" void _system_name(const int *, const int *, const _type *,   \
-                               const _type *, const int *, const _type *, \
-                               const int *, _type *, const int *);        \
-  void ger(int m, int n, _type alpha, const _type a[], int incX,          \
-           const _type b[], int incY, _type c[], int lda) {               \
-    _system_name(&m, &n, &alpha, a, &incX, b, &incY, c, &lda);            \
-  }                                                                       \
-  }  // namespace reference_blas
+CBLAS_DIAG c_diag(char x) {
+  switch (x) {
+    case 'u':
+    case 'U':
+      return CblasUnit;
+    case 'n':
+    case 'N':
+      return CblasNonUnit;
+  }
+}
+}  // namespace
 
-ENABLE_SYSTEM_GER(float, sger_)
-ENABLE_SYSTEM_GER(double, dger_)
+namespace reference_blas {
 
-#undef ENABLE_SYSTEM_GER
-#define ENABLE_SYSTEM_GEMM(_type, _system_name)                               \
-  namespace reference_blas {                                                  \
-  extern "C" void _system_name(const char *, const char *, const int *,       \
-                               const int *, const int *, const _type *,       \
-                               const _type *, const int *, const _type *,     \
-                               const int *, const _type *, _type *,           \
-                               const int *);                                  \
-  void gemm(const char *transA, const char *transB, int m, int n, int k,      \
-            _type alpha, const _type a[], int lda, const _type b[], int ldb,  \
-            _type beta, _type c[], int ldc) {                                 \
-    _system_name(transA, transB, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, \
-                 c, &ldc);                                                    \
-  }                                                                           \
-  }  // namespace reference_blas
+template <typename selector_t>
+struct TypeDispatcher;
 
-ENABLE_SYSTEM_GEMM(float, sgemm_)
-ENABLE_SYSTEM_GEMM(double, dgemm_)
+template <>
+struct TypeDispatcher<float> {
+  template <typename ret_t = void, typename floatfn_t, typename doublefn_t,
+            typename... Args>
+  static ret_t call(floatfn_t ffn, doublefn_t dfn, Args... args) {
+    return ffn(args...);
+  }
+};
 
-#undef ENABLE_SYSTEM_GEMM
+#if DOUBLE_SUPPORT
+template <>
+struct TypeDispatcher<double> {
+  template <typename ret_t = void, typename floatfn_t, typename doublefn_t,
+            typename... Args>
+  static ret_t call(floatfn_t ffn, doublefn_t dfn, Args... args) {
+    return dfn(args...);
+  }
+};
+#endif
+
+// =======
+// Level 2
+// =======
+template <typename scalar_t>
+void gemv(const char *trans, int m, int n, scalar_t alpha, const scalar_t a[],
+          int lda, const scalar_t b[], int incX, scalar_t beta, scalar_t c[],
+          int incY) {
+  TypeDispatcher<scalar_t>::call(&cblas_sgemv, &cblas_dgemv, CblasColMajor,
+                                 c_trans(*trans), m, n, alpha, a, lda, b, incX,
+                                 beta, c, incY);
+}
+
+template <typename scalar_t>
+void ger(int m, int n, scalar_t alpha, const scalar_t a[], int incX,
+         const scalar_t b[], int incY, scalar_t c[], int lda) {
+  TypeDispatcher<scalar_t>::call(&cblas_sger, &cblas_dger, CblasColMajor, m, n,
+                                 alpha, a, incX, b, incY, c, lda);
+}
+
+template <typename scalar_t>
+void trmv(const char *uplo, const char *trans, const char *diag, const int n,
+          const scalar_t *a, const int lda, scalar_t *x, const int incX) {
+  TypeDispatcher<scalar_t>::call(&cblas_strmv, &cblas_dtrmv, CblasColMajor,
+                                 c_uplo(*uplo), c_trans(*trans), c_diag(*diag),
+                                 n, a, lda, x, incX);
+}
+
+template <typename scalar_t>
+void syr(const char *uplo, const int n, const scalar_t alpha, const scalar_t *x,
+         const int incX, scalar_t *a, const int lda) {
+  TypeDispatcher<scalar_t>::call(&cblas_ssyr, &cblas_dsyr, CblasColMajor,
+                                 c_uplo(*uplo), n, alpha, x, incX, a, lda);
+}
+
+template <typename scalar_t>
+void syr2(const char *uplo, const int n, const scalar_t alpha,
+          const scalar_t *x, const int incX, const scalar_t *y, const int incY,
+          scalar_t *a, const int lda) {
+  TypeDispatcher<scalar_t>::call(&cblas_ssyr2, &cblas_dsyr2, CblasColMajor,
+                                 c_uplo(*uplo), n, alpha, x, incX, y, incY, a,
+                                 lda);
+}
+
+template <typename scalar_t>
+void symv(const char *uplo, const int n, const scalar_t alpha,
+          const scalar_t *a, const int lda, const scalar_t *x, const int incX,
+          const scalar_t beta, scalar_t *y, const int incY) {
+  TypeDispatcher<scalar_t>::call(&cblas_ssymv, &cblas_dsymv, CblasColMajor,
+                                 c_uplo(*uplo), n, alpha, a, lda, x, incX, beta,
+                                 y, incY);
+}
+
+// =======
+// Level 3
+// =======
+template <typename scalar_t>
+void gemm(const char *transA, const char *transB, int m, int n, int k,
+          scalar_t alpha, const scalar_t a[], int lda, const scalar_t b[],
+          int ldb, scalar_t beta, scalar_t c[], int ldc) {
+  TypeDispatcher<scalar_t>::call(&cblas_sgemm, &cblas_dgemm, CblasColMajor,
+                                 c_trans(*transA), c_trans(*transB), m, n, k,
+                                 alpha, a, lda, b, ldb, beta, c, ldc);
+}
+
+#undef COROUTINE_SELECT
+}  // namespace reference_blas
+
 #endif /* end of include guard: SYSTEM_REFERENCE_BLAS_HPP */

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -27,7 +27,7 @@ cmake_minimum_required(VERSION 3.2.2)
 project(syclblas_unittest)
 
 set(SYCLBLAS_UNITTEST ${CMAKE_CURRENT_SOURCE_DIR})
-set(SYCLBLAS_TEST_INCLUDE "${SYCLBLAS_TEST}/include")
+set(SYCLBLAS_TEST_INCLUDE "${SYCLBLAS_TEST}/include" "${SYCLBLAS_TEST}../external/cblas")
 
 include_directories(${SYCLBLAS_TEST} ${BLAS_INCLUDE_DIRS})
 
@@ -45,8 +45,12 @@ set(SYCL_UNITTEST_SRCS
   ${SYCLBLAS_UNITTEST}/blas1/blas1_iamax_test.cpp
   ${SYCLBLAS_UNITTEST}/blas1/blas1_iamin_test.cpp
   # Blas 2 tests
- ${SYCLBLAS_UNITTEST}/blas2/blas2_gemv_test.cpp
- ${SYCLBLAS_UNITTEST}/blas2/blas2_ger_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas2/blas2_gemv_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas2/blas2_ger_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas2/blas2_trmv_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas2/blas2_syr_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas2/blas2_syr2_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas2/blas2_symv_test.cpp
   # Blas 3 tests
   ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_test.cpp
   ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_batched_test.cpp
@@ -60,6 +64,9 @@ foreach(blas_test ${SYCL_UNITTEST_SRCS})
   add_executable(${test_exec} main.cpp ${blas_test})
   set_property(TARGET ${test_exec} PROPERTY CXX_STANDARD 11)
   add_dependencies(${test_exec} gtest_main sycl_blas)
+  if (STRESS_TESTING)
+  target_compile_definitions(${test_exec} PRIVATE STRESS_TESTING)
+  endif()
   target_link_libraries(${test_exec} PUBLIC gtest_main ${BLAS_LIBRARIES} sycl_blas ComputeCpp::ComputeCpp)
   add_test(NAME ${test_exec} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${test_exec})
   message("-- Created google test ${test_exec}")

--- a/test/unittest/blas2/blas2_ger_test.cpp
+++ b/test/unittest/blas2/blas2_ger_test.cpp
@@ -25,62 +25,85 @@
 
 #include "blas_test.hpp"
 
-typedef ::testing::Types<blas_test_float<>, blas_test_double<> > BlasTypes;
+template <typename scalar_t>
+using combination_t = std::tuple<int, int, scalar_t, int, int, int>;
 
-TYPED_TEST_CASE(BLAS_Test, BlasTypes);
+template <typename scalar_t>
+void run_test(const combination_t<scalar_t> combi) {
+  using type_t = blas_test_args<scalar_t, void>;
+  using blas_test_t = BLAS_Test<type_t>;
+  using executor_t = typename type_t::executor_t;
 
-REGISTER_PREC(float, 1e-4, ger_test)
-REGISTER_PREC(double, 1e-8, ger_test)
-
-TYPED_TEST(BLAS_Test, ger_test) {
-  using scalar_t = typename TypeParam::scalar_t;
-  using ExecutorType = typename TypeParam::executor_t;
-  using TestClass = BLAS_Test<TypeParam>;
-  using test = class ger_test;
-
-  int m = 125;
-  int n = 127;
-  int lda = m;
-  int incX = 1;
-  int incY = 1;
-  scalar_t prec = TestClass::template test_prec<test>();
-  scalar_t alpha = scalar_t(3);
+  int m;
+  int n;
+  int lda_mul;
+  int incX;
+  int incY;
+  scalar_t alpha;
+  std::tie(m, n, alpha, incX, incY, lda_mul) = combi;
+  int lda = m * lda_mul;
 
   // Input matrix
-  std::vector<scalar_t> a_v(m);
+  std::vector<scalar_t> a_v(m * incX);
   // Input Vector
-  std::vector<scalar_t> b_v(n);
+  std::vector<scalar_t> b_v(n * incY);
   // output Vector
-  std::vector<scalar_t> c_m_gpu_result(m * n, scalar_t(0));
+  std::vector<scalar_t> c_m_gpu_result(lda * n, scalar_t(10));
   // output system vector
-  std::vector<scalar_t> c_m_cpu(m * n, scalar_t(0));
-  TestClass::set_rand(a_v, m);
-  TestClass::set_rand(b_v, n);
+  std::vector<scalar_t> c_m_cpu(lda * n, scalar_t(10));
+  blas_test_t::set_rand(a_v, m * incX);
+  blas_test_t::set_rand(b_v, n * incY);
 
-  // SYSTEM GEMMV
+  // SYSTEM GER
   reference_blas::ger(m, n, alpha, a_v.data(), incX, b_v.data(), incY,
-                      c_m_cpu.data(), m);
+                      c_m_cpu.data(), lda);
 
   SYCL_DEVICE_SELECTOR d;
-  auto q = TestClass::make_queue(d);
-  Executor<ExecutorType> ex(q);
-  auto v_a_gpu = ex.get_policy_handler().template allocate<scalar_t>(m);
-  auto v_b_gpu = ex.get_policy_handler().template allocate<scalar_t>(n);
-  auto m_c_gpu = ex.get_policy_handler().template allocate<scalar_t>(m * n);
-  ex.get_policy_handler().copy_to_device(a_v.data(), v_a_gpu, m);
-  ex.get_policy_handler().copy_to_device(b_v.data(), v_b_gpu, n);
-  ex.get_policy_handler().copy_to_device(c_m_gpu_result.data(), m_c_gpu, m * n);
+  auto q = blas_test_t::make_queue(d);
+  Executor<executor_t> ex(q);
+  auto v_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(a_v, m * incX);
+  auto v_b_gpu = blas::make_sycl_iterator_buffer<scalar_t>(b_v, n * incY);
+  auto m_c_gpu =
+      blas::make_sycl_iterator_buffer<scalar_t>(c_m_gpu_result, lda * n);
+
   // SYCLger
-  _ger(ex, m, n, alpha, v_a_gpu, incX, v_b_gpu, incY, m_c_gpu, m);
+  _ger(ex, m, n, alpha, v_a_gpu, incX, v_b_gpu, incY, m_c_gpu, lda);
 
   auto event = ex.get_policy_handler().copy_to_host(
-      m_c_gpu, c_m_gpu_result.data(), m * n);
+      m_c_gpu, c_m_gpu_result.data(), lda * n);
   ex.get_policy_handler().wait(event);
 
-  for (int i = 0; i < m * n; ++i) {
-    ASSERT_NEAR(c_m_gpu_result[i], c_m_cpu[i], prec);
+  for (int i = 0; i < lda * n; ++i) {
+    ASSERT_T_EQUAL(scalar_t, c_m_gpu_result[i], c_m_cpu[i]);
   }
-  ex.get_policy_handler().template deallocate<scalar_t>(v_a_gpu);
-  ex.get_policy_handler().template deallocate<scalar_t>(v_b_gpu);
-  ex.get_policy_handler().template deallocate<scalar_t>(m_c_gpu);
 }
+
+#ifdef STRESS_TESTING
+const auto combi =
+    ::testing::Combine(::testing::Values(11, 65, 255, 1023, 1024 * 1024),  // m
+                       ::testing::Values(14, 63, 257, 1010, 1024 * 1024),  // n
+                       ::testing::Values(0.0, 1.0, 1.5),  // alpha
+                       ::testing::Values(1, 2),           // incX
+                       ::testing::Values(1, 3),           // incY
+                       ::testing::Values(1, 2)            // lda_mul
+    );
+#else
+// For the purpose of travis and other slower platforms, we need a faster test
+const auto combi = ::testing::Combine(::testing::Values(11, 1023),  // m
+                                      ::testing::Values(14, 1010),  // n
+                                      ::testing::Values(0.0, 1.5),  // alpha
+                                      ::testing::Values(2),         // incX
+                                      ::testing::Values(3),         // incY
+                                      ::testing::Values(2)          // lda_mul
+);
+#endif
+
+class GerFloat : public ::testing::TestWithParam<combination_t<float>> {};
+TEST_P(GerFloat, test) { run_test<float>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(gemv, GerFloat, combi);
+
+#if DOUBLE_SUPPORT
+class GerDouble : public ::testing::TestWithParam<combination_t<double>> {};
+TEST_P(GerDouble, test) { run_test<double>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(gemv, GerDouble, combi);
+#endif

--- a/test/unittest/blas2/blas2_symv_test.cpp
+++ b/test/unittest/blas2/blas2_symv_test.cpp
@@ -1,0 +1,112 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename blas2_symv_test.cpp
+ *
+ **************************************************************************/
+
+#include "blas_test.hpp"
+
+template <typename scalar_t>
+using combination_t = std::tuple<char, int, scalar_t, int, int, scalar_t, int>;
+
+template <typename scalar_t>
+void run_test(const combination_t<scalar_t> combi) {
+  using type_t = blas_test_args<scalar_t, void>;
+  using blas_test_t = BLAS_Test<type_t>;
+  using executor_t = typename type_t::executor_t;
+
+  int n;
+  int lda_mul;
+  int incX;
+  int incY;
+  char uplo;
+  scalar_t alpha;
+  scalar_t beta;
+  std::tie(uplo, n, alpha, lda_mul, incX, beta, incY) = combi;
+  int lda = n * lda_mul;
+
+  // Input matrix
+  std::vector<scalar_t> a_m(lda * n);
+  blas_test_t::set_rand(a_m, lda * n);
+
+  // Input vector
+  std::vector<scalar_t> x_v(n * incX);
+  blas_test_t::set_rand(x_v, n * incX);
+
+  // Output Vector
+  std::vector<scalar_t> y_v(n * incY, 1.0);
+  std::vector<scalar_t> y_cpu_v(n * incY, 1.0);
+
+  // SYSTEM symv
+  reference_blas::symv(&uplo, n, alpha, a_m.data(), lda, x_v.data(), incX, beta,
+                       y_cpu_v.data(), incY);
+
+  SYCL_DEVICE_SELECTOR d;
+  auto q = blas_test_t::make_queue(d);
+  Executor<executor_t> ex(q);
+  auto a_m_gpu = blas::make_sycl_iterator_buffer<scalar_t>(a_m, lda * n);
+  auto x_v_gpu = blas::make_sycl_iterator_buffer<scalar_t>(x_v, n * incX);
+  auto y_v_gpu = blas::make_sycl_iterator_buffer<scalar_t>(y_v, n * incY);
+
+  // SYCLsymv
+  _symv(ex, uplo, n, alpha, a_m_gpu, lda, x_v_gpu, incX, beta, y_v_gpu, incY);
+
+  auto event =
+      ex.get_policy_handler().copy_to_host(y_v_gpu, y_v.data(), n * incY);
+  ex.get_policy_handler().wait(event);
+
+  for (int i = 0; i < n * incY; ++i) {
+    ASSERT_T_EQUAL(scalar_t, y_v[i], y_cpu_v[i]);
+  }
+}
+
+#ifdef STRESS_TESTING
+const auto combi =
+    ::testing::Combine(::testing::Values('u', 'l'),                 // UPLO
+                       ::testing::Values(14, 63, 257, 1010, 2025),  // n
+                       ::testing::Values(0.0, 1.0, 1.5),            // alpha
+                       ::testing::Values(1, 2),                     // lda_mul
+                       ::testing::Values(1, 2),                     // incX
+                       ::testing::Values(0.0, 1.0, 1.5),            // beta
+                       ::testing::Values(1, 3)                      // incY
+    );
+#else
+// For the purpose of travis and other slower platforms, we need a faster test
+const auto combi = ::testing::Combine(::testing::Values('u', 'l'),  // UPLO
+                                      ::testing::Values(2025),      // n
+                                      ::testing::Values(0.0, 1.5),  // alpha
+                                      ::testing::Values(2),         // lda_mul
+                                      ::testing::Values(2),         // incX
+                                      ::testing::Values(0.0, 1.5),  // beta
+                                      ::testing::Values(3)          // incY
+);
+#endif
+
+class SymvFloat : public ::testing::TestWithParam<combination_t<float>> {};
+TEST_P(SymvFloat, test) { run_test<float>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(symv, SymvFloat, combi);
+
+#if DOUBLE_SUPPORT
+class SymvDouble : public ::testing::TestWithParam<combination_t<double>> {};
+TEST_P(SymvDouble, test) { run_test<double>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(symv, SymvDouble, combi);
+#endif

--- a/test/unittest/blas2/blas2_syr2_test.cpp
+++ b/test/unittest/blas2/blas2_syr2_test.cpp
@@ -1,0 +1,107 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename blas2_syr2_test.cpp
+ *
+ **************************************************************************/
+
+#include "blas_test.hpp"
+
+template <typename scalar_t>
+using combination_t = std::tuple<char, int, scalar_t, int, int, int>;
+
+template <typename scalar_t>
+void run_test(const combination_t<scalar_t> combi) {
+  using type_t = blas_test_args<scalar_t, void>;
+  using blas_test_t = BLAS_Test<type_t>;
+  using executor_t = typename type_t::executor_t;
+
+  int n;
+  int lda_mul;
+  int incX;
+  int incY;
+  char uplo;
+  scalar_t alpha;
+  std::tie(uplo, n, alpha, incX, incY, lda_mul) = combi;
+  int lda = n * lda_mul;
+
+  // Input vector
+  std::vector<scalar_t> x_v(n * incX);
+  std::vector<scalar_t> y_v(n * incY);
+  blas_test_t::set_rand(x_v, n * incX);
+  blas_test_t::set_rand(y_v, n * incY);
+
+  // Output matrix
+  std::vector<scalar_t> a_m(n * lda, 7.0);
+  std::vector<scalar_t> a_cpu_m(n * lda, 7.0);
+
+  // SYSTEM SYR
+  reference_blas::syr2(&uplo, n, alpha, x_v.data(), incX, y_v.data(), incY,
+                       a_cpu_m.data(), lda);
+
+  SYCL_DEVICE_SELECTOR d;
+  auto q = blas_test_t::make_queue(d);
+  Executor<executor_t> ex(q);
+  auto x_v_gpu = blas::make_sycl_iterator_buffer<scalar_t>(x_v, n * incX);
+  auto y_v_gpu = blas::make_sycl_iterator_buffer<scalar_t>(y_v, n * incY);
+  auto a_m_gpu = blas::make_sycl_iterator_buffer<scalar_t>(a_m, lda * n);
+
+  // SYCLsyr2
+  _syr2(ex, uplo, n, alpha, x_v_gpu, incX, y_v_gpu, incY, a_m_gpu, lda);
+
+  auto event =
+      ex.get_policy_handler().copy_to_host(a_m_gpu, a_m.data(), n * lda);
+  ex.get_policy_handler().wait(event);
+
+  for (int i = 0; i < n * lda; ++i) {
+    ASSERT_T_EQUAL(scalar_t, a_m[i], a_cpu_m[i]);
+  }
+}
+
+#ifdef STRESS_TESTING
+const auto combi =
+    ::testing::Combine(::testing::Values('u', 'l'),                 // UPLO
+                       ::testing::Values(14, 63, 257, 1010, 2025),  // n
+                       ::testing::Values(0.0, 1.0, 1.5),            // alpha
+                       ::testing::Values(1, 2),                     // incX
+                       ::testing::Values(1, 2),                     // incY
+                       ::testing::Values(1, 2)                      // lda_mul
+    );
+#else
+// For the purpose of travis and other slower platforms, we need a faster test
+const auto combi = ::testing::Combine(::testing::Values('u', 'l'),  // UPLO
+                                      ::testing::Values(2025),      // n
+                                      ::testing::Values(0.0, 1.5),  // alpha
+                                      ::testing::Values(2),         // incX
+                                      ::testing::Values(2),         // incY
+                                      ::testing::Values(2)          // lda_mul
+);
+#endif
+
+class Syr2Float : public ::testing::TestWithParam<combination_t<float>> {};
+TEST_P(Syr2Float, test) { run_test<float>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(syr2, Syr2Float, combi);
+
+#if DOUBLE_SUPPORT
+class Syr2Double : public ::testing::TestWithParam<combination_t<double>> {};
+TEST_P(Syr2Double, test) { run_test<double>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(syr2, Syr2Double, combi);
+#endif

--- a/test/unittest/blas2/blas2_syr_test.cpp
+++ b/test/unittest/blas2/blas2_syr_test.cpp
@@ -1,0 +1,100 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename blas2_syr_test.cpp
+ *
+ **************************************************************************/
+
+#include "blas_test.hpp"
+
+template <typename scalar_t>
+using combination_t = std::tuple<char, int, scalar_t, int, int>;
+
+template <typename scalar_t>
+void run_test(const combination_t<scalar_t> combi) {
+  using type_t = blas_test_args<scalar_t, void>;
+  using blas_test_t = BLAS_Test<type_t>;
+  using executor_t = typename type_t::executor_t;
+
+  int n;
+  int lda_mul;
+  int incX;
+  char uplo;
+  scalar_t alpha;
+  std::tie(uplo, n, alpha, incX, lda_mul) = combi;
+  int lda = n * lda_mul;
+
+  // Input vector
+  std::vector<scalar_t> x_v(n * incX);
+  blas_test_t::set_rand(x_v, n * incX);
+
+  // Output matrix
+  std::vector<scalar_t> a_m(n * lda, 7.0);
+  std::vector<scalar_t> a_cpu_m(n * lda, 7.0);
+
+  // SYSTEM SYR
+  reference_blas::syr(&uplo, n, alpha, x_v.data(), incX, a_cpu_m.data(), lda);
+
+  SYCL_DEVICE_SELECTOR d;
+  auto q = blas_test_t::make_queue(d);
+  Executor<executor_t> ex(q);
+  auto x_v_gpu = blas::make_sycl_iterator_buffer<scalar_t>(x_v, n * incX);
+  auto a_m_gpu = blas::make_sycl_iterator_buffer<scalar_t>(a_m, lda * n);
+
+  // SYCLsyr
+  _syr(ex, uplo, n, alpha, x_v_gpu, incX, a_m_gpu, lda);
+
+  auto event =
+      ex.get_policy_handler().copy_to_host(a_m_gpu, a_m.data(), n * lda);
+  ex.get_policy_handler().wait(event);
+
+  for (int i = 0; i < n * lda; ++i) {
+    ASSERT_T_EQUAL(scalar_t, a_m[i], a_cpu_m[i]);
+  }
+}
+
+#ifdef STRESS_TESTING
+const auto combi =
+    ::testing::Combine(::testing::Values('u', 'l'),                 // UPLO
+                       ::testing::Values(14, 63, 257, 1010, 2025),  // n
+                       ::testing::Values(0.0, 1.0, 1.5),            // alpha
+                       ::testing::Values(1, 2),                     // incX
+                       ::testing::Values(1, 2)                      // lda_mul
+    );
+#else
+// For the purpose of travis and other slower platforms, we need a faster test
+const auto combi = ::testing::Combine(::testing::Values('u', 'l'),  // UPLO
+                                      ::testing::Values(14, 1010),  // n
+                                      ::testing::Values(0.0, 1.5),  // alpha
+                                      ::testing::Values(2),         // incX
+                                      ::testing::Values(2)          // lda_mul
+);
+#endif
+
+class SyrFloat : public ::testing::TestWithParam<combination_t<float>> {};
+TEST_P(SyrFloat, test) { run_test<float>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(syr, SyrFloat, combi);
+
+#if DOUBLE_SUPPORT
+class SyrDouble : public ::testing::TestWithParam<combination_t<double>> {};
+TEST_P(SyrDouble, test) { run_test<double>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(syr, SyrDouble, combi);
+#endif

--- a/test/unittest/blas2/blas2_trmv_test.cpp
+++ b/test/unittest/blas2/blas2_trmv_test.cpp
@@ -1,0 +1,117 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename blas2_trmv_test.cpp
+ *
+ **************************************************************************/
+
+#include "blas_test.hpp"
+
+// Please note:
+// TRMV is broken in OpenBLAS 0.2.18
+// If you are seeing fails from this, it could be that
+// Seems to have been fixed in modern OpenBLASes
+
+using combination_t = std::tuple<char, char, char, int, int, int>;
+
+template <typename scalar_t>
+void run_test(const combination_t combi) {
+  using type_t = blas_test_args<scalar_t, void>;
+  using blas_test_t = BLAS_Test<type_t>;
+  using executor_t = typename type_t::executor_t;
+
+  int n;
+  int lda_mul;
+  int incX;
+  char uplo;
+  char trans;
+  char diag;
+  std::tie(uplo, trans, diag, n, incX, lda_mul) = combi;
+  int lda = n * lda_mul;
+
+  // Input matrix
+  std::vector<scalar_t> a_m(lda * n);
+  blas_test_t::set_rand(a_m, lda * n);
+
+  // Output Vector
+  std::vector<scalar_t> x_v(n * incX, 7.0);
+  std::vector<scalar_t> x_cpu_v(n * incX, 7.0);
+
+  // If this is a unit triangle, we should set the diagonal
+  if (diag == 'u' || diag == 'U') {
+    for (int i = 0; i < n; i++) {
+      // a_m[i][i], basically
+      a_m[(i * lda) + i] = 1.0;
+    }
+  }
+
+  // SYSTEM GER
+  reference_blas::trmv(&uplo, &trans, &diag, n, a_m.data(), lda, x_cpu_v.data(),
+                       incX);
+
+  SYCL_DEVICE_SELECTOR d;
+  auto q = blas_test_t::make_queue(d);
+  Executor<executor_t> ex(q);
+  auto a_m_gpu = blas::make_sycl_iterator_buffer<scalar_t>(a_m, lda * n);
+  auto x_v_gpu = blas::make_sycl_iterator_buffer<scalar_t>(x_v, n * incX);
+
+  // SYCLtrmv
+  _trmv(ex, uplo, trans, diag, n, a_m_gpu, lda, x_v_gpu, incX);
+
+  auto event =
+      ex.get_policy_handler().copy_to_host(x_v_gpu, x_v.data(), n * incX);
+  ex.get_policy_handler().wait(event);
+
+  for (int i = 0; i < n * incX; ++i) {
+    ASSERT_T_EQUAL(scalar_t, x_v[i], x_cpu_v[i]);
+  }
+}
+
+#ifdef STRESS_TESTING
+// For the purpose of travis and other slower platforms, we need a faster test
+const auto combi =
+    ::testing::Combine(::testing::Values('u', 'l'),                     // UPLO
+                       ::testing::Values('n', 't'),                     // TRANS
+                       ::testing::Values('u', 'n'),                     // DIAG
+                       ::testing::Values(14, 63, 257, 1010, 1024 * 5),  // n
+                       ::testing::Values(1, 2),                         // incX
+                       ::testing::Values(1, 2)  // lda_mul
+    );
+#else
+// For the purpose of travis and other slower platforms, we need a faster test
+const auto combi = ::testing::Combine(::testing::Values('u', 'l'),  // UPLO
+                                      ::testing::Values('n', 't'),  // TRANS
+                                      ::testing::Values('u', 'n'),  // DIAG
+                                      ::testing::Values(2025),      // n
+                                      ::testing::Values(2),         // incX
+                                      ::testing::Values(2)          // lda_mul
+);
+#endif
+
+class TrmvFloat : public ::testing::TestWithParam<combination_t> {};
+TEST_P(TrmvFloat, test) { run_test<float>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(trmv, TrmvFloat, combi);
+
+#if DOUBLE_SUPPORT
+class TrmvDouble : public ::testing::TestWithParam<combination_t> {};
+TEST_P(TrmvDouble, test) { run_test<double>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(trmv, TrmvDouble, combi);
+#endif

--- a/test/unittest/blas3/blas3_gemm_common.hpp
+++ b/test/unittest/blas3/blas3_gemm_common.hpp
@@ -45,7 +45,7 @@ const auto combi = ::testing::Combine(
 const auto combi = ::testing::Combine(::testing::Values(5),        // batch_size
                                       ::testing::Values(11, 512),  // m
                                       ::testing::Values(14, 49),   // n
-                                      ::testing::Values(2, 512),   // k
+                                      ::testing::Values(21),       // k
                                       ::testing::Values('n', 't'),  // transa
                                       ::testing::Values('n', 't'),  // transb
                                       ::testing::Values(1.5),       // alpha


### PR DESCRIPTION
This change adds an (updated) test for GER, SYMV, SYR, SYR2, and
TRMV.

As part of this, the reference blas system was rewritten and now
uses the proper cblas.h header.

Please note: This requires the fix for unit triangles in TRMV.