### PR TITLE
Support for nested IndexTuple operators and a CollapseIndex op

### DIFF
--- a/include/operations/blas1_trees.h
+++ b/include/operations/blas1_trees.h
@@ -26,6 +26,7 @@
 #ifndef SYCL_BLAS_BLAS1_TREES_H
 #define SYCL_BLAS_BLAS1_TREES_H
 #include "operations/blas_constants.h"
+#include "operations/blas_operators.h"
 #include <CL/sycl.hpp>
 #include <stdexcept>
 #include <vector>
@@ -94,7 +95,7 @@ struct DoubleAssign {
 template <typename operator_t, typename scalar_t, typename rhs_t>
 struct ScalarOp {
   using index_t = typename rhs_t::index_t;
-  using value_t = typename rhs_t::value_t;
+  using value_t = typename ResolveReturnType<operator_t, rhs_t>::type::value_t;
   scalar_t scalar_;
   rhs_t rhs_;
   ScalarOp(scalar_t _scl, rhs_t &_r);
@@ -112,7 +113,7 @@ struct ScalarOp {
 template <typename operator_t, typename rhs_t>
 struct UnaryOp {
   using index_t = typename rhs_t::index_t;
-  using value_t = typename rhs_t::value_t;
+  using value_t = typename ResolveReturnType<operator_t, rhs_t>::type::value_t;
   rhs_t rhs_;
   UnaryOp(rhs_t &_r);
   index_t get_size() const;
@@ -129,7 +130,7 @@ struct UnaryOp {
 template <typename operator_t, typename lhs_t, typename rhs_t>
 struct BinaryOp {
   using index_t = typename rhs_t::index_t;
-  using value_t = typename rhs_t::value_t;
+  using value_t = typename ResolveReturnType<operator_t, rhs_t>::type::value_t;
   lhs_t lhs_;
   rhs_t rhs_;
   BinaryOp(lhs_t &_l, rhs_t &_r);
@@ -164,7 +165,7 @@ struct TupleOp {
  */
 template <typename operator_t, typename lhs_t, typename rhs_t>
 struct AssignReduction {
-  using value_t = typename rhs_t::value_t;
+  using value_t = typename ResolveReturnType<operator_t, rhs_t>::type::value_t;
   using index_t = typename rhs_t::index_t;
   lhs_t lhs_;
   rhs_t rhs_;

--- a/include/operations/blas_operators.h
+++ b/include/operations/blas_operators.h
@@ -30,6 +30,20 @@
 
 namespace blas {
 struct Operators;
+
+// A template for getting the return type of a blas operator
+// This is special cased for the CollapseIndex operator, which returns a
+// different type than its input
+template <typename operator_t, typename rhs_t>
+struct ResolveReturnType {
+  using type = rhs_t;
+};
+
+struct CollapseIndexTupleOperator;
+template <typename rhs_t>
+struct ResolveReturnType<CollapseIndexTupleOperator, rhs_t> {
+  using type = typename rhs_t::value_t;
+};
 }  // namespace blas
 
 #endif

--- a/test/exprtest/CMakeLists.txt
+++ b/test/exprtest/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SYCLBLAS_EXPRTEST ${CMAKE_CURRENT_SOURCE_DIR})
 set(SYCL_EXPRTEST_SRCS
   ${SYCLBLAS_EXPRTEST}/blas1_scal_asum_test.cpp
   ${SYCLBLAS_EXPRTEST}/blas1_axpy_copy_test.cpp
+  ${SYCLBLAS_EXPRTEST}/collapse_nested_tuple.cpp
 )
 
 foreach(blas_test ${SYCL_EXPRTEST_SRCS})
@@ -50,6 +51,6 @@ foreach(blas_test ${SYCL_EXPRTEST_SRCS})
     add_test(NAME ${test_exec} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${test_exec})
   endif()
   message("-- Created google test ${test_exec}")
-  install(TARGETS ${test_exec} RUNTIME DESTINATION sycl_blas/bin)  
+  install(TARGETS ${test_exec} RUNTIME DESTINATION sycl_blas/bin)
   include_directories(${test_exec} PUBLIC ${SYCLBLAS_TEST} ${SYCLBLAS_SRC} ${SYCLBLAS_INCLUDE} ${THIRD_PARTIES_INCLUDE} ${BLAS_INCLUDE_DIRS})
 endforeach()

--- a/test/exprtest/collapse_nested_tuple.cpp
+++ b/test/exprtest/collapse_nested_tuple.cpp
@@ -1,0 +1,112 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename collapse_nested_tuple.cpp
+ *
+ **************************************************************************/
+#include "blas_test.hpp"
+#include "sycl_blas.hpp"
+
+// inputs combination
+template <typename scalar_t>
+using combination_t = std::tuple<int, int>;
+
+template <typename scalar_t>
+void run_test(const combination_t<scalar_t> combi) {
+  const int OFFSET = 5;  // The first tuples are offset by this amount
+  int size;
+  int factor;
+  std::tie(size, factor) = combi;
+
+  auto q = make_queue();
+  test_executor_t ex(q);
+
+  // Input buffer
+  auto v_in = std::vector<scalar_t>(size);
+  fill_random(v_in);
+  // Intermediate buffer
+  auto v_int = std::vector<IndexValueTuple<int, scalar_t>>(
+      size, IndexValueTuple<int, scalar_t>(scalar_t(), int()));
+  // Output buffer
+  auto v_out = std::vector<IndexValueTuple<int, scalar_t>>(
+      size, IndexValueTuple<int, scalar_t>(scalar_t(), int()));
+
+  // Load v_int with v_in as tuples
+  {
+    const auto gpu_v_in =
+        blas::make_sycl_iterator_buffer<scalar_t>(v_in.data(), size);
+    auto gpu_v_in_vv = make_vector_view(ex, gpu_v_in, 1, size);
+    auto gpu_v_int =
+        blas::make_sycl_iterator_buffer<IndexValueTuple<int, scalar_t>>(
+            v_int.data(), size);
+    auto gpu_v_int_vv = make_vector_view(ex, gpu_v_int, 1, size);
+
+    auto tuples = make_tuple_op(gpu_v_in_vv);
+    auto assign_tuple = make_op<Assign>(gpu_v_int_vv, tuples);
+    ex.execute(assign_tuple);
+  }
+
+  // Increment the indexes, so they are different to the ones in the next step
+  for (int i = 0; i < size; i++) {
+    ASSERT_EQ(i, v_int[i].ind);
+    v_int[i].ind += OFFSET;
+  }
+
+  // And the final tuple and collapse
+  {
+    auto gpu_v_int =
+        blas::make_sycl_iterator_buffer<IndexValueTuple<int, scalar_t>>(
+            v_int.data(), size);
+    auto gpu_v_int_vv = make_vector_view(ex, gpu_v_int, 1, size);
+    auto gpu_v_out =
+        blas::make_sycl_iterator_buffer<IndexValueTuple<int, scalar_t>>(
+            v_out.data(), size);
+    auto gpu_v_out_vv = make_vector_view(ex, gpu_v_out, 1, size);
+
+    auto tuples = make_tuple_op(gpu_v_int_vv);
+    auto collapsed =
+        make_op<ScalarOp, CollapseIndexTupleOperator>(factor, tuples);
+    auto assign_tuple = make_op<Assign>(gpu_v_out_vv, collapsed);
+    ex.execute(assign_tuple);
+  }
+
+  // Check the result
+  for (int i = 0; i < size; i++) {
+    int expected = i * factor + (i + OFFSET);
+    ASSERT_EQ(expected, v_out[i].ind);
+    ASSERT_TRUE(utils::almost_equal(v_out[i].val, v_in[i]));
+  }
+}
+
+const auto combi = ::testing::Combine(::testing::Values(16, 1023),  // length
+                                      ::testing::Values(0, 1, 5));  // factor
+
+class CollapseNestedTupleFloat
+    : public ::testing::TestWithParam<combination_t<float>> {};
+TEST_P(CollapseNestedTupleFloat, test) { run_test<float>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(collapsent, CollapseNestedTupleFloat, combi);
+
+#if DOUBLE_SUPPORT
+class CollapseNestedTupleDouble
+    : public ::testing::TestWithParam<combination_t<double>> {};
+TEST_P(CollapseNestedTupleDouble, test) { run_test<double>(GetParam()); };
+INSTANTIATE_TEST_SUITE_P(collapsent, CollapseNestedTupleDouble, combi);
+#endif


### PR DESCRIPTION
The new operator converts (a, (b, x)) to (a * n + b, x).

This also includes a workaround for a ComputeCPP bug with larger
data types (e.g., nested tuples).