### PR TITLE
Updated tests for iamax/iamin

### DIFF
--- a/test/unittest/blas1/blas1_iamax_test.cpp
+++ b/test/unittest/blas1/blas1_iamax_test.cpp
@@ -1,7 +1,6 @@
 #include "blas_test.hpp"
+#include "unittest/blas1/blas1_iaminmax_common.hpp"
 #include <limits>
-
-using combination_t = std::tuple<int, int, bool>;
 
 template <typename scalar_t>
 void run_test(const combination_t combi) {
@@ -9,20 +8,18 @@ void run_test(const combination_t combi) {
 
   int size;
   int incX;
-  bool all_max;
-  std::tie(size, incX, all_max) = combi;
+  generation_mode_t mode;
+  std::tie(size, incX, mode) = combi;
 
   // Input vector
-  std::vector<scalar_t> x_v(size * incX, 0.0);
-  if (!all_max) {
-    fill_random(x_v);
-  }
+  std::vector<scalar_t> x_v(size * incX);
+  populate_data<scalar_t>(mode, 0.0, x_v);
 
   // Output scalar
   std::vector<tuple_t> out_s(1, tuple_t(0, 0.0));
 
   // Reference implementation
-  scalar_t out_cpu_s = reference_blas::iamax(size, x_v.data(), incX);
+  int out_cpu_s = reference_blas::iamax(size, x_v.data(), incX);
 
   // SYCL implementation
   auto q = make_queue();
@@ -36,25 +33,13 @@ void run_test(const combination_t combi) {
 
   _iamax(ex, size, gpu_x_v, incX, gpu_out_s);
   auto event = ex.get_policy_handler().copy_to_host(gpu_out_s, out_s.data(), 1);
-  ex.get_policy_handler().wait(event);
+  ex.get_policy_handler().wait();
 
   // Validate the result
   ASSERT_EQ(out_cpu_s, out_s[0].ind);
+  ASSERT_EQ(x_v[out_s[0].ind * incX], out_s[0].val);
+  ASSERT_EQ(x_v[out_cpu_s * incX], out_s[0].val);
 }
-
-#ifdef STRESS_TESTING
-const auto combi =
-    ::testing::Combine(::testing::Values(11, 65, 10000, 1002400),  // size
-                       ::testing::Values(1, 5),                    // incX
-                       ::testing::Values(true, false)  // All zero input
-    );
-#else
-const auto combi =
-    ::testing::Combine(::testing::Values(11, 65, 10000),  // size
-                       ::testing::Values(5),              // incX
-                       ::testing::Values(true, false)     // All max input
-    );
-#endif
 
 class IamaxFloat : public ::testing::TestWithParam<combination_t> {};
 TEST_P(IamaxFloat, test) { run_test<float>(GetParam()); };

--- a/test/unittest/blas1/blas1_iaminmax_common.hpp
+++ b/test/unittest/blas1/blas1_iaminmax_common.hpp
@@ -1,0 +1,79 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename blas1_iaminmax_common.hpp
+ *
+ **************************************************************************/
+
+#ifndef BLAS_TEST_IAMINMAX_COMMON_HPP
+#define BLAS_TEST_IAMINMAX_COMMON_HPP
+
+#include "blas_test.hpp"
+
+enum class generation_mode_t : char {
+  Random = 'r',
+  Limit = 'l',  // The largest (iamin) or smallest (iamax) legal value
+  Incrementing = 'i',
+  Decrementing = 'd'
+};
+
+using combination_t = std::tuple<int, int, generation_mode_t>;
+
+template <typename scalar_t>
+void populate_data(generation_mode_t mode, scalar_t limit,
+                   std::vector<scalar_t> &vec) {
+  switch (mode) {
+    case generation_mode_t::Random:
+      fill_random(vec);
+      break;
+    case generation_mode_t::Limit:
+      std::fill(vec.begin(), vec.end(), limit);
+      break;
+    case generation_mode_t::Incrementing:
+      for (int i = 0; i < vec.size(); i++) {
+        vec[i] = scalar_t(i);
+      }
+      break;
+    case generation_mode_t::Decrementing:
+      for (int i = 0; i < vec.size(); i++) {
+        vec[i] = scalar_t(vec.size() - i - 1);
+      }
+      break;
+  }
+}
+
+#ifdef STRESS_TESTING
+const auto combi = ::testing::Combine(
+    ::testing::Values(11, 65, 10000, 1002400),  // size
+    ::testing::Values(1, 5),                    // incX
+    ::testing::Values(generation_mode_t::Random, generation_mode_t::Limit,
+                      generation_mode_t::Incrementing,
+                      generation_mode_t::Decrementing));
+#else
+const auto combi = ::testing::Combine(
+    ::testing::Values(11, 65, 1000000),  // size
+    ::testing::Values(5),                // incX
+    ::testing::Values(generation_mode_t::Random, generation_mode_t::Limit,
+                      generation_mode_t::Incrementing,
+                      generation_mode_t::Decrementing));
+#endif
+
+#endif


### PR DESCRIPTION
It now has four "profiles" which determine the generation of the
data. Also added a common header file so that the code for these
profiles isn't duplicated.

We also don't write the reference blas output into a float/double,
because that was wrong.