### PR TITLE
Set the initial values for iamax and iamin correctly

### DIFF
--- a/include/operations/blas_constants.h
+++ b/include/operations/blas_constants.h
@@ -106,7 +106,7 @@ struct constant<IndexValueTuple<value_t, index_t>, const_val::imax> {
   constexpr static SYCL_BLAS_INLINE IndexValueTuple<value_t, index_t> value() {
     return IndexValueTuple<value_t, index_t>(
         std::numeric_limits<index_t>::max(),
-        std::numeric_limits<value_t>::min());
+        static_cast<value_t>(0)); // This is used for absolute max, -1 == 1
   }
 };
 

--- a/test/unittest/blas1/blas1_iamax_test.cpp
+++ b/test/unittest/blas1/blas1_iamax_test.cpp
@@ -52,10 +52,10 @@ TYPED_TEST(BLAS_Test, iamax_test) {
   // create a vector which will hold the result
   std::vector<IndexValueTuple<scalar_t, index_t>> vI(1, val);
 
-  scalar_t max = scalar_t(0);
-  index_t imax = std::numeric_limits<index_t>::max();
+  scalar_t max = vX[0];
+  index_t imax = 0;
   // compute index and value of the element with biggest absolute value
-  for (index_t i = 0; i < size; i += strd) {
+  for (index_t i = 1; i < size; i += strd) {
     if (std::abs(vX[i]) > std::abs(max)) {
       max = vX[i];
       imax = i;


### PR DESCRIPTION
This change changes the base value for the maximum value to (0,
0.0). If the first element is 0.0, this is the output, if it is
greater than 0.0, then it will be treated as larger and get set.