### PR TITLE
Updated BLAS1 tests to match BLAS2/3 tests

### DIFF
--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -33,6 +33,7 @@
 #include <iomanip>
 #include <iostream>
 #include <vector>
+#include <random>
 
 #include <gtest/gtest.h>
 
@@ -42,6 +43,7 @@
 #include "utils/system_reference_blas.hpp"
 #include "utils/cli_device_selector.hpp"
 #include "utils/print_queue_information.hpp"
+#include "utils/float_comparison.hpp"
 
 struct Args {
   std::string program_name;
@@ -240,8 +242,19 @@ inline cl::sycl::queue make_queue() {
   return q;
 };
 
-#define ASSERT_T_EQUAL(T, val1, val2)                                         \
-  ASSERT_PRED_FORMAT2(::testing::internal::CmpHelperFloatingPointEQ<T>, val1, \
-                      val2)
+/**
+ * @fn random_data
+ * @brief Generates a random vector of scalar values, using a uniform
+ * distribution.
+ */
+template <typename scalar_t>
+static inline void fill_random(std::vector<scalar_t> &vec) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> dis(-1.0, 1.0);
+  for (scalar_t &e : vec) {
+    e = dis(gen);
+  }
+}
 
 #endif /* end of include guard: BLAS_TEST_HPP */

--- a/test/unittest/blas1/blas1_axpy_test.cpp
+++ b/test/unittest/blas1/blas1_axpy_test.cpp
@@ -22,172 +22,76 @@
  *  @filename blas1_axpy_test.cpp
  *
  **************************************************************************/
+
 #include "blas_test.hpp"
-typedef ::testing::Types<blas_test_float<>, blas_test_double<> > BlasTypes;
 
-TYPED_TEST_CASE(BLAS_Test, BlasTypes);
+template <typename scalar_t>
+using combination_t = std::tuple<int, scalar_t, int, int>;
 
-REGISTER_SIZE(::RANDOM_SIZE, axpy_test_buff)
-REGISTER_STRD(::RANDOM_STRD, axpy_test_buff)
-REGISTER_PREC(float, 1e-4, axpy_test_buff)
-REGISTER_PREC(double, 1e-6, axpy_test_buff)
-REGISTER_PREC(std::complex<float>, 1e-4, axpy_test_buff)
-REGISTER_PREC(std::complex<double>, 1e-6, axpy_test_buff)
+template <typename scalar_t>
+void run_test(const combination_t<scalar_t> combi) {
+  using type_t = blas_test_args<scalar_t, void>;
+  using blas_test_t = BLAS_Test<type_t>;
+  using executor_t = typename type_t::executor_t;
 
-TYPED_TEST(BLAS_Test, axpy_test_buff) {
-  using scalar_t = typename TypeParam::scalar_t;
-  using ExecutorType = typename TypeParam::executor_t;
-  using TestClass = BLAS_Test<TypeParam>;
-  using test = class axpy_test_buff;
+  int size;
+  scalar_t alpha;
+  int incX;
+  int incY;
+  std::tie(size, alpha, incX, incY) = combi;
 
-  int size = TestClass::template test_size<test>();
-  int strd = TestClass::template test_strd<test>();
-  scalar_t prec = TestClass::template test_prec<test>();
+  // Input vector
+  std::vector<scalar_t> x_v(size * incX);
+  fill_random(x_v);
 
-  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
-  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
-  // setting alpha to some value
-  scalar_t alpha(1.54);
-  // creating three vectors: vX, vY and vZ.
-  // the for loop will compute axpy for vX, vY
-  std::vector<scalar_t> vX(size);
-  std::vector<scalar_t> vY(size);
-  std::vector<scalar_t> vZ(size, 0);
-  TestClass::set_rand(vX, size);
-  TestClass::set_rand(vY, size);
+  // Output vector
+  std::vector<scalar_t> y_v(size * incY, 10.0);
+  std::vector<scalar_t> y_cpu_v(size * incY, 10.0);
 
-  // compute axpy in a for loop and put the result into vZ
-  for (int i = 0; i < size; ++i) {
-    if (i % strd == 0) {
-      vZ[i] = alpha * vX[i] + vY[i];
-    } else {
-      vZ[i] = vY[i];
-    }
-  }
+  // Reference implementation
+  reference_blas::axpy(size, alpha, x_v.data(), incX, y_cpu_v.data(), incY);
 
-  auto q = make_queue();
-  Executor<ExecutorType> ex(q);
-  auto gpu_vX = blas::make_sycl_iterator_buffer<scalar_t>(vX, size);
-  auto gpu_vY = blas::make_sycl_iterator_buffer<scalar_t>(vY, size);
-  _axpy(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY, strd);
-  auto event = ex.get_policy_handler().copy_to_host(gpu_vY, vY.data(), size);
+  // SYCL implementation
+  SYCL_DEVICE_SELECTOR d;
+  auto q = blas_test_t::make_queue(d);
+  Executor<executor_t> ex(q);
+
+  // Iterators
+  auto gpu_x_v = blas::make_sycl_iterator_buffer<scalar_t>(int(size * incX));
+  ex.get_policy_handler().copy_to_device(x_v.data(), gpu_x_v, size * incX);
+  auto gpu_y_v = blas::make_sycl_iterator_buffer<scalar_t>(int(size * incY));
+  ex.get_policy_handler().copy_to_device(y_v.data(), gpu_y_v, size * incY);
+
+  _axpy(ex, size, alpha, gpu_x_v, incX, gpu_y_v, incY);
+  auto event =
+      ex.get_policy_handler().copy_to_host(gpu_y_v, y_v.data(), size * incY);
   ex.get_policy_handler().wait(event);
 
-  // check that both results are the same
-  for (int i = 0; i < size; ++i) {
-    ASSERT_NEAR(vZ[i], vY[i], prec);
-  }
+  // Validate the result
+  ASSERT_TRUE(utils::compare_vectors(y_v, y_cpu_v));
 }
 
-TYPED_TEST_CASE(BLAS_Test, BlasTypes);
+#ifdef STRESS_TESTING
+const auto combi =
+    ::testing::Combine(::testing::Values(11, 65, 1002, 1002400),  // size
+                       ::testing::Values(0.0, 1.0, 1.5),          // alpha
+                       ::testing::Values(1, 4),                   // incX
+                       ::testing::Values(1, 3)                    // incY
+    );
+#else
+const auto combi = ::testing::Combine(::testing::Values(11, 1002),  // size
+                                      ::testing::Values(0.0, 1.5),  // alpha
+                                      ::testing::Values(1, 4),      // incX
+                                      ::testing::Values(1, 3)       // incY
+);
+#endif
 
-REGISTER_SIZE(::RANDOM_SIZE, axpy_test)
-REGISTER_STRD(::RANDOM_STRD, axpy_test)
-REGISTER_PREC(float, 1e-4, axpy_test)
-REGISTER_PREC(double, 1e-6, axpy_test)
-REGISTER_PREC(std::complex<float>, 1e-4, axpy_test)
-REGISTER_PREC(std::complex<double>, 1e-6, axpy_test)
+class AxpyFloat : public ::testing::TestWithParam<combination_t<float>> {};
+TEST_P(AxpyFloat, test) { run_test<float>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(axpy, AxpyFloat, combi);
 
-TYPED_TEST(BLAS_Test, axpy_test) {
-  using scalar_t = typename TypeParam::scalar_t;
-  using ExecutorType = typename TypeParam::executor_t;
-  using TestClass = BLAS_Test<TypeParam>;
-  using test = class axpy_test;
-
-  int size = TestClass::template test_size<test>();
-  int strd = TestClass::template test_strd<test>();
-  scalar_t prec = TestClass::template test_prec<test>();
-
-  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
-  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
-  // setting alpha to some value
-  scalar_t alpha(1.54);
-  // creating three vectors: vX, vY and vZ.
-  // the for loop will compute axpy for vX, vY
-  std::vector<scalar_t> vX(size);
-  std::vector<scalar_t> vY(size);
-  std::vector<scalar_t> vZ(size, 0);
-  TestClass::set_rand(vX, size);
-  TestClass::set_rand(vY, size);
-
-  // compute axpy in a for loop and put the result into vZ
-  for (int i = 0; i < size; ++i) {
-    if (i % strd == 0) {
-      vZ[i] = alpha * vX[i] + vY[i];
-    } else {
-      vZ[i] = vY[i];
-    }
-  }
-
-  auto q = make_queue();
-  Executor<ExecutorType> ex(q);
-  auto gpu_vX = blas::make_sycl_iterator_buffer<scalar_t>(vX, size);
-  auto gpu_vY = ex.get_policy_handler().template allocate<scalar_t>(size);
-  ex.get_policy_handler().copy_to_device(vY.data(), gpu_vY, size);
-  _axpy(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY, strd);
-  auto event = ex.get_policy_handler().copy_to_host(gpu_vY, vY.data(), size);
-  ex.get_policy_handler().wait(event);
-
-  // check that both results are the same
-  for (int i = 0; i < size; ++i) {
-    ASSERT_NEAR(vZ[i], vY[i], prec);
-  }
-  ex.get_policy_handler().template deallocate<scalar_t>(gpu_vY);
-}
-
-REGISTER_SIZE(::RANDOM_SIZE, axpy_test_vpr)
-REGISTER_STRD(::RANDOM_STRD, axpy_test_vpr)
-REGISTER_PREC(float, 1e-4, axpy_test_vpr)
-REGISTER_PREC(double, 1e-6, axpy_test_vpr)
-REGISTER_PREC(std::complex<float>, 1e-4, axpy_test_vpr)
-REGISTER_PREC(std::complex<double>, 1e-6, axpy_test_vpr)
-
-TYPED_TEST(BLAS_Test, axpy_test_vpr) {
-  using scalar_t = typename TypeParam::scalar_t;
-  using ExecutorType = typename TypeParam::executor_t;
-  using TestClass = BLAS_Test<TypeParam>;
-  using test = class axpy_test_vpr;
-
-  int size = TestClass::template test_size<test>();
-  int strd = TestClass::template test_strd<test>();
-  scalar_t prec = TestClass::template test_prec<test>();
-
-  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
-  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
-  // setting alpha to some value
-  scalar_t alpha(1.54);
-  // creating three vectors: vX, vY and vZ.
-  // the for loop will compute axpy for vX, vY
-  std::vector<scalar_t> vX(size);
-  std::vector<scalar_t> vY(size);
-  std::vector<scalar_t> vZ(size, 0);
-  TestClass::set_rand(vX, size);
-  TestClass::set_rand(vY, size);
-
-  // compute axpy in a for loop and put the result into vZ
-  for (int i = 0; i < size; ++i) {
-    if (i % strd == 0) {
-      vZ[i] = alpha * vX[i] + vY[i];
-    } else {
-      vZ[i] = vY[i];
-    }
-  }
-
-  auto q = make_queue();
-  Executor<ExecutorType> ex(q);
-  auto gpu_vX = ex.get_policy_handler().template allocate<scalar_t>(size);
-  auto gpu_vY = ex.get_policy_handler().template allocate<scalar_t>(size);
-  ex.get_policy_handler().copy_to_device(vX.data(), gpu_vX, size);
-  ex.get_policy_handler().copy_to_device(vY.data(), gpu_vY, size);
-  _axpy(ex, (size + strd - 1) / strd, alpha, gpu_vX, strd, gpu_vY, strd);
-  auto event = ex.get_policy_handler().copy_to_host(gpu_vY, vY.data(), size);
-  ex.get_policy_handler().wait(event);
-
-  // check that both results are the same
-  for (int i = 0; i < size; ++i) {
-    ASSERT_NEAR(vZ[i], vY[i], prec);
-  }
-
-  ex.get_policy_handler().template deallocate<scalar_t>(gpu_vX);
-  ex.get_policy_handler().template deallocate<scalar_t>(gpu_vY);
-}
+#if DOUBLE_SUPPORT
+class AxpyDouble : public ::testing::TestWithParam<combination_t<double>> {};
+TEST_P(AxpyDouble, test) { run_test<double>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(axpy, AxpyDouble, combi);
+#endif

--- a/test/unittest/blas1/blas1_copy_test.cpp
+++ b/test/unittest/blas1/blas1_copy_test.cpp
@@ -25,86 +25,69 @@
 
 #include "blas_test.hpp"
 
-typedef ::testing::Types<blas_test_float<>, blas_test_double<> > BlasTypes;
+using combination_t = std::tuple<int, int, int>;
 
-TYPED_TEST_CASE(BLAS_Test, BlasTypes);
+template <typename scalar_t>
+void run_test(const combination_t combi) {
+  using type_t = blas_test_args<scalar_t, void>;
+  using blas_test_t = BLAS_Test<type_t>;
+  using executor_t = typename type_t::executor_t;
 
-REGISTER_SIZE(::RANDOM_SIZE, copy_test)
-REGISTER_STRD(::RANDOM_STRD, copy_test)
+  int size;
+  int incX;
+  int incY;
+  std::tie(size, incX, incY) = combi;
 
-TYPED_TEST(BLAS_Test, copy_test) {
-  using scalar_t = typename TypeParam::scalar_t;
-  using ExecutorType = typename TypeParam::executor_t;
-  using TestClass = BLAS_Test<TypeParam>;
-  using test = class copy_test;
+  // Input vector
+  std::vector<scalar_t> x_v(size * incX);
+  fill_random(x_v);
 
-  int size = TestClass::template test_size<test>();
-  int strd = TestClass::template test_strd<test>();
+  // Output vector
+  std::vector<scalar_t> y_v(size * incY, 10.0);
+  std::vector<scalar_t> y_cpu_v(size * incY, 10.0);
 
-  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
-  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
+  // Reference implementation
+  reference_blas::copy(size, x_v.data(), incX, y_cpu_v.data(), incY);
 
-  // create two vectors: vX and vY
-  std::vector<scalar_t> vX(size);
-  std::vector<scalar_t> vY(size, 0);
-  TestClass::set_rand(vX, size);
+  // SYCL implementation
+  SYCL_DEVICE_SELECTOR d;
+  auto q = blas_test_t::make_queue(d);
+  Executor<executor_t> ex(q);
 
-  auto q = make_queue();
-  Executor<ExecutorType> ex(q);
-  auto gpu_vX = blas::make_sycl_iterator_buffer<scalar_t>(vX, size);
-  auto gpu_vY = blas::make_sycl_iterator_buffer<scalar_t>(vY, size);
-  _copy(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vY, strd);
-  auto event = ex.get_policy_handler().copy_to_host(gpu_vY, vY.data(), size);
-  ex.get_policy_handler().wait(event);
-  // check that vX and vY are the same
-  for (int i = 0; i < size; ++i) {
-    if (i % strd == 0) {
-      ASSERT_EQ(vX[i], vY[i]);
-    } else {
-      ASSERT_EQ(0, vY[i]);
-    }
-  }
-}
+  // Iterators
+  auto gpu_x_v = blas::make_sycl_iterator_buffer<scalar_t>(int(size * incX));
+  ex.get_policy_handler().copy_to_device(x_v.data(), gpu_x_v, size * incX);
+  auto gpu_y_v = blas::make_sycl_iterator_buffer<scalar_t>(int(size * incY));
+  ex.get_policy_handler().copy_to_device(y_v.data(), gpu_y_v, size * incY);
 
-REGISTER_SIZE(::RANDOM_SIZE, copy_test_vpr)
-REGISTER_STRD(::RANDOM_STRD, copy_test_vpr)
-
-TYPED_TEST(BLAS_Test, copy_test_vpr) {
-  using scalar_t = typename TypeParam::scalar_t;
-  using ExecutorType = typename TypeParam::executor_t;
-  using TestClass = BLAS_Test<TypeParam>;
-  using test = class copy_test_vpr;
-
-  int size = TestClass::template test_size<test>();
-  int strd = TestClass::template test_strd<test>();
-
-  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
-  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
-
-  // create two vectors: vX and vY
-  std::vector<scalar_t> vX(size);
-  std::vector<scalar_t> vY(size, 0);
-  TestClass::set_rand(vX, size);
-
-  auto q = make_queue();
-  Executor<ExecutorType> ex(q);
-  auto gpu_vX = ex.get_policy_handler().template allocate<scalar_t>(size);
-  auto gpu_vY = ex.get_policy_handler().template allocate<scalar_t>(size);
-  ex.get_policy_handler().copy_to_device(vX.data(), gpu_vX, size);
-  ex.get_policy_handler().copy_to_device(vY.data(), gpu_vY, size);
-  _copy(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vY, strd);
-  auto event = ex.get_policy_handler().copy_to_host(gpu_vY, vY.data(), size);
+  _copy(ex, size, gpu_x_v, incX, gpu_y_v, incY);
+  auto event =
+      ex.get_policy_handler().copy_to_host(gpu_y_v, y_v.data(), size * incY);
   ex.get_policy_handler().wait(event);
 
-  // check that vX and vY are the same
-  for (int i = 0; i < size; ++i) {
-    if (i % strd == 0) {
-      ASSERT_EQ(vX[i], vY[i]);
-    } else {
-      ASSERT_EQ(0, vY[i]);
-    }
-  }
-
-  ex.get_policy_handler().template deallocate<scalar_t>(gpu_vX);
-  ex.get_policy_handler().template deallocate<scalar_t>(gpu_vY);
+  // Validate the result
+  ASSERT_TRUE(utils::compare_vectors(y_v, y_cpu_v));
 }
+
+#ifdef STRESS_TESTING
+const auto combi =
+    ::testing::Combine(::testing::Values(11, 65, 1002, 1002400),  // size
+                       ::testing::Values(1, 4),                   // incX
+                       ::testing::Values(1, 3)                    // incY
+    );
+#else
+const auto combi = ::testing::Combine(::testing::Values(11, 1002),  // size
+                                      ::testing::Values(1, 4),      // incX
+                                      ::testing::Values(1, 3)       // incY
+);
+#endif
+
+class CopyFloat : public ::testing::TestWithParam<combination_t> {};
+TEST_P(CopyFloat, test) { run_test<float>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(copy, CopyFloat, combi);
+
+#if DOUBLE_SUPPORT
+class CopyDouble : public ::testing::TestWithParam<combination_t> {};
+TEST_P(CopyDouble, test) { run_test<double>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(copy, CopyDouble, combi);
+#endif

--- a/test/unittest/blas1/blas1_iamax_test.cpp
+++ b/test/unittest/blas1/blas1_iamax_test.cpp
@@ -1,135 +1,71 @@
-/***************************************************************************
- *
- *  @license
- *  Copyright (C) Codeplay Software Limited
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  For your convenience, a copy of the License has been included in this
- *  repository.
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- *  SYCL-BLAS: BLAS implementation using SYCL
- *
- *  @filename blas1_iamax_test.cpp
- *
- **************************************************************************/
-
 #include "blas_test.hpp"
-typedef ::testing::Types<blas_test_float<>, blas_test_double<>> BlasTypes;
+#include <limits>
 
-TYPED_TEST_CASE(BLAS_Test, BlasTypes);
-REGISTER_SIZE(::RANDOM_SIZE, iamax_test)
-REGISTER_STRD(1, iamax_test)
-REGISTER_PREC(float, 1e-4, iamax_test)
-REGISTER_PREC(double, 1e-6, iamax_test)
+using combination_t = std::tuple<int, int, bool>;
 
-TYPED_TEST(BLAS_Test, iamax_test) {
-  using scalar_t = typename TypeParam::scalar_t;
-  using ExecutorType = typename TypeParam::executor_t;
-  using TestClass = BLAS_Test<TypeParam>;
-  using test = class iamax_test;
-  using index_t = int;
-  index_t size = TestClass::template test_size<test>();
-  index_t strd = TestClass::template test_strd<test>();
+template <typename scalar_t>
+void run_test(const combination_t combi) {
+  using type_t = blas_test_args<scalar_t, void>;
+  using blas_test_t = BLAS_Test<type_t>;
+  using executor_t = typename type_t::executor_t;
+  using tuple_t = IndexValueTuple<scalar_t, int>;
 
-  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
-  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
+  int size;
+  int incX;
+  bool all_max;
+  std::tie(size, incX, all_max) = combi;
 
-  // create a random vector vX
-  std::vector<scalar_t> vX(size);
-  TestClass::set_rand(vX, size);
-  constexpr auto val =
-      constant<IndexValueTuple<scalar_t, index_t>, const_val::imax>::value();
-  // create a vector which will hold the result
-  std::vector<IndexValueTuple<scalar_t, index_t>> vI(1, val);
-
-  scalar_t max = vX[0];
-  index_t imax = 0;
-  // compute index and value of the element with biggest absolute value
-  for (index_t i = 1; i < size; i += strd) {
-    if (std::abs(vX[i]) > std::abs(max)) {
-      max = vX[i];
-      imax = i;
-    }
+  // Input vector
+  std::vector<scalar_t> x_v(size * incX, 0.0);
+  if (!all_max) {
+    fill_random(x_v);
   }
-  IndexValueTuple<scalar_t, index_t> res(imax, max);
 
-  auto q = make_queue();
-  Executor<ExecutorType> ex(q);
-  auto gpu_vX = blas::make_sycl_iterator_buffer<scalar_t>(vX, size);
-  auto gpu_vI =
-      blas::make_sycl_iterator_buffer<IndexValueTuple<scalar_t, index_t>>(
-          index_t(1));
-  _iamax(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vI);
-  auto event = ex.get_policy_handler().copy_to_host(gpu_vI, vI.data(), 1);
+  // Output scalar
+  std::vector<tuple_t> out_s(1, tuple_t(0, 0.0));
+
+  // Reference implementation
+  scalar_t out_cpu_s = reference_blas::iamax(size, x_v.data(), incX);
+
+  // SYCL implementation
+  SYCL_DEVICE_SELECTOR d;
+  auto q = blas_test_t::make_queue(d);
+  Executor<executor_t> ex(q);
+
+  // Iterators
+  auto gpu_x_v = blas::make_sycl_iterator_buffer<scalar_t>(int(size * incX));
+  ex.get_policy_handler().copy_to_device(x_v.data(), gpu_x_v, size * incX);
+  auto gpu_out_s = blas::make_sycl_iterator_buffer<tuple_t>(int(1));
+  ex.get_policy_handler().copy_to_device(out_s.data(), gpu_out_s, 1);
+
+  _iamax(ex, size, gpu_x_v, incX, gpu_out_s);
+  auto event = ex.get_policy_handler().copy_to_host(gpu_out_s, out_s.data(), 1);
   ex.get_policy_handler().wait(event);
 
-  // check that the result value is the same
-  ASSERT_EQ(res.get_value(), vI[0].get_value());
-  // check that the result index is the same
-  ASSERT_EQ(res.get_index(), vI[0].get_index());
+  // Validate the result
+  ASSERT_EQ(out_cpu_s, out_s[0].ind);
 }
 
-REGISTER_SIZE(::RANDOM_SIZE, iamax_test_vpr)
-REGISTER_STRD(1, iamax_test_vpr)
+#ifdef STRESS_TESTING
+const auto combi =
+    ::testing::Combine(::testing::Values(11, 65, 10000, 1002400),  // size
+                       ::testing::Values(1, 5),                    // incX
+                       ::testing::Values(true, false)  // All zero input
+    );
+#else
+const auto combi =
+    ::testing::Combine(::testing::Values(11, 65, 10000),  // size
+                       ::testing::Values(5),              // incX
+                       ::testing::Values(true, false)     // All max input
+    );
+#endif
 
-TYPED_TEST(BLAS_Test, iamax_test_vpr) {
-  using scalar_t = typename TypeParam::scalar_t;
-  using ExecutorType = typename TypeParam::executor_t;
-  using TestClass = BLAS_Test<TypeParam>;
-  using test = class iamax_test_vpr;
-  using index_t = int;
+class IamaxFloat : public ::testing::TestWithParam<combination_t> {};
+TEST_P(IamaxFloat, test) { run_test<float>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(iamax, IamaxFloat, combi);
 
-  index_t size = TestClass::template test_size<test>();
-  index_t strd = TestClass::template test_strd<test>();
-
-  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
-  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
-
-  // create a random vector vX
-  std::vector<scalar_t> vX(size);
-  TestClass::set_rand(vX, size);
-  constexpr auto val =
-      constant<IndexValueTuple<scalar_t, index_t>, const_val::imax>::value();
-  // create a vector which will hold the result
-  std::vector<IndexValueTuple<scalar_t, index_t>> vI(1, val);
-
-  scalar_t max = scalar_t(0);
-  index_t imax = std::numeric_limits<index_t>::max();
-  // compute index and value of the element with biggest absolute value
-  for (index_t i = 0; i < size; i += strd) {
-    if (std::abs(vX[i]) > std::abs(max)) {
-      max = vX[i];
-      imax = i;
-    }
-  }
-  IndexValueTuple<scalar_t, index_t> res(imax, max);
-
-  auto q = make_queue();
-  Executor<ExecutorType> ex(q);
-  auto gpu_vX = ex.get_policy_handler().template allocate<scalar_t>(size);
-  auto gpu_vI = ex.get_policy_handler()
-                    .template allocate<IndexValueTuple<scalar_t, index_t>>(1);
-  ex.get_policy_handler().copy_to_device(vX.data(), gpu_vX, size);
-  _iamax(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vI);
-  auto event = ex.get_policy_handler().copy_to_host(gpu_vI, vI.data(), 1);
-  ex.get_policy_handler().wait(event);
-
-  IndexValueTuple<scalar_t, index_t> res2(vI[0]);
-  // check that the result value is the same
-  ASSERT_EQ(res.get_value(), res2.get_value());
-  // check that the result index is the same
-  ASSERT_EQ(res.get_index(), res2.get_index());
-  ex.get_policy_handler().template deallocate<scalar_t>(gpu_vX);
-  ex.get_policy_handler()
-      .template deallocate<IndexValueTuple<scalar_t, index_t>>(gpu_vI);
-}
+#if DOUBLE_SUPPORT
+class IamaxDouble : public ::testing::TestWithParam<combination_t> {};
+TEST_P(IamaxDouble, test) { run_test<double>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(iamax, IamaxDouble, combi);
+#endif

--- a/test/unittest/blas1/blas1_iamin_test.cpp
+++ b/test/unittest/blas1/blas1_iamin_test.cpp
@@ -24,60 +24,81 @@
  **************************************************************************/
 
 #include "blas_test.hpp"
+#include <limits>
 
-typedef ::testing::Types<blas_test_float<>, blas_test_double<>> BlasTypes;
+using combination_t = std::tuple<int, int, bool>;
 
-TYPED_TEST_CASE(BLAS_Test, BlasTypes);
+template <typename scalar_t>
+void run_test(const combination_t combi) {
+  using type_t = blas_test_args<scalar_t, void>;
+  using blas_test_t = BLAS_Test<type_t>;
+  using executor_t = typename type_t::executor_t;
+  using tuple_t = IndexValueTuple<scalar_t, int>;
 
-REGISTER_SIZE(::RANDOM_SIZE, iamin_test)
-REGISTER_STRD(1, iamin_test)
+  int size;
+  int incX;
+  bool all_max;
+  std::tie(size, incX, all_max) = combi;
 
-TYPED_TEST(BLAS_Test, iamin_test) {
-  using scalar_t = typename TypeParam::scalar_t;
-  using ExecutorType = typename TypeParam::executor_t;
-  using TestClass = BLAS_Test<TypeParam>;
-  using test = class iamin_test;
-  using index_t = int;
-  index_t size = TestClass::template test_size<test>();
-  index_t strd = TestClass::template test_strd<test>();
+  const scalar_t max = std::numeric_limits<scalar_t>::max();
 
-  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
-  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
-
-  std::vector<scalar_t> vX(size);
-  TestClass::set_rand(vX, size);
-  constexpr auto val =
-      constant<IndexValueTuple<scalar_t, index_t>, const_val::imin>::value();
-  std::vector<IndexValueTuple<scalar_t, index_t>> vI(1, val);
-
-  // compute iamin of vX into res with a for loop
-  scalar_t min = std::numeric_limits<scalar_t>::max();
-  index_t imin = std::numeric_limits<index_t>::max();
-  for (index_t i = 0; i < size; i += strd) {
-    if (std::abs(vX[i]) < std::abs(min)) {
-      min = vX[i];
-      imin = i;
+  // Input vector
+  std::vector<scalar_t> x_v(size * incX, max);
+  if (!all_max) {
+    fill_random(x_v);
+  }
+  for (int i = 0; i < size * incX; i++) {
+    // There is a bug in Openblas where 0s are not handled correctly
+    if (x_v[i] == 0.0) {
+      x_v[i] = 1.0;
     }
   }
-  IndexValueTuple<scalar_t, index_t> res(imin, min);
 
-  auto q = make_queue();
-  Executor<ExecutorType> ex(q);
-  auto gpu_vX = ex.get_policy_handler().template allocate<scalar_t>(size);
-  auto gpu_vI =
-      ex.get_policy_handler()
-          .template allocate<IndexValueTuple<scalar_t, index_t>>(index_t(1));
-  ex.get_policy_handler().copy_to_device(vX.data(), gpu_vX, size);
-  _iamin(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vI);
-  auto event = ex.get_policy_handler().copy_to_host(gpu_vI, vI.data(), 1);
+  // Output scalar
+  std::vector<tuple_t> out_s(1, tuple_t(0, max));
+
+  // Reference implementation
+  scalar_t out_cpu_s = reference_blas::iamin(size, x_v.data(), incX);
+
+  // SYCL implementation
+  SYCL_DEVICE_SELECTOR d;
+  auto q = blas_test_t::make_queue(d);
+  Executor<executor_t> ex(q);
+
+  // Iterators
+  auto gpu_x_v = blas::make_sycl_iterator_buffer<scalar_t>(int(size * incX));
+  ex.get_policy_handler().copy_to_device(x_v.data(), gpu_x_v, size * incX);
+  auto gpu_out_s = blas::make_sycl_iterator_buffer<tuple_t>(int(1));
+  ex.get_policy_handler().copy_to_device(out_s.data(), gpu_out_s, 1);
+
+  _iamin(ex, size, gpu_x_v, incX, gpu_out_s);
+  auto event = ex.get_policy_handler().copy_to_host(gpu_out_s, out_s.data(), 1);
   ex.get_policy_handler().wait(event);
 
-  IndexValueTuple<scalar_t, index_t> res2(vI[0]);
-  // check that the result value is the same
-  ASSERT_EQ(res.get_value(), res2.get_value());
-  // check that the result index is the same
-  ASSERT_EQ(res.get_index(), res2.get_index());
-  ex.get_policy_handler().template deallocate<scalar_t>(gpu_vX);
-  ex.get_policy_handler()
-      .template deallocate<IndexValueTuple<scalar_t, index_t>>(gpu_vI);
+  // Validate the result
+  ASSERT_EQ(out_cpu_s, out_s[0].ind);
 }
+
+#ifdef STRESS_TESTING
+const auto combi =
+    ::testing::Combine(::testing::Values(11, 65, 10000, 1002400),  // size
+                       ::testing::Values(1, 5),                    // incX
+                       ::testing::Values(true, false)  // All zero input
+    );
+#else
+const auto combi =
+    ::testing::Combine(::testing::Values(11, 65, 10000),  // size
+                       ::testing::Values(5),              // incX
+                       ::testing::Values(true, false)     // All max input
+    );
+#endif
+
+class IaminFloat : public ::testing::TestWithParam<combination_t> {};
+TEST_P(IaminFloat, test) { run_test<float>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(iamin, IaminFloat, combi);
+
+#if DOUBLE_SUPPORT
+class IaminDouble : public ::testing::TestWithParam<combination_t> {};
+TEST_P(IaminDouble, test) { run_test<double>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(iamin, IaminDouble, combi);
+#endif

--- a/test/unittest/blas1/blas1_nrm2_test.cpp
+++ b/test/unittest/blas1/blas1_nrm2_test.cpp
@@ -1,14 +1,14 @@
 /***************************************************************************
  *
  *  @license
- *  Copyright (C) Codeplay Software Limited
+ *  Nrm2right (C) Codeplay Software Limited
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *  You may obtain a nrm2 of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  For your convenience, a copy of the License has been included in this
+ *  For your convenience, a nrm2 of the License has been included in this
  *  repository.
  *
  *  Unless required by applicable law or agreed to in writing, software
@@ -25,54 +25,57 @@
 
 #include "blas_test.hpp"
 
-typedef ::testing::Types<blas_test_float<>, blas_test_double<> > BlasTypes;
+using combination_t = std::tuple<int, int>;
 
-TYPED_TEST_CASE(BLAS_Test, BlasTypes);
+template <typename scalar_t>
+void run_test(const combination_t combi) {
+  using type_t = blas_test_args<scalar_t, void>;
+  using blas_test_t = BLAS_Test<type_t>;
+  using executor_t = typename type_t::executor_t;
 
-REGISTER_SIZE(::RANDOM_SIZE, nrm2_test)
-REGISTER_STRD(::RANDOM_STRD, nrm2_test)
-REGISTER_PREC(float, 1e-4, nrm2_test)
-REGISTER_PREC(double, 1e-6, nrm2_test)
+  int size;
+  int incX;
+  std::tie(size, incX) = combi;
 
-TYPED_TEST(BLAS_Test, nrm2_test) {
-  using scalar_t = typename TypeParam::scalar_t;
-  using ExecutorType = typename TypeParam::executor_t;
-  using TestClass = BLAS_Test<TypeParam>;
-  using test = class nrm2_test;
+  // Input vectors
+  std::vector<scalar_t> x_v(size * incX);
+  fill_random(x_v);
 
-  int size = TestClass::template test_size<test>();
-  int strd = TestClass::template test_strd<test>();
-  scalar_t prec = TestClass::template test_prec<test>();
+  // Output vector
+  std::vector<scalar_t> out_s(1, 10.0);
 
-  DEBUG_PRINT(std::cout << "size == " << size << std::endl);
-  DEBUG_PRINT(std::cout << "strd == " << strd << std::endl);
+  // Reference implementation
+  auto out_cpu_s = reference_blas::nrm2(size, x_v.data(), incX);
 
-  // create a random vector
-  std::vector<scalar_t> vX(size);
-  // create a vector which will hold the result
-  std::vector<scalar_t> vR(1, scalar_t(0));
-  TestClass::set_rand(vX, size);
+  // SYCL implementation
+  SYCL_DEVICE_SELECTOR d;
+  auto q = blas_test_t::make_queue(d);
+  Executor<executor_t> ex(q);
 
-  scalar_t res(0);
-  // compute nrm2 (euclidean length) of vX into res in a for loop
-  for (int i = 0; i < size; i += strd) {
-    res += vX[i] * vX[i];
-  }
-  res = std::sqrt(res);
+  // Iterators
+  auto gpu_x_v = blas::make_sycl_iterator_buffer<scalar_t>(int(size * incX));
+  ex.get_policy_handler().copy_to_device(x_v.data(), gpu_x_v, size * incX);
+  auto gpu_out_s = blas::make_sycl_iterator_buffer<scalar_t>(int(1));
+  ex.get_policy_handler().copy_to_device(out_s.data(), gpu_out_s, 1);
 
-  auto q = make_queue();
-  Executor<ExecutorType> ex(q);
-  // compute nrm2 of a vX into vR
-  auto gpu_vX = ex.get_policy_handler().template allocate<scalar_t>(size);
-  auto gpu_vR = ex.get_policy_handler().template allocate<scalar_t>(1);
-  ex.get_policy_handler().copy_to_device(vX.data(), gpu_vX, size);
-  ex.get_policy_handler().copy_to_device(vR.data(), gpu_vR, 1);
-  _nrm2(ex, (size + strd - 1) / strd, gpu_vX, strd, gpu_vR);
-  auto event = ex.get_policy_handler().copy_to_host(gpu_vR, vR.data(), 1);
+  _nrm2(ex, size, gpu_x_v, incX, gpu_out_s);
+  auto event = ex.get_policy_handler().copy_to_host(gpu_out_s, out_s.data(), 1);
   ex.get_policy_handler().wait(event);
 
-  // check that the result is the same
-  ASSERT_NEAR(res, vR[0], prec);
-  ex.get_policy_handler().template deallocate<scalar_t>(gpu_vX);
-  ex.get_policy_handler().template deallocate<scalar_t>(gpu_vR);
+  // Validate the result
+  ASSERT_TRUE(utils::almost_equal(out_s[0], out_cpu_s));
 }
+
+const auto combi = ::testing::Combine(::testing::Values(11, 1002),  // size
+                                      ::testing::Values(1, 4)       // incX
+);
+
+class Nrm2Float : public ::testing::TestWithParam<combination_t> {};
+TEST_P(Nrm2Float, test) { run_test<float>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(nrm2, Nrm2Float, combi);
+
+#if DOUBLE_SUPPORT
+class Nrm2Double : public ::testing::TestWithParam<combination_t> {};
+TEST_P(Nrm2Double, test) { run_test<double>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(nrm2, Nrm2Double, combi);
+#endif

--- a/test/unittest/blas2/blas2_gemv_test.cpp
+++ b/test/unittest/blas2/blas2_gemv_test.cpp
@@ -58,8 +58,8 @@ void run_test(const combination_t<scalar_t> combi) {
   std::vector<scalar_t> c_v_gpu_result(y * incY, scalar_t(10.0));
   // output system vector
   std::vector<scalar_t> c_v_cpu(y * incY, scalar_t(10.0));
-  blas_test_t::set_rand(a_m, lda * n);
-  blas_test_t::set_rand(b_v, x * incX);
+  fill_random(a_m);
+  fill_random(b_v);
 
   // SYSTEM GEMMV
   reference_blas::gemv(t_str, m, n, alpha, a_m.data(), lda, b_v.data(), incX,
@@ -79,9 +79,7 @@ void run_test(const combination_t<scalar_t> combi) {
       v_c_gpu, c_v_gpu_result.data(), y * incY);
   ex.get_policy_handler().wait(event);
 
-  for (int i = 0; i < y * incY; ++i) {
-    ASSERT_T_EQUAL(scalar_t, c_v_gpu_result[i], c_v_cpu[i]);
-  }
+  ASSERT_TRUE(utils::compare_vectors(c_v_gpu_result, c_v_cpu));
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas2/blas2_ger_test.cpp
+++ b/test/unittest/blas2/blas2_ger_test.cpp
@@ -51,8 +51,8 @@ void run_test(const combination_t<scalar_t> combi) {
   std::vector<scalar_t> c_m_gpu_result(lda * n, scalar_t(10));
   // output system vector
   std::vector<scalar_t> c_m_cpu(lda * n, scalar_t(10));
-  blas_test_t::set_rand(a_v, m * incX);
-  blas_test_t::set_rand(b_v, n * incY);
+  fill_random(a_v);
+  fill_random(b_v);
 
   // SYSTEM GER
   reference_blas::ger(m, n, alpha, a_v.data(), incX, b_v.data(), incY,
@@ -72,9 +72,7 @@ void run_test(const combination_t<scalar_t> combi) {
       m_c_gpu, c_m_gpu_result.data(), lda * n);
   ex.get_policy_handler().wait(event);
 
-  for (int i = 0; i < lda * n; ++i) {
-    ASSERT_T_EQUAL(scalar_t, c_m_gpu_result[i], c_m_cpu[i]);
-  }
+  ASSERT_TRUE(utils::compare_vectors(c_m_gpu_result, c_m_cpu));
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas2/blas2_symv_test.cpp
+++ b/test/unittest/blas2/blas2_symv_test.cpp
@@ -46,11 +46,11 @@ void run_test(const combination_t<scalar_t> combi) {
 
   // Input matrix
   std::vector<scalar_t> a_m(lda * n);
-  blas_test_t::set_rand(a_m, lda * n);
+  fill_random(a_m);
 
   // Input vector
   std::vector<scalar_t> x_v(n * incX);
-  blas_test_t::set_rand(x_v, n * incX);
+  fill_random(x_v);
 
   // Output Vector
   std::vector<scalar_t> y_v(n * incY, 1.0);
@@ -73,9 +73,7 @@ void run_test(const combination_t<scalar_t> combi) {
       ex.get_policy_handler().copy_to_host(y_v_gpu, y_v.data(), n * incY);
   ex.get_policy_handler().wait(event);
 
-  for (int i = 0; i < n * incY; ++i) {
-    ASSERT_T_EQUAL(scalar_t, y_v[i], y_cpu_v[i]);
-  }
+  ASSERT_TRUE(utils::compare_vectors(y_v, y_cpu_v));
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas2/blas2_syr2_test.cpp
+++ b/test/unittest/blas2/blas2_syr2_test.cpp
@@ -46,8 +46,8 @@ void run_test(const combination_t<scalar_t> combi) {
   // Input vector
   std::vector<scalar_t> x_v(n * incX);
   std::vector<scalar_t> y_v(n * incY);
-  blas_test_t::set_rand(x_v, n * incX);
-  blas_test_t::set_rand(y_v, n * incY);
+  fill_random(x_v);
+  fill_random(y_v);
 
   // Output matrix
   std::vector<scalar_t> a_m(n * lda, 7.0);
@@ -70,9 +70,7 @@ void run_test(const combination_t<scalar_t> combi) {
       ex.get_policy_handler().copy_to_host(a_m_gpu, a_m.data(), n * lda);
   ex.get_policy_handler().wait(event);
 
-  for (int i = 0; i < n * lda; ++i) {
-    ASSERT_T_EQUAL(scalar_t, a_m[i], a_cpu_m[i]);
-  }
+  ASSERT_TRUE(utils::compare_vectors(a_m, a_cpu_m));
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas2/blas2_syr_test.cpp
+++ b/test/unittest/blas2/blas2_syr_test.cpp
@@ -44,7 +44,7 @@ void run_test(const combination_t<scalar_t> combi) {
 
   // Input vector
   std::vector<scalar_t> x_v(n * incX);
-  blas_test_t::set_rand(x_v, n * incX);
+  fill_random(x_v);
 
   // Output matrix
   std::vector<scalar_t> a_m(n * lda, 7.0);
@@ -65,9 +65,7 @@ void run_test(const combination_t<scalar_t> combi) {
       ex.get_policy_handler().copy_to_host(a_m_gpu, a_m.data(), n * lda);
   ex.get_policy_handler().wait(event);
 
-  for (int i = 0; i < n * lda; ++i) {
-    ASSERT_T_EQUAL(scalar_t, a_m[i], a_cpu_m[i]);
-  }
+  ASSERT_TRUE(utils::compare_vectors(a_m, a_cpu_m));
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas2/blas2_trmv_test.cpp
+++ b/test/unittest/blas2/blas2_trmv_test.cpp
@@ -49,7 +49,7 @@ void run_test(const combination_t combi) {
 
   // Input matrix
   std::vector<scalar_t> a_m(lda * n);
-  blas_test_t::set_rand(a_m, lda * n);
+  fill_random(a_m);
 
   // Output Vector
   std::vector<scalar_t> x_v(n * incX, 7.0);
@@ -79,9 +79,7 @@ void run_test(const combination_t combi) {
       ex.get_policy_handler().copy_to_host(x_v_gpu, x_v.data(), n * incX);
   ex.get_policy_handler().wait(event);
 
-  for (int i = 0; i < n * incX; ++i) {
-    ASSERT_T_EQUAL(scalar_t, x_v[i], x_cpu_v[i]);
-  }
+  ASSERT_TRUE(utils::compare_vectors(x_v, x_cpu_v));
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas3/blas3_gemm_batched_test.cpp
+++ b/test/unittest/blas3/blas3_gemm_batched_test.cpp
@@ -81,9 +81,9 @@ void run_test(const combination_t<scalar_t> combi) {
   std::vector<scalar_t> c_m_gpu(_size(dim_c, ldc_mul));
   std::vector<scalar_t> c_m_cpu(_size(dim_c, ldc_mul));
 
-  blas_test_t::set_rand(a_m, _size(dim_a, lda_mul));
-  blas_test_t::set_rand(b_m, _size(dim_b, ldb_mul));
-  blas_test_t::set_rand(c_m_gpu, _size(dim_c, ldc_mul));
+  fill_random(a_m);
+  fill_random(b_m);
+  fill_random(c_m_gpu);
   std::copy(c_m_gpu.begin(), c_m_gpu.end(), c_m_cpu.begin());
 
   auto m_a_gpu =
@@ -112,9 +112,7 @@ void run_test(const combination_t<scalar_t> combi) {
                                            _size(dim_c, ldc_mul));
   policy_handler.wait(event);
 
-  for (int i = 0; i < _size(dim_c, ldc_mul); ++i) {
-    ASSERT_T_EQUAL(scalar_t, c_m_gpu[i], c_m_cpu[i]);
-  }
+  ASSERT_TRUE(utils::compare_vectors(c_m_gpu, c_m_cpu));
 
   policy_handler.template deallocate<scalar_t>(m_a_gpu);
   policy_handler.template deallocate<scalar_t>(m_b_gpu);

--- a/test/unittest/blas3/blas3_gemm_test.cpp
+++ b/test/unittest/blas3/blas3_gemm_test.cpp
@@ -81,9 +81,9 @@ void run_test(const combination_t<scalar_t> combi) {
   std::vector<scalar_t> c_m_gpu(_size(dim_c, ldc_mul));
   std::vector<scalar_t> c_m_cpu(_size(dim_c, ldc_mul));
 
-  blas_test_t::set_rand(a_m, _size(dim_a, lda_mul));
-  blas_test_t::set_rand(b_m, _size(dim_b, ldb_mul));
-  blas_test_t::set_rand(c_m_gpu, _size(dim_c, ldc_mul));
+  fill_random(a_m);
+  fill_random(b_m);
+  fill_random(c_m_gpu);
   std::copy(c_m_gpu.begin(), c_m_gpu.end(), c_m_cpu.begin());
 
   auto m_a_gpu =
@@ -116,15 +116,14 @@ void run_test(const combination_t<scalar_t> combi) {
           m_b_gpu + _base(dim_b, ldb_mul, bs), ldb, beta,
           m_c_gpu + _base(dim_c, ldc_mul, bs), ldc);
 
-    auto event = policy_handler.copy_to_host(
-        m_c_gpu + _base(dim_c, ldc_mul, bs),
-        c_m_gpu.data() + _base(dim_c, ldc_mul, bs), _size_batch(dim_c, ldc_mul));
+    auto event =
+        policy_handler.copy_to_host(m_c_gpu + _base(dim_c, ldc_mul, bs),
+                                    c_m_gpu.data() + _base(dim_c, ldc_mul, bs),
+                                    _size_batch(dim_c, ldc_mul));
     policy_handler.wait(event);
   }
 
-  for (int i = 0; i < _size(dim_c, ldc_mul); ++i) {
-    ASSERT_T_EQUAL(scalar_t, c_m_gpu[i], c_m_cpu[i]);
-  }
+  ASSERT_TRUE(utils::compare_vectors(c_m_gpu, c_m_cpu));
 
   policy_handler.template deallocate<scalar_t>(m_a_gpu);
   policy_handler.template deallocate<scalar_t>(m_b_gpu);


### PR DESCRIPTION
This uses a parametized test now, and compares their values to
those produced by the reference blas (rather than hardcoding the
algorithm).