### PR TITLE
Constant refactoring

### DIFF
--- a/benchmark/syclblas/blas1/iamax.cpp
+++ b/benchmark/syclblas/blas1/iamax.cpp
@@ -46,21 +46,21 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
 
   // Create data
   std::vector<scalar_t> v1 = blas_benchmark::utils::random_data<scalar_t>(size);
-  blas::IndexValueTuple<scalar_t, index_t> out(-1, -1);
+  blas::IndexValueTuple<index_t, scalar_t> out(-1, 0);
 
   auto inx = blas::make_sycl_iterator_buffer<scalar_t>(v1, size);
   auto outI =
-      blas::make_sycl_iterator_buffer<blas::IndexValueTuple<scalar_t, index_t>>(
+      blas::make_sycl_iterator_buffer<blas::IndexValueTuple<index_t, scalar_t>>(
           &out, 1);
 
 #ifdef BLAS_VERIFY_BENCHMARK
   // Run a first time with a verification of the results
   index_t idx_ref =
       static_cast<index_t>(reference_blas::iamax(size, v1.data(), 1));
-  blas::IndexValueTuple<scalar_t, index_t> idx_temp(-1, -1);
+  blas::IndexValueTuple<index_t, scalar_t> idx_temp(-1, 0);
   {
     auto idx_temp_gpu =
-        blas::make_sycl_iterator_buffer<blas::IndexValueTuple<scalar_t, int>>(
+        blas::make_sycl_iterator_buffer<blas::IndexValueTuple<int, scalar_t>>(
             &idx_temp, 1);
     auto event = _iamax(ex, size, inx, 1, idx_temp_gpu);
     ex.get_policy_handler().wait(event);

--- a/benchmark/syclblas/blas1/iamin.cpp
+++ b/benchmark/syclblas/blas1/iamin.cpp
@@ -1,4 +1,5 @@
-/**************************************************************************
+/********************************* IndexValueTuple<index_t, scalar_t>
+    IndexValueTuple<index_t, scalar_t>
  *
  *  @license
  *  Copyright (C) 2016 Codeplay Software Limited
@@ -46,21 +47,21 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
 
   // Create data
   std::vector<scalar_t> v1 = blas_benchmark::utils::random_data<scalar_t>(size);
-  blas::IndexValueTuple<scalar_t, index_t> out(0, 0);
+  blas::IndexValueTuple<index_t, scalar_t> out(0, 0);
 
   auto inx = blas::make_sycl_iterator_buffer<scalar_t>(v1, size);
   auto outI =
-      blas::make_sycl_iterator_buffer<blas::IndexValueTuple<scalar_t, index_t>>(
+      blas::make_sycl_iterator_buffer<blas::IndexValueTuple<index_t, scalar_t>>(
           &out, 1);
 
 #ifdef BLAS_VERIFY_BENCHMARK
   // Run a first time with a verification of the results
   index_t idx_ref =
       static_cast<index_t>(reference_blas::iamin(size, v1.data(), 1));
-  blas::IndexValueTuple<scalar_t, index_t> idx_temp(-1, -1);
+  blas::IndexValueTuple<index_t, scalar_t> idx_temp(-1, -1);
   {
     auto idx_temp_gpu =
-        blas::make_sycl_iterator_buffer<blas::IndexValueTuple<scalar_t, int>>(
+        blas::make_sycl_iterator_buffer<blas::IndexValueTuple<int, scalar_t>>(
             &idx_temp, 1);
     auto event = _iamin(ex, size, inx, 1, idx_temp_gpu);
     ex.get_policy_handler().wait(event);

--- a/benchmark/syclblas/blas1/iamin.cpp
+++ b/benchmark/syclblas/blas1/iamin.cpp
@@ -1,5 +1,4 @@
-/********************************* IndexValueTuple<index_t, scalar_t>
-    IndexValueTuple<index_t, scalar_t>
+/**************************************************************************
  *
  *  @license
  *  Copyright (C) 2016 Codeplay Software Limited

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -23,8 +23,8 @@
 # *
 # **************************************************************************/
 # represent the list of supported handler for executor
-set(executor_list "PolicyHandler<codeplay_policy>") 
-#represent the list of supported index/increment type 
+set(executor_list "PolicyHandler<codeplay_policy>")
+#represent the list of supported index/increment type
 set(index_list "int" )
 #represent the list of supported data type.
 #Each data type in a data list determines the container types.
@@ -38,7 +38,7 @@ endif()
 ## represent the list of bolean options
 set(boolean_list "true" "false")
 
-# gemm_configuration(work_group_size, double_buffer, conflict_a, conflict_b, 
+# gemm_configuration(work_group_size, double_buffer, conflict_a, conflict_b,
 #                    cache_line_size, tir, tic, twr, twc, tlr, tlc, local_mem)
 set(gemm_configuration_lists "")
 
@@ -49,8 +49,8 @@ if(${TARGET} STREQUAL "INTEL_GPU")
   set(gemm_configuration_2 64 "true" "false" "false" 64 4 4 8 8 1 1 "local_memory")
   set(gemm_configuration_3 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local_memory")
   set(gemm_configuration_4 64 "true" "false" "false" 64 8 8 8 8 1 1 "local_memory")
-  list(APPEND gemm_configuration_lists gemm_configuration_0 gemm_configuration_1 
-                                       gemm_configuration_2 gemm_configuration_3 
+  list(APPEND gemm_configuration_lists gemm_configuration_0 gemm_configuration_1
+                                       gemm_configuration_2 gemm_configuration_3
                                        gemm_configuration_4)
 elseif(${TARGET} STREQUAL "RCAR") # need investigation
 
@@ -61,7 +61,7 @@ elseif(${TARGET} STREQUAL "ARM_GPU")
   set(gemm_configuration_0 64 "false" "false" "false" 64 4 4 8 8 1 1 "no_local_memory")
   set(gemm_configuration_1 128 "false" "false" "false" 64 4 8 16 8 1 1 "no_local_memory")
   set(gemm_configuration_2 32 "false" "false" "false" 64 8 4 4 8 1 1 "no_local_memory")
-  list(APPEND gemm_configuration_lists gemm_configuration_0 gemm_configuration_1 
+  list(APPEND gemm_configuration_lists gemm_configuration_0 gemm_configuration_1
                                        gemm_configuration_2)
 elseif(${TARGET} STREQUAL "AMD_GPU")  # need investigation
   set(gemm_configuration_0 256 "true" "false" "false" 64 1 1 16 16 1 1 "local_memory")
@@ -114,9 +114,9 @@ foreach(executor ${executor_list})
           STRING(REGEX REPLACE "(\\*|<| |,|>)" "_" file_name ${file_name})
           STRING(REGEX REPLACE "(___|__)" "_" file_name ${file_name})
           add_custom_command(OUTPUT "${LOCATION}/${file_name}"
-            COMMAND ${PYTHON_EXECUTABLE} ${SYCLBLAS_SRC_GENERATOR}/py_gen_blas_unary.py 
+            COMMAND ${PYTHON_EXECUTABLE} ${SYCLBLAS_SRC_GENERATOR}/py_gen_blas_unary.py
               ${PROJECT_SOURCE_DIR}/external/
-              ${SYCLBLAS_SRC_GENERATOR}/gen 
+              ${SYCLBLAS_SRC_GENERATOR}/gen
               ${blas_level}
               ${func}
               ${SYCLBLAS_SRC}/interface/${blas_level}/${func}.cpp.in
@@ -159,9 +159,9 @@ foreach(executor ${executor_list})
             STRING(REGEX REPLACE "(\\*|<| |,|>)" "_" file_name ${file_name})
             STRING(REGEX REPLACE "(___|__)" "_" file_name ${file_name})
             add_custom_command(OUTPUT "${LOCATION}/${file_name}"
-              COMMAND ${PYTHON_EXECUTABLE} ${SYCLBLAS_SRC_GENERATOR}/py_gen_blas_binary.py 
+              COMMAND ${PYTHON_EXECUTABLE} ${SYCLBLAS_SRC_GENERATOR}/py_gen_blas_binary.py
                 ${PROJECT_SOURCE_DIR}/external/
-                ${SYCLBLAS_SRC_GENERATOR}/gen 
+                ${SYCLBLAS_SRC_GENERATOR}/gen
                 ${blas_level}
                 ${func}
                 ${SYCLBLAS_SRC}/interface/${blas_level}/${func}.cpp.in
@@ -200,7 +200,7 @@ foreach(executor ${executor_list})
   foreach(data ${data_list})
     set(container_list_in "BufferIterator<${data},codeplay_policy>")
     foreach(index ${index_list})
-      set(container_list_out "BufferIterator<IndexValueTuple<${data},${index}>,codeplay_policy>")
+      set(container_list_out "BufferIterator<IndexValueTuple<${index},${data}>,codeplay_policy>")
       foreach(container0 ${container_list_in})
         foreach(container1 ${container_list_out})
           foreach(increment ${index_list})
@@ -208,9 +208,9 @@ foreach(executor ${executor_list})
             STRING(REGEX REPLACE "(\\*|<| |,|>)" "_" file_name ${file_name})
             STRING(REGEX REPLACE "(___|__)" "_" file_name ${file_name})
             add_custom_command(OUTPUT "${LOCATION}/${file_name}"
-              COMMAND ${PYTHON_EXECUTABLE} ${SYCLBLAS_SRC_GENERATOR}/py_gen_blas_binary_special.py 
+              COMMAND ${PYTHON_EXECUTABLE} ${SYCLBLAS_SRC_GENERATOR}/py_gen_blas_binary_special.py
                 ${PROJECT_SOURCE_DIR}/external/
-                ${SYCLBLAS_SRC_GENERATOR}/gen 
+                ${SYCLBLAS_SRC_GENERATOR}/gen
                 ${blas_level}
                 ${func}
                 ${SYCLBLAS_SRC}/interface/${blas_level}/${func}.cpp.in
@@ -257,9 +257,9 @@ foreach(executor ${executor_list})
               STRING(REGEX REPLACE "(\\*|<| |,|>)" "_" file_name ${file_name})
               STRING(REGEX REPLACE "(___|__)" "_" file_name ${file_name})
               add_custom_command(OUTPUT "${LOCATION}/${file_name}"
-                COMMAND ${PYTHON_EXECUTABLE} ${SYCLBLAS_SRC_GENERATOR}/py_gen_blas_ternary.py 
+                COMMAND ${PYTHON_EXECUTABLE} ${SYCLBLAS_SRC_GENERATOR}/py_gen_blas_ternary.py
                   ${PROJECT_SOURCE_DIR}/external/
-                  ${SYCLBLAS_SRC_GENERATOR}/gen 
+                  ${SYCLBLAS_SRC_GENERATOR}/gen
                   ${blas_level}
                   ${func}
                   ${SYCLBLAS_SRC}/interface/${blas_level}/${func}.cpp.in
@@ -323,9 +323,9 @@ set(LOCATION "${SYCLBLAS_GENERATED_SRC}/${blas_level}/${func}/")
                     STRING(REGEX REPLACE "(\\*|<| |,|>)" "_" file_name ${file_name})
                     STRING(REGEX REPLACE "(___|__)" "_" file_name ${file_name})
                     add_custom_command(OUTPUT "${LOCATION}/${file_name}"
-                      COMMAND ${PYTHON_EXECUTABLE} ${SYCLBLAS_SRC_GENERATOR}/py_gen_blas_gemm_launcher.py 
+                      COMMAND ${PYTHON_EXECUTABLE} ${SYCLBLAS_SRC_GENERATOR}/py_gen_blas_gemm_launcher.py
                         ${PROJECT_SOURCE_DIR}/external/
-                        ${SYCLBLAS_SRC_GENERATOR}/gen 
+                        ${SYCLBLAS_SRC_GENERATOR}/gen
                         ${blas_level}
                         ${func}
                         ${SYCLBLAS_SRC}/interface/${blas_level}/${func}.cpp.in
@@ -371,7 +371,7 @@ endfunction(generate_blas_gemm_objects)
 
 function (build_library LIB_NAME LIB_TYPE)
 add_library(${LIB_NAME} ${LIB_TYPE}
-                             $<TARGET_OBJECTS:sycl_policy> 
+                             $<TARGET_OBJECTS:sycl_policy>
                              $<TARGET_OBJECTS:axpy>
                              $<TARGET_OBJECTS:asum>
                              $<TARGET_OBJECTS:asum_return>

--- a/include/operations/blas1_trees.h
+++ b/include/operations/blas1_trees.h
@@ -147,7 +147,7 @@ struct BinaryOp {
 template <typename rhs_t>
 struct TupleOp {
   using index_t = typename rhs_t::index_t;
-  using value_t = IndexValueTuple<typename rhs_t::value_t, index_t>;
+  using value_t = IndexValueTuple<index_t, typename rhs_t::value_t>;
   rhs_t rhs_;
   TupleOp(rhs_t &_r);
   index_t get_size() const;

--- a/include/operations/blas_constants.h
+++ b/include/operations/blas_constants.h
@@ -35,15 +35,16 @@ namespace blas {
 /*!
 @brief Container for a scalar value and an index.
 */
-template <typename scalar_t, typename index_t>
+template <typename ix_t, typename val_t>
 struct IndexValueTuple {
-  using value_t = scalar_t;
-  using ind_t = index_t;
-  value_t val;
+  using value_t = val_t;
+  using index_t = ix_t;
+
   index_t ind;
+  value_t val;
 
   constexpr explicit IndexValueTuple(index_t _ind, value_t _val)
-      : val(_val), ind(_ind){};
+      : ind(_ind), val(_val){};
   SYCL_BLAS_INLINE index_t get_index() const { return ind; }
   SYCL_BLAS_INLINE value_t get_value() const { return val; }
 };
@@ -51,109 +52,17 @@ struct IndexValueTuple {
 /*!
 @brief Enum class used to indicate a constant value associated with a type.
 */
-// enum class const_val : int {
-//   zero = 0,
-//   one = 1,
-//   m_one = -1,
-//   two = 2,
-//   m_two = -2,
-//   max = 3,
-//   min = 4,
-//   abs_max = 5,
-//   abs_min = 6,
-// };
-
-namespace const_val {
-
-struct zero {
-  template <typename value_t>
-  constexpr static SYCL_BLAS_INLINE value_t value() {
-    return static_cast<value_t>(0);
-  }
+enum class const_val : int {
+  zero = 0,
+  one = 1,
+  m_one = -1,
+  two = 2,
+  m_two = -2,
+  max = 3,
+  min = 4,
+  abs_max = 5,
+  abs_min = 6,
 };
-
-struct one {
-  template <typename value_t>
-  constexpr static SYCL_BLAS_INLINE value_t value() {
-    return static_cast<value_t>(1);
-  }
-};
-
-struct m_one {
-  template <typename value_t>
-  constexpr static SYCL_BLAS_INLINE value_t value() {
-    return static_cast<value_t>(-1);
-  }
-};
-
-struct two {
-  template <typename value_t>
-  constexpr static SYCL_BLAS_INLINE value_t value() {
-    return static_cast<value_t>(2);
-  }
-};
-
-struct m_two {
-  template <typename value_t>
-  constexpr static SYCL_BLAS_INLINE value_t value() {
-    return static_cast<value_t>(-2);
-  }
-};
-
-struct max {
-  template <typename value_t>
-  constexpr static SYCL_BLAS_INLINE value_t value() {
-    return std::numeric_limits<value_t>::max();
-  }
-};
-
-struct min {
-  template <typename value_t>
-  constexpr static SYCL_BLAS_INLINE value_t value() {
-    return std::numeric_limits<value_t>::min();
-  }
-};
-
-struct abs_max {
-  template <typename value_t>
-  constexpr static SYCL_BLAS_INLINE value_t value() {
-    return std::numeric_limits<value_t>::max();
-  }
-};
-
-struct abs_min {
-  template <typename value_t>
-  constexpr static SYCL_BLAS_INLINE value_t value() {
-    return static_cast<value_t>(0);
-  }
-};
-
-// template <typename value_const>
-// struct complex {
-//   template <typename elem_t>
-//   constexpr static SYCL_BLAS_INLINE std::complex<value_t> value() {
-//     return std::complex<value_t>(value_const::value<value_t>(),
-//                                  value_const::value<value_t>());
-//   }
-// };
-
-template <typename value_const, typename index_const>
-struct index_val {
-  template <typename tuple_t>
-  constexpr static SYCL_BLAS_INLINE tuple_t value() {
-    return tuple_t(index_const::template value<typename tuple_t::ind_t>(),
-                   value_const::template value<typename tuple_t::value_t>());
-  }
-};
-
-}  // namespace const_val
-
-// template <typename elem_t, typename init_t>
-// struct constant {
-//   constexpr static SYCL_BLAS_INLINE elem_t value() {
-//     return init_t::<elem_t> value();
-//   };
-// };
 
 /*!
 @brief Template struct used to represent constants within a compile-time
@@ -162,70 +71,57 @@ variable of the type value_t initialized to the specified constant.
 @tparam value_t Value type of the constant.
 @tparam kIndicator Enumeration specifying the constant.
 */
-// template <typename value_t, const_val Indicator>
-// struct constant {
-//   constexpr static SYCL_BLAS_INLINE value_t value() {
-//     return static_cast<value_t>(Indicator);
-//   }
-// };
+template <typename value_t, const_val Indicator>
+struct constant {
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return static_cast<value_t>(Indicator);
+  }
+};
 
-// template <typename value_t>
-// struct constant<value_t, const_val::max> {
-//   constexpr static SYCL_BLAS_INLINE value_t value() {
-//     return std::numeric_limits<value_t>::max();
-//   }
-// };
+template <typename value_t>
+struct constant<value_t, const_val::max> {
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return std::numeric_limits<value_t>::max();
+  }
+};
 
-// template <typename value_t>
-// struct constant<value_t, const_val::min> {
-//   constexpr static SYCL_BLAS_INLINE value_t value() {
-//     return std::numeric_limits<value_t>::min();
-//   }
-// };
+template <typename value_t>
+struct constant<value_t, const_val::min> {
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return std::numeric_limits<value_t>::min();
+  }
+};
 
-// template <typename value_t>
-// struct constant<value_t, const_val::abs_max> {
-//   constexpr static SYCL_BLAS_INLINE value_t value() {
-//     return std::numeric_limits<value_t>::max();
-//   }
-// };
+template <typename value_t>
+struct constant<value_t, const_val::abs_max> {
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return std::numeric_limits<value_t>::max();
+  }
+};
 
-// template <typename value_t>
-// struct constant<value_t, const_val::abs_min> {
-//   constexpr static SYCL_BLAS_INLINE value_t value() {
-//     return static_cast<value_t>(0);
-//   }
-// };
+template <typename value_t>
+struct constant<value_t, const_val::abs_min> {
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return static_cast<value_t>(0);
+  }
+};
 
-// template <typename value_t, typename index_t>
-// struct constant<IndexValueTuple<value_t, index_t>, const_val::abs_min> {
-//   constexpr static SYCL_BLAS_INLINE IndexValueTuple<value_t, index_t> value()
-//   {
-//     return IndexValueTuple<value_t, index_t>(
-//         constant<index_t, const_val::max>::value(),
-//         constant<value_t, const_val::abs_min>::
-//             value());  // This is used for absolute max, -1 == 1
-//   }
-// };
+template <typename value_t, const_val Indicator>
+struct constant<std::complex<value_t>, Indicator> {
+  constexpr static SYCL_BLAS_INLINE std::complex<value_t> value() {
+    return std::complex<value_t>(constant<value_t, Indicator>::value(),
+                                 constant<value_t, Indicator>::value());
+  }
+};
 
-// template <typename value_t, typename index_t>
-// struct constant<IndexValueTuple<value_t, index_t>, const_val::abs_max> {
-//   constexpr static SYCL_BLAS_INLINE IndexValueTuple<value_t, index_t> value()
-//   {
-//     return IndexValueTuple<value_t, index_t>(
-//         constant<index_t, const_val::max>::value(),
-//         constant<value_t, const_val::abs_max>::value());
-//     // This is used for absolute max, -1 == 1
-//   }
-// };
-
-// template <typename value_t, const_val Indicator>
-// struct constant<std::complex<value_t>, Indicator> {
-//   constexpr static SYCL_BLAS_INLINE std::complex<value_t> value() {
-//     return std::complex<value_t>(constant<value_t, Indicator>::value(),
-//                                  constant<value_t, Indicator>::value());
-//   }
-// };
+template <typename iv_type, const_val IndexIndicator, const_val ValueIndicator>
+struct constant_pair {
+  constexpr static SYCL_BLAS_INLINE iv_type value() {
+    return iv_type(
+        constant<typename iv_type::index_t, IndexIndicator>::value(),
+        constant<typename iv_type::value_t, ValueIndicator>::value());
+  }
+};
 
 }  // namespace blas
 

--- a/include/operations/blas_constants.h
+++ b/include/operations/blas_constants.h
@@ -38,6 +38,7 @@ namespace blas {
 template <typename scalar_t, typename index_t>
 struct IndexValueTuple {
   using value_t = scalar_t;
+  using ind_t = index_t;
   value_t val;
   index_t ind;
 
@@ -50,81 +51,181 @@ struct IndexValueTuple {
 /*!
 @brief Enum class used to indicate a constant value associated with a type.
 */
-enum class const_val : int {
-  zero = 0,
-  one = 1,
-  m_one = -1,
-  two = 2,
-  m_two = -2,
-  max = 3,
-  min = 4,
-  imax = 5,
-  imin = 6
-};
-/*!
-@def define a specialization of the constant template value for each indicator.
-@ref ConstValue.
-@tparam primitive_t The value type to specialize for.
-@tparam Indicator The constant to specialize for.
-*/
-template <typename primitive_t, const_val Indicator>
-struct ConstValue {
-  constexpr static SYCL_BLAS_INLINE primitive_t init() {
-    return static_cast<primitive_t>(static_cast<int>(Indicator));
-  }
-};
-template <typename primitive_t>
-struct ConstValue<primitive_t, const_val::max> {
-  constexpr static SYCL_BLAS_INLINE primitive_t init() {
-    return std::numeric_limits<primitive_t>::min();
+// enum class const_val : int {
+//   zero = 0,
+//   one = 1,
+//   m_one = -1,
+//   two = 2,
+//   m_two = -2,
+//   max = 3,
+//   min = 4,
+//   abs_max = 5,
+//   abs_min = 6,
+// };
+
+namespace const_val {
+
+struct zero {
+  template <typename value_t>
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return static_cast<value_t>(0);
   }
 };
 
-template <typename primitive_t>
-struct ConstValue<primitive_t, const_val::min> {
-  constexpr static SYCL_BLAS_INLINE primitive_t init() {
-    return std::numeric_limits<primitive_t>::max();
+struct one {
+  template <typename value_t>
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return static_cast<value_t>(1);
   }
 };
+
+struct m_one {
+  template <typename value_t>
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return static_cast<value_t>(-1);
+  }
+};
+
+struct two {
+  template <typename value_t>
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return static_cast<value_t>(2);
+  }
+};
+
+struct m_two {
+  template <typename value_t>
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return static_cast<value_t>(-2);
+  }
+};
+
+struct max {
+  template <typename value_t>
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return std::numeric_limits<value_t>::max();
+  }
+};
+
+struct min {
+  template <typename value_t>
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return std::numeric_limits<value_t>::min();
+  }
+};
+
+struct abs_max {
+  template <typename value_t>
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return std::numeric_limits<value_t>::max();
+  }
+};
+
+struct abs_min {
+  template <typename value_t>
+  constexpr static SYCL_BLAS_INLINE value_t value() {
+    return static_cast<value_t>(0);
+  }
+};
+
+// template <typename value_const>
+// struct complex {
+//   template <typename elem_t>
+//   constexpr static SYCL_BLAS_INLINE std::complex<value_t> value() {
+//     return std::complex<value_t>(value_const::value<value_t>(),
+//                                  value_const::value<value_t>());
+//   }
+// };
+
+template <typename value_const, typename index_const>
+struct index_val {
+  template <typename tuple_t>
+  constexpr static SYCL_BLAS_INLINE tuple_t value() {
+    return tuple_t(index_const::template value<typename tuple_t::ind_t>(),
+                   value_const::template value<typename tuple_t::value_t>());
+  }
+};
+
+}  // namespace const_val
+
+// template <typename elem_t, typename init_t>
+// struct constant {
+//   constexpr static SYCL_BLAS_INLINE elem_t value() {
+//     return init_t::<elem_t> value();
+//   };
+// };
 
 /*!
 @brief Template struct used to represent constants within a compile-time
-expression tree, each instantiation will have a static constexpr member variable
-of the type value_t initialized to the specified constant.
+expression tree, each instantiation will have a static constexpr member
+variable of the type value_t initialized to the specified constant.
 @tparam value_t Value type of the constant.
 @tparam kIndicator Enumeration specifying the constant.
 */
-template <typename value_t, const_val Indicator>
-struct constant {
-  constexpr static SYCL_BLAS_INLINE value_t value() {
-    return ConstValue<value_t, Indicator>::init();
-  }
-};
+// template <typename value_t, const_val Indicator>
+// struct constant {
+//   constexpr static SYCL_BLAS_INLINE value_t value() {
+//     return static_cast<value_t>(Indicator);
+//   }
+// };
 
-template <typename value_t, typename index_t>
-struct constant<IndexValueTuple<value_t, index_t>, const_val::imax> {
-  constexpr static SYCL_BLAS_INLINE IndexValueTuple<value_t, index_t> value() {
-    return IndexValueTuple<value_t, index_t>(
-        std::numeric_limits<index_t>::max(),
-        static_cast<value_t>(0)); // This is used for absolute max, -1 == 1
-  }
-};
+// template <typename value_t>
+// struct constant<value_t, const_val::max> {
+//   constexpr static SYCL_BLAS_INLINE value_t value() {
+//     return std::numeric_limits<value_t>::max();
+//   }
+// };
 
-template <typename value_t, typename index_t>
-struct constant<IndexValueTuple<value_t, index_t>, const_val::imin> {
-  constexpr static SYCL_BLAS_INLINE IndexValueTuple<value_t, index_t> value() {
-    return IndexValueTuple<value_t, index_t>(
-        std::numeric_limits<index_t>::max(),
-        std::numeric_limits<value_t>::max());
-  }
-};
-template <typename value_t, const_val Indicator>
-struct constant<std::complex<value_t>, Indicator> {
-  constexpr static SYCL_BLAS_INLINE std::complex<value_t> value() {
-    return std::complex<value_t>(ConstValue<value_t, Indicator>::init(),
-                                 ConstValue<value_t, Indicator>::init());
-  }
-};
+// template <typename value_t>
+// struct constant<value_t, const_val::min> {
+//   constexpr static SYCL_BLAS_INLINE value_t value() {
+//     return std::numeric_limits<value_t>::min();
+//   }
+// };
+
+// template <typename value_t>
+// struct constant<value_t, const_val::abs_max> {
+//   constexpr static SYCL_BLAS_INLINE value_t value() {
+//     return std::numeric_limits<value_t>::max();
+//   }
+// };
+
+// template <typename value_t>
+// struct constant<value_t, const_val::abs_min> {
+//   constexpr static SYCL_BLAS_INLINE value_t value() {
+//     return static_cast<value_t>(0);
+//   }
+// };
+
+// template <typename value_t, typename index_t>
+// struct constant<IndexValueTuple<value_t, index_t>, const_val::abs_min> {
+//   constexpr static SYCL_BLAS_INLINE IndexValueTuple<value_t, index_t> value()
+//   {
+//     return IndexValueTuple<value_t, index_t>(
+//         constant<index_t, const_val::max>::value(),
+//         constant<value_t, const_val::abs_min>::
+//             value());  // This is used for absolute max, -1 == 1
+//   }
+// };
+
+// template <typename value_t, typename index_t>
+// struct constant<IndexValueTuple<value_t, index_t>, const_val::abs_max> {
+//   constexpr static SYCL_BLAS_INLINE IndexValueTuple<value_t, index_t> value()
+//   {
+//     return IndexValueTuple<value_t, index_t>(
+//         constant<index_t, const_val::max>::value(),
+//         constant<value_t, const_val::abs_max>::value());
+//     // This is used for absolute max, -1 == 1
+//   }
+// };
+
+// template <typename value_t, const_val Indicator>
+// struct constant<std::complex<value_t>, Indicator> {
+//   constexpr static SYCL_BLAS_INLINE std::complex<value_t> value() {
+//     return std::complex<value_t>(constant<value_t, Indicator>::value(),
+//                                  constant<value_t, Indicator>::value());
+//   }
+// };
 
 }  // namespace blas
 

--- a/src/interface/blas1_interface.hpp
+++ b/src/interface/blas1_interface.hpp
@@ -327,7 +327,7 @@ template <typename executor_t, typename container_t, typename index_t,
           typename increment_t>
 index_t _iamax(executor_t &ex, index_t _N, container_t _vx, increment_t _incx) {
   using element_t = typename ValueType<container_t>::type;
-  using IndValTuple = IndexValueTuple<element_t, index_t>;
+  using IndValTuple = IndexValueTuple<index_t, element_t>;
   std::vector<IndValTuple> rsT(1, IndValTuple(index_t(-1), element_t(-1)));
   auto gpu_res =
       make_sycl_iterator_buffer<IndValTuple>(static_cast<index_t>(1));
@@ -345,7 +345,7 @@ template <typename executor_t, typename container_t, typename index_t,
           typename increment_t>
 index_t _iamin(executor_t &ex, index_t _N, container_t _vx, increment_t _incx) {
   using element_t = typename ValueType<container_t>::type;
-  using IndValTuple = IndexValueTuple<element_t, index_t>;
+  using IndValTuple = IndexValueTuple<index_t, element_t>;
   std::vector<IndValTuple> rsT(1, IndValTuple(index_t(-1), element_t(-1)));
   auto gpu_res =
       make_sycl_iterator_buffer<IndValTuple>(static_cast<index_t>(1));

--- a/src/operations/blas_operators.hpp
+++ b/src/operations/blas_operators.hpp
@@ -68,19 +68,19 @@ struct StripASP {
   GENERATE_STRIP_ASP(data_t, local_ptr)     \
   GENERATE_STRIP_ASP(data_t, global_ptr)
 
-#define GENERATE_STRIP_ASP_TUPLE(data_t, index_t, pointer_type)     \
+#define GENERATE_STRIP_ASP_TUPLE(index_t, data_t, pointer_type)     \
   template <>                                                       \
   struct StripASP<                                                  \
       typename std::remove_pointer<typename cl::sycl::pointer_type< \
-          IndexValueTuple<data_t, index_t>>::pointer_t>::type> {    \
-    typedef IndexValueTuple<data_t, index_t> type;                  \
+          IndexValueTuple<index_t, data_t>>::pointer_t>::type> {    \
+    typedef IndexValueTuple<index_t, data_t> type;                  \
   };
 
-#define INDEX_VALUE_STRIP_ASP_LOCATION(data_t, index_t)   \
-  GENERATE_STRIP_ASP_TUPLE(data_t, index_t, constant_ptr) \
-  GENERATE_STRIP_ASP_TUPLE(data_t, index_t, private_ptr)  \
-  GENERATE_STRIP_ASP_TUPLE(data_t, index_t, local_ptr)    \
-  GENERATE_STRIP_ASP_TUPLE(data_t, index_t, global_ptr)
+#define INDEX_VALUE_STRIP_ASP_LOCATION(index_t, data_t)   \
+  GENERATE_STRIP_ASP_TUPLE(index_t, data_t, constant_ptr) \
+  GENERATE_STRIP_ASP_TUPLE(index_t, data_t, private_ptr)  \
+  GENERATE_STRIP_ASP_TUPLE(index_t, data_t, local_ptr)    \
+  GENERATE_STRIP_ASP_TUPLE(index_t, data_t, global_ptr)
 #endif  // __SYCL_DEVICE_ONLY__  && __COMPUTECPP__
 
 /**
@@ -113,12 +113,12 @@ struct AbsoluteValue {
 #if defined(__SYCL_DEVICE_ONLY__) && defined(__COMPUTECPP__)
 GENERATE_STRIP_ASP_LOCATION(double)
 GENERATE_STRIP_ASP_LOCATION(float)
-INDEX_VALUE_STRIP_ASP_LOCATION(float, int)
-INDEX_VALUE_STRIP_ASP_LOCATION(float, long)
-INDEX_VALUE_STRIP_ASP_LOCATION(float, long long)
-INDEX_VALUE_STRIP_ASP_LOCATION(double, int)
-INDEX_VALUE_STRIP_ASP_LOCATION(double, long)
-INDEX_VALUE_STRIP_ASP_LOCATION(double, long long)
+INDEX_VALUE_STRIP_ASP_LOCATION(int, float)
+INDEX_VALUE_STRIP_ASP_LOCATION(long, float)
+INDEX_VALUE_STRIP_ASP_LOCATION(long long, float)
+INDEX_VALUE_STRIP_ASP_LOCATION(int, double)
+INDEX_VALUE_STRIP_ASP_LOCATION(long, double)
+INDEX_VALUE_STRIP_ASP_LOCATION(long long, double)
 #endif
 
 /*!
@@ -127,14 +127,14 @@ Definitions of unary operators
 struct AdditionIdentity : public Operators {
   template <typename rhs_t>
   static SYCL_BLAS_INLINE rhs_t eval(const rhs_t r) {
-    return const_val::zero::value<rhs_t>();
+    return constant<rhs_t, const_val::zero>::value();
   }
 };
 
 struct ProductIdentity : public Operators {
   template <typename rhs_t>
   static SYCL_BLAS_INLINE rhs_t eval(const rhs_t r) {
-    return (const_val::one::value<rhs_t>());
+    return (constant<rhs_t, const_val::one>::value());
   }
 };
 
@@ -185,7 +185,7 @@ struct AddOperator : public Operators {
 
   template <typename rhs_t>
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
-    return const_val::zero::value<typename rhs_t::value_t>();
+    return constant<typename rhs_t::value_t, const_val::zero>::value();
   }
 };
 
@@ -198,7 +198,7 @@ struct ProductOperator : public Operators {
 
   template <typename rhs_t>
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
-    return const_val::one::value<typename rhs_t::value_t>();
+    return constant<typename rhs_t::value_t, const_val::one>::value();
   }
 };
 
@@ -211,7 +211,7 @@ struct DivisionOperator : public Operators {
 
   template <typename rhs_t>
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
-    return const_val::one::value<typename rhs_t::value_t>();
+    return constant<typename rhs_t::value_t, const_val::one>::value();
   }
 };
 
@@ -224,7 +224,7 @@ struct MaxOperator : public Operators {
 
   template <typename rhs_t>
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
-    return const_val::min::value<typename rhs_t::value_t>();
+    return constant<typename rhs_t::value_t, const_val::min>::value();
   }
 };
 
@@ -237,7 +237,7 @@ struct MinOperator : public Operators {
 
   template <typename rhs_t>
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
-    return const_val::max::value<typename rhs_t::value_t>();
+    return constant<typename rhs_t::value_t, const_val::max>::value();
   }
 };
 
@@ -250,7 +250,7 @@ struct AbsoluteAddOperator : public Operators {
 
   template <typename rhs_t>
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
-    return const_val::zero::value<typename rhs_t::value_t>();
+    return constant<typename rhs_t::value_t, const_val::zero>::value();
   }
 };
 
@@ -275,8 +275,8 @@ struct IMaxOperator : public Operators {
 
   template <typename rhs_t>
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
-    return const_val::index_val<const_val::abs_min, const_val::max>::value<
-        typename rhs_t::value_t>();
+    return constant_pair<typename rhs_t::value_t, const_val::max,
+                         const_val::zero>::value();
   }
 };
 
@@ -301,8 +301,8 @@ struct IMinOperator : public Operators {
 
   template <typename rhs_t>
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
-    return const_val::index_val<const_val::abs_max, const_val::max>::value<
-        typename rhs_t::value_t>();
+    return constant_pair<typename rhs_t::value_t, const_val::max,
+                         const_val::abs_max>::value();
   }
 };
 

--- a/src/operations/blas_operators.hpp
+++ b/src/operations/blas_operators.hpp
@@ -39,39 +39,6 @@
 namespace blas {
 struct Operators {};
 
-/*!
-@def Macro for defining a unary operator.
-@param name Name of the operator.
-@param expr Return expression of the eval function of the oeprator.
-*/
-#define SYCLBLAS_DEFINE_UNARY_OPERATOR(name, expr)      \
-  struct name : public Operators {                      \
-    template <typename rhs_t>                           \
-    static SYCL_BLAS_INLINE rhs_t eval(const rhs_t r) { \
-      return expr;                                      \
-    }                                                   \
-  };
-
-/*!
-@brief Macro for defining a binary operator.
-@param name Name of the operator.
-@param inital Initial value used in the init function of the operator.
-@param expr Return expression of the eval function of the operator.
-*/
-#define SYCLBLAS_DEFINE_BINARY_OPERATOR(Name, initial_t, expr)         \
-  struct Name : public Operators {                                     \
-    template <typename lhs_t, typename rhs_t>                          \
-    static SYCL_BLAS_INLINE typename StripASP<rhs_t>::type eval(       \
-        const lhs_t &l, const rhs_t &r) {                              \
-      return expr;                                                     \
-    }                                                                  \
-                                                                       \
-    template <typename rhs_t>                                          \
-    constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() { \
-      return constant<typename rhs_t::value_t, initial_t>::value();    \
-    }                                                                  \
-  };
-
 /* StripASP.
  * When using ComputeCpp CE, the Device Compiler uses Address Spaces
  * to deal with the different global memories.
@@ -155,51 +122,189 @@ INDEX_VALUE_STRIP_ASP_LOCATION(double, long long)
 #endif
 
 /*!
-Definitions of unary, bianry and ternary operators using the above macros.
+Definitions of unary operators
 */
-SYCLBLAS_DEFINE_UNARY_OPERATOR(AdditionIdentity,
-                               (constant<rhs_t, const_val::zero>::value()))
-SYCLBLAS_DEFINE_UNARY_OPERATOR(ProductIdentity,
-                               (constant<rhs_t, const_val::one>::value()))
-SYCLBLAS_DEFINE_UNARY_OPERATOR(IdentityOperator, (r))
-SYCLBLAS_DEFINE_UNARY_OPERATOR(NegationOperator, (-r))
-SYCLBLAS_DEFINE_UNARY_OPERATOR(SqrtOperator, (cl::sycl::sqrt(r)))
-SYCLBLAS_DEFINE_UNARY_OPERATOR(DoubleOperator, (r + r))
-SYCLBLAS_DEFINE_UNARY_OPERATOR(SquareOperator, (r * r))
-SYCLBLAS_DEFINE_BINARY_OPERATOR(AddOperator, const_val::zero, (l + r))
-SYCLBLAS_DEFINE_BINARY_OPERATOR(ProductOperator, const_val::one, (l * r))
-SYCLBLAS_DEFINE_BINARY_OPERATOR(DivisionOperator, const_val::one, (l / r))
-SYCLBLAS_DEFINE_BINARY_OPERATOR(MaxOperator, const_val::min, ((l > r) ? l : r))
-SYCLBLAS_DEFINE_BINARY_OPERATOR(MinOperator, const_val::max, ((l < r) ? l : r))
-SYCLBLAS_DEFINE_BINARY_OPERATOR(AbsoluteAddOperator, const_val::zero,
-                                (AbsoluteValue::eval(l) +
-                                 AbsoluteValue::eval(r)))
-SYCLBLAS_DEFINE_BINARY_OPERATOR(
-    IMaxOperator, const_val::imax,
-    (AbsoluteValue::eval(
-         static_cast<typename StripASP<lhs_t>::type>(l).get_value()) <
-         AbsoluteValue::eval(
-             static_cast<typename StripASP<rhs_t>::type>(r).get_value()) ||
-     (AbsoluteValue::eval(
-          static_cast<typename StripASP<lhs_t>::type>(l).get_value()) ==
-          AbsoluteValue::eval(
-              static_cast<typename StripASP<rhs_t>::type>(r).get_value()) &&
-      l.get_index() > r.get_index()))
-        ? static_cast<typename StripASP<rhs_t>::type>(r)
-        : static_cast<typename StripASP<lhs_t>::type>(l))
-SYCLBLAS_DEFINE_BINARY_OPERATOR(
-    IMinOperator, const_val::imin,
-    (AbsoluteValue::eval(
-         static_cast<typename StripASP<lhs_t>::type>(l).get_value()) >
-         AbsoluteValue::eval(
-             static_cast<typename StripASP<rhs_t>::type>(r).get_value()) ||
-     (AbsoluteValue::eval(
-          static_cast<typename StripASP<lhs_t>::type>(l).get_value()) ==
-          AbsoluteValue::eval(
-              static_cast<typename StripASP<rhs_t>::type>(r).get_value()) &&
-      l.get_index() > r.get_index()))
-        ? static_cast<typename StripASP<rhs_t>::type>(r)
-        : static_cast<typename StripASP<lhs_t>::type>(l))
+struct AdditionIdentity : public Operators {
+  template <typename rhs_t>
+  static SYCL_BLAS_INLINE rhs_t eval(const rhs_t r) {
+    return const_val::zero::value<rhs_t>();
+  }
+};
+
+struct ProductIdentity : public Operators {
+  template <typename rhs_t>
+  static SYCL_BLAS_INLINE rhs_t eval(const rhs_t r) {
+    return (const_val::one::value<rhs_t>());
+  }
+};
+
+struct IdentityOperator : public Operators {
+  template <typename rhs_t>
+  static SYCL_BLAS_INLINE rhs_t eval(const rhs_t r) {
+    return (r);
+  }
+};
+
+struct NegationOperator : public Operators {
+  template <typename rhs_t>
+  static SYCL_BLAS_INLINE rhs_t eval(const rhs_t r) {
+    return (-r);
+  }
+};
+
+struct SqrtOperator : public Operators {
+  template <typename rhs_t>
+  static SYCL_BLAS_INLINE rhs_t eval(const rhs_t r) {
+    return (cl::sycl::sqrt(r));
+  }
+};
+
+struct DoubleOperator : public Operators {
+  template <typename rhs_t>
+  static SYCL_BLAS_INLINE rhs_t eval(const rhs_t r) {
+    return (r + r);
+  }
+};
+
+struct SquareOperator : public Operators {
+  template <typename rhs_t>
+  static SYCL_BLAS_INLINE rhs_t eval(const rhs_t r) {
+    return (r * r);
+  }
+};
+
+/*!
+ Definitions of binary operators
+*/
+struct AddOperator : public Operators {
+  template <typename lhs_t, typename rhs_t>
+  static SYCL_BLAS_INLINE typename StripASP<rhs_t>::type eval(const lhs_t &l,
+                                                              const rhs_t &r) {
+    return (l + r);
+  }
+
+  template <typename rhs_t>
+  constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
+    return const_val::zero::value<typename rhs_t::value_t>();
+  }
+};
+
+struct ProductOperator : public Operators {
+  template <typename lhs_t, typename rhs_t>
+  static SYCL_BLAS_INLINE typename StripASP<rhs_t>::type eval(const lhs_t &l,
+                                                              const rhs_t &r) {
+    return (l * r);
+  }
+
+  template <typename rhs_t>
+  constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
+    return const_val::one::value<typename rhs_t::value_t>();
+  }
+};
+
+struct DivisionOperator : public Operators {
+  template <typename lhs_t, typename rhs_t>
+  static SYCL_BLAS_INLINE typename StripASP<rhs_t>::type eval(const lhs_t &l,
+                                                              const rhs_t &r) {
+    return (l / r);
+  }
+
+  template <typename rhs_t>
+  constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
+    return const_val::one::value<typename rhs_t::value_t>();
+  }
+};
+
+struct MaxOperator : public Operators {
+  template <typename lhs_t, typename rhs_t>
+  static SYCL_BLAS_INLINE typename StripASP<rhs_t>::type eval(const lhs_t &l,
+                                                              const rhs_t &r) {
+    return ((l > r) ? l : r);
+  }
+
+  template <typename rhs_t>
+  constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
+    return const_val::min::value<typename rhs_t::value_t>();
+  }
+};
+
+struct MinOperator : public Operators {
+  template <typename lhs_t, typename rhs_t>
+  static SYCL_BLAS_INLINE typename StripASP<rhs_t>::type eval(const lhs_t &l,
+                                                              const rhs_t &r) {
+    return ((l < r) ? l : r);
+  }
+
+  template <typename rhs_t>
+  constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
+    return const_val::max::value<typename rhs_t::value_t>();
+  }
+};
+
+struct AbsoluteAddOperator : public Operators {
+  template <typename lhs_t, typename rhs_t>
+  static SYCL_BLAS_INLINE typename StripASP<rhs_t>::type eval(const lhs_t &l,
+                                                              const rhs_t &r) {
+    return AbsoluteValue::eval(l) + AbsoluteValue::eval(r);
+  }  // namespace blas
+
+  template <typename rhs_t>
+  constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
+    return const_val::zero::value<typename rhs_t::value_t>();
+  }
+};
+
+struct IMaxOperator : public Operators {
+  template <typename lhs_t, typename rhs_t>
+  static SYCL_BLAS_INLINE typename StripASP<rhs_t>::type eval(const lhs_t &l,
+                                                              const rhs_t &r) {
+    if (AbsoluteValue::eval(
+            static_cast<typename StripASP<lhs_t>::type>(l).get_value()) <
+            AbsoluteValue::eval(
+                static_cast<typename StripASP<rhs_t>::type>(r).get_value()) or
+        (AbsoluteValue::eval(
+             static_cast<typename StripASP<lhs_t>::type>(l).get_value()) ==
+             AbsoluteValue::eval(
+                 static_cast<typename StripASP<rhs_t>::type>(r).get_value()) and
+         l.get_index() > r.get_index())) {
+      return static_cast<typename StripASP<rhs_t>::type>(r);
+    } else {
+      return static_cast<typename StripASP<lhs_t>::type>(l);
+    }
+  }
+
+  template <typename rhs_t>
+  constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
+    return const_val::index_val<const_val::abs_min, const_val::max>::value<
+        typename rhs_t::value_t>();
+  }
+};
+
+struct IMinOperator : public Operators {
+  template <typename lhs_t, typename rhs_t>
+  static SYCL_BLAS_INLINE typename StripASP<rhs_t>::type eval(const lhs_t &l,
+                                                              const rhs_t &r) {
+    if (AbsoluteValue::eval(
+            static_cast<typename StripASP<lhs_t>::type>(l).get_value()) >
+            AbsoluteValue::eval(
+                static_cast<typename StripASP<rhs_t>::type>(r).get_value()) ||
+        (AbsoluteValue::eval(
+             static_cast<typename StripASP<lhs_t>::type>(l).get_value()) ==
+             AbsoluteValue::eval(
+                 static_cast<typename StripASP<rhs_t>::type>(r).get_value()) &&
+         l.get_index() > r.get_index())) {
+      return static_cast<typename StripASP<rhs_t>::type>(r);
+    } else {
+      return static_cast<typename StripASP<lhs_t>::type>(l);
+    }
+  }
+
+  template <typename rhs_t>
+  constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
+    return const_val::index_val<const_val::abs_max, const_val::max>::value<
+        typename rhs_t::value_t>();
+  }
+};
 
 }  // namespace blas
 

--- a/src/policy/sycl_policy_handler.cpp
+++ b/src/policy/sycl_policy_handler.cpp
@@ -128,12 +128,12 @@ INSTANTIATE_TEMPLATE_METHODS(double)
   PolicyHandler<codeplay_policy>::get_offset<IndexValueTuple<ind, val>>(      \
       BufferIterator<IndexValueTuple<ind, val>, codeplay_policy> ptr) const;
 
-INSTANTIATE_TEMPLATE_METHODS_SPECIAL(float, int)
-INSTANTIATE_TEMPLATE_METHODS_SPECIAL(float, long)
-INSTANTIATE_TEMPLATE_METHODS_SPECIAL(float, long long)
-INSTANTIATE_TEMPLATE_METHODS_SPECIAL(double, int)
-INSTANTIATE_TEMPLATE_METHODS_SPECIAL(double, long)
-INSTANTIATE_TEMPLATE_METHODS_SPECIAL(double, long long)
+INSTANTIATE_TEMPLATE_METHODS_SPECIAL(int, float)
+INSTANTIATE_TEMPLATE_METHODS_SPECIAL(long, float)
+INSTANTIATE_TEMPLATE_METHODS_SPECIAL(long long, float)
+INSTANTIATE_TEMPLATE_METHODS_SPECIAL(int, double)
+INSTANTIATE_TEMPLATE_METHODS_SPECIAL(long, double)
+INSTANTIATE_TEMPLATE_METHODS_SPECIAL(long long, double)
 
 }  // namespace blas
 #endif

--- a/test/exprtest/blas1_iface_test.cpp
+++ b/test/exprtest/blas1_iface_test.cpp
@@ -113,11 +113,20 @@ TYPED_TEST(BLAS_Test, interface1_test) {
   // for dot after _rot
   std::vector<scalar_t> vU(1);
   // for iamax/iamin
-  constexpr auto max_val =
-      constant<IndexValueTuple<scalar_t, index_t>, const_val::imax>::value();
+  constexpr auto max_val = IndexValueTuple<scalar_t, index_t>(
+      std::numeric_limits<index_t>::max(), static_cast<scalar_t>(0));
+
+  //     const_val::pair<const_val::abs_max, const_val::max>::value <
+  //     IndexValueTuple<scalar_t, index_t>();
+
+  // constant<IndexValueTuple<scalar_t, index_t>, const_val::imax>::value();
+
   std::vector<IndexValueTuple<scalar_t, index_t>> vImax(1, max_val);
+
   constexpr auto min_val =
-      constant<IndexValueTuple<scalar_t, index_t>, const_val::imin>::value();
+      IndexValueTuple<scalar_t, index_t>(std::numeric_limits<index_t>::max(),
+                                         std::numeric_limits<scalar_t>::max());
+  // constant<IndexValueTuple<scalar_t, index_t>, const_val::imin>::value();
   std::vector<IndexValueTuple<scalar_t, index_t>> vImin(1, min_val);
 
   auto q = make_queue();

--- a/test/exprtest/blas1_iface_test.cpp
+++ b/test/exprtest/blas1_iface_test.cpp
@@ -113,21 +113,15 @@ TYPED_TEST(BLAS_Test, interface1_test) {
   // for dot after _rot
   std::vector<scalar_t> vU(1);
   // for iamax/iamin
-  constexpr auto max_val = IndexValueTuple<scalar_t, index_t>(
+  constexpr auto max_val = IndexValueTuple<index_t, scalar_t>(
       std::numeric_limits<index_t>::max(), static_cast<scalar_t>(0));
 
-  //     const_val::pair<const_val::abs_max, const_val::max>::value <
-  //     IndexValueTuple<scalar_t, index_t>();
-
-  // constant<IndexValueTuple<scalar_t, index_t>, const_val::imax>::value();
-
-  std::vector<IndexValueTuple<scalar_t, index_t>> vImax(1, max_val);
+  std::vector<IndexValueTuple<index_t, scalar_t>> vImax(1, max_val);
 
   constexpr auto min_val =
-      IndexValueTuple<scalar_t, index_t>(std::numeric_limits<index_t>::max(),
+      IndexValueTuple<index_t, scalar_t>(std::numeric_limits<index_t>::max(),
                                          std::numeric_limits<scalar_t>::max());
-  // constant<IndexValueTuple<scalar_t, index_t>, const_val::imin>::value();
-  std::vector<IndexValueTuple<scalar_t, index_t>> vImin(1, min_val);
+  std::vector<IndexValueTuple<index_t, scalar_t>> vImin(1, min_val);
 
   auto q = make_queue();
   Executor<ExecutorType> ex(q);
@@ -139,10 +133,10 @@ TYPED_TEST(BLAS_Test, interface1_test) {
   auto gpu_vU = ex.get_policy_handler().template allocate<scalar_t>(1);
   auto gpu_vImax =
       ex.get_policy_handler()
-          .template allocate<IndexValueTuple<scalar_t, index_t>>(1);
+          .template allocate<IndexValueTuple<index_t, scalar_t>>(1);
   auto gpu_vImin =
       ex.get_policy_handler()
-          .template allocate<IndexValueTuple<scalar_t, index_t>>(1);
+          .template allocate<IndexValueTuple<index_t, scalar_t>>(1);
   ex.get_policy_handler().copy_to_device(vX.data(), gpu_vX, size);
   ex.get_policy_handler().copy_to_device(vY.data(), gpu_vY, size);
   _axpy(ex, size, alpha, gpu_vX, strd, gpu_vY, strd);
@@ -195,7 +189,7 @@ TYPED_TEST(BLAS_Test, interface1_test) {
   ex.get_policy_handler().template deallocate<scalar_t>(gpu_vT);
   ex.get_policy_handler().template deallocate<scalar_t>(gpu_vU);
   ex.get_policy_handler()
-      .template deallocate<IndexValueTuple<scalar_t, index_t>>(gpu_vImax);
+      .template deallocate<IndexValueTuple<index_t, scalar_t>>(gpu_vImax);
   ex.get_policy_handler()
-      .template deallocate<IndexValueTuple<scalar_t, index_t>>(gpu_vImin);
+      .template deallocate<IndexValueTuple<index_t, scalar_t>>(gpu_vImin);
 }

--- a/test/unittest/blas1/blas1_iamax_test.cpp
+++ b/test/unittest/blas1/blas1_iamax_test.cpp
@@ -4,7 +4,7 @@
 
 template <typename scalar_t>
 void run_test(const combination_t combi) {
-  using tuple_t = IndexValueTuple<scalar_t, int>;
+  using tuple_t = IndexValueTuple<int, scalar_t>;
 
   int size;
   int incX;

--- a/test/unittest/blas1/blas1_iamin_test.cpp
+++ b/test/unittest/blas1/blas1_iamin_test.cpp
@@ -29,7 +29,7 @@
 
 template <typename scalar_t>
 void run_test(const combination_t combi) {
-  using tuple_t = IndexValueTuple<scalar_t, int>;
+  using tuple_t = IndexValueTuple<int, scalar_t>;
 
   int size;
   int incX;


### PR DESCRIPTION
This PR significantly refactors the binary/unary operation definitions, along with theconstant generation machinery. Additionally, it also refactors the `IndexValueTuple` type so that template types are passed in the same order as in the the constructor. 