### PR TITLE
WIP: Extend BufferIterator

### DIFF
--- a/include/container/sycl_iterator.h
+++ b/include/container/sycl_iterator.h
@@ -55,6 +55,12 @@ class BufferIterator<element_t, codeplay_policy> {
                                                                 acc_md_t>
       get_range_accessor(BufferIterator<scal_t, codeplay_policy> buff_iterator,
                          size_t size);
+
+  /*!
+   * @brief See BufferIterator.
+   */
+  BufferIterator();
+
   /*!
    * @brief See BufferIterator.
    */
@@ -69,6 +75,11 @@ class BufferIterator<element_t, codeplay_policy> {
    */
   template <typename other_scalar_t>
   BufferIterator(const BufferIterator<other_scalar_t, codeplay_policy>& other);
+
+  /*!
+   * @brief See BufferIterator.
+   */
+  operator BufferIterator<const element_t, codeplay_policy>() const;
 
   /*!
    * @brief See BufferIterator.

--- a/src/container/sycl_iterator.hpp
+++ b/src/container/sycl_iterator.hpp
@@ -30,6 +30,10 @@
 namespace blas {
 
 template <typename element_t>
+inline BufferIterator<element_t, codeplay_policy>::BufferIterator()
+    : BufferIterator(cl::sycl::buffer<element_t>(cl::sycl::range<1>(1)), 0) {}
+
+template <typename element_t>
 inline BufferIterator<element_t, codeplay_policy>::BufferIterator(
     const typename BufferIterator<element_t, codeplay_policy>::buff_t& buff,
     std::ptrdiff_t offset)
@@ -44,7 +48,15 @@ template <typename element_t>
 template <typename other_scalar_t>
 inline BufferIterator<element_t, codeplay_policy>::BufferIterator(
     const BufferIterator<other_scalar_t, codeplay_policy>& other)
-    : BufferIterator(other.get_buffer(), other.get_offset()) {}
+    : BufferIterator(other.get_buffer().template reinterpret<element_t>(
+                         cl::sycl::range<1>(other.get_buffer().get_count())),
+                     other.get_offset()) {}
+
+template <typename element_t>
+inline BufferIterator<element_t, codeplay_policy>::operator
+    BufferIterator<const element_t, codeplay_policy>() const {
+  return BufferIterator<const element_t, codeplay_policy>(*this);
+}
 
 template <typename element_t>
 inline BufferIterator<element_t, codeplay_policy>&


### PR DESCRIPTION
These are changes required by SYCL-DNN in order to be able to use the BufferIterator instead of the PointerMapper. The BufferIterator needs to behave like a pointer so we need to have:
* a default constructor
* a copy constructor able to construct `BufferIterator<const T>` from `BufferIterator<T>`
* `BufferIterator<T>` implicitly convertible to `BufferIterator<const T>`