### PR TITLE
Added 2D versions of the operations: `Scalar2DOp`, `Unary2DOp`, `Binary2DOp`, `Assign2D`

### DIFF
--- a/include/operations/blas2_trees.h
+++ b/include/operations/blas2_trees.h
@@ -293,7 +293,7 @@ struct Unary2DOp {
 };
 
 /*! Binary2DOp.
- * @brief Implements a Binary Operation (x OP z) with x and z vectors.
+ * @brief Implements a Binary Operation (A OP B) with A and B matrices.
  */
 template <typename operator_t, typename lhs_t, typename rhs_t>
 struct Binary2DOp {

--- a/include/operations/blas2_trees.h
+++ b/include/operations/blas2_trees.h
@@ -249,5 +249,90 @@ GerCol<Single, Lower, Diag, Upper, lhs_t, rhs_1_t, rhs_2_t> make_Ger_Col(
   return GerCol<Single, Lower, Diag, Upper, lhs_t, rhs_1_t, rhs_2_t>(
       lhs_, scalar_, rhs_1_, rhs_2_, nWG_row_, nWG_col_, local_memory_size_);
 }
+
+/*!Scalar2DOp.
+ * @brief Implements an scalar operation.
+ * (e.g alpha OP A, with alpha scalar and A matrix)
+ */
+template <typename operator_t, typename scalar_t, typename rhs_t>
+struct Scalar2DOp {
+  using index_t = typename rhs_t::index_t;
+  using value_t = typename rhs_t::value_t;
+  scalar_t scalar_;
+  rhs_t rhs_;
+  Scalar2DOp(scalar_t _scl, rhs_t &_r);
+  index_t get_size() const;
+  index_t getSizeL() const;
+  index_t get_size_row() const;
+  index_t get_size_col() const;
+  bool valid_thread(cl::sycl::nd_item<1> ndItem) const;
+  value_t eval(index_t i);
+  value_t eval(cl::sycl::nd_item<1> ndItem);
+  void bind(cl::sycl::handler &h);
+  void adjust_access_displacement();
+};
+
+/*! Unary2DOp.
+ * Implements a Unary Operation ( operator_t(z), e.g. z++), with z a vector.
+ */
+template <typename operator_t, typename rhs_t>
+struct Unary2DOp {
+  using index_t = typename rhs_t::index_t;
+  using value_t = typename rhs_t::value_t;
+  rhs_t rhs_;
+  Unary2DOp(rhs_t &_r);
+  index_t get_size() const;
+  index_t getSizeL() const;
+  index_t get_size_row() const;
+  index_t get_size_col() const;
+  bool valid_thread(cl::sycl::nd_item<1> ndItem) const;
+  value_t eval(index_t i);
+  value_t eval(cl::sycl::nd_item<1> ndItem);
+  void bind(cl::sycl::handler &h);
+  void adjust_access_displacement();
+};
+
+/*! Binary2DOp.
+ * @brief Implements a Binary Operation (x OP z) with x and z vectors.
+ */
+template <typename operator_t, typename lhs_t, typename rhs_t>
+struct Binary2DOp {
+  using index_t = typename rhs_t::index_t;
+  using value_t = typename rhs_t::value_t;
+  lhs_t lhs_;
+  rhs_t rhs_;
+  Binary2DOp(lhs_t &_l, rhs_t &_r);
+  index_t get_size() const;
+  index_t getSizeL() const;
+  index_t get_size_row() const;
+  index_t get_size_col() const;
+  bool valid_thread(cl::sycl::nd_item<1> ndItem) const;
+  value_t eval(index_t i);
+  value_t eval(cl::sycl::nd_item<1> ndItem);
+  void bind(cl::sycl::handler &h);
+  void adjust_access_displacement();
+};
+
+/*! Assign2D.
+ * @brief Assign the rhs to the lhs
+ */
+template <typename lhs_t, typename rhs_t>
+struct Assign2D {
+  using index_t = typename lhs_t::index_t;
+  using value_t = typename rhs_t::value_t;
+  lhs_t lhs_;
+  rhs_t rhs_;
+  Assign2D(lhs_t &_l, rhs_t _r);
+  index_t get_size() const;
+  index_t getSizeL() const;
+  index_t get_size_row() const;
+  index_t get_size_col() const;
+  bool valid_thread(cl::sycl::nd_item<1> ndItem) const;
+  value_t eval(index_t i);
+  value_t eval(cl::sycl::nd_item<1> ndItem);
+  void bind(cl::sycl::handler &h);
+  void adjust_access_displacement();
+};
+
 }  // namespace blas
 #endif  // BLAS2_TREES_H

--- a/include/operations/blas2_trees.h
+++ b/include/operations/blas2_trees.h
@@ -273,7 +273,7 @@ struct Scalar2DOp {
 };
 
 /*! Unary2DOp.
- * Implements a Unary Operation ( operator_t(z), e.g. z++), with z a vector.
+ * Implements a Unary Operation ( operator_t(A), e.g. A++), with A a matrix.
  */
 template <typename operator_t, typename rhs_t>
 struct Unary2DOp {

--- a/src/operations/blas2_trees.hpp
+++ b/src/operations/blas2_trees.hpp
@@ -29,4 +29,235 @@
 #include "blas2/gemv.hpp"
 #include "blas2/ger.hpp"
 
+namespace blas {
+
+/*! Scalar2DOp.
+ * @brief Implements an scalar operation.
+ * (e.g alpha OP A, with alpha scalar and A matrix)
+ */
+template <typename operator_t, typename scalar_t, typename rhs_t>
+Scalar2DOp<operator_t, scalar_t, rhs_t>::Scalar2DOp(scalar_t _scl, rhs_t &_r)
+    : scalar_(_scl), rhs_(_r) {}
+
+template <typename operator_t, typename scalar_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Scalar2DOp<operator_t, scalar_t, rhs_t>::index_t
+Scalar2DOp<operator_t, scalar_t, rhs_t>::get_size() const {
+  return rhs_.get_size();
+}
+template <typename operator_t, typename scalar_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Scalar2DOp<operator_t, scalar_t, rhs_t>::index_t
+Scalar2DOp<operator_t, scalar_t, rhs_t>::getSizeL() const {
+  return rhs_.getSizeL();
+}
+template <typename operator_t, typename scalar_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Scalar2DOp<operator_t, scalar_t, rhs_t>::index_t
+Scalar2DOp<operator_t, scalar_t, rhs_t>::get_size_row() const {
+  return rhs_.get_size_row();
+}
+template <typename operator_t, typename scalar_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Scalar2DOp<operator_t, scalar_t, rhs_t>::index_t
+Scalar2DOp<operator_t, scalar_t, rhs_t>::get_size_col() const {
+  return rhs_.get_size_col();
+}
+template <typename operator_t, typename scalar_t, typename rhs_t>
+SYCL_BLAS_INLINE bool Scalar2DOp<operator_t, scalar_t, rhs_t>::valid_thread(
+    cl::sycl::nd_item<1> ndItem) const {
+  return ((ndItem.get_global_id(0) <
+           Scalar2DOp<operator_t, scalar_t, rhs_t>::get_size()));
+}
+template <typename operator_t, typename scalar_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Scalar2DOp<operator_t, scalar_t, rhs_t>::value_t
+Scalar2DOp<operator_t, scalar_t, rhs_t>::eval(
+    typename Scalar2DOp<operator_t, scalar_t, rhs_t>::index_t i) {
+  return operator_t::eval(internal::get_scalar(scalar_), rhs_.eval(i));
+}
+template <typename operator_t, typename scalar_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Scalar2DOp<operator_t, scalar_t, rhs_t>::value_t
+Scalar2DOp<operator_t, scalar_t, rhs_t>::eval(cl::sycl::nd_item<1> ndItem) {
+  return Scalar2DOp<operator_t, scalar_t, rhs_t>::eval(ndItem.get_global_id(0));
+}
+template <typename operator_t, typename scalar_t, typename rhs_t>
+SYCL_BLAS_INLINE void Scalar2DOp<operator_t, scalar_t, rhs_t>::bind(
+    cl::sycl::handler &h) {
+  rhs_.bind(h);
+}
+
+template <typename operator_t, typename scalar_t, typename rhs_t>
+SYCL_BLAS_INLINE void
+Scalar2DOp<operator_t, scalar_t, rhs_t>::adjust_access_displacement() {
+  rhs_.adjust_access_displacement();
+}
+
+/*! Unary2DOp.
+ * Implements a Unary Operation ( operator_t(A), e.g. A++), with A a matrix.
+ */
+template <typename operator_t, typename rhs_t>
+Unary2DOp<operator_t, rhs_t>::Unary2DOp(rhs_t &_r) : rhs_(_r) {}
+
+template <typename operator_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Unary2DOp<operator_t, rhs_t>::index_t
+Unary2DOp<operator_t, rhs_t>::get_size() const {
+  return rhs_.get_size();
+}
+template <typename operator_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Unary2DOp<operator_t, rhs_t>::index_t
+Unary2DOp<operator_t, rhs_t>::getSizeL() const {
+  return rhs_.getSizeL();
+}
+template <typename operator_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Unary2DOp<operator_t, rhs_t>::index_t
+Unary2DOp<operator_t, rhs_t>::get_size_row() const {
+  return rhs_.get_size_row();
+}
+template <typename operator_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Unary2DOp<operator_t, rhs_t>::index_t
+Unary2DOp<operator_t, rhs_t>::get_size_col() const {
+  return rhs_.get_size_col();
+}
+template <typename operator_t, typename rhs_t>
+SYCL_BLAS_INLINE bool Unary2DOp<operator_t, rhs_t>::valid_thread(
+    cl::sycl::nd_item<1> ndItem) const {
+  return ((ndItem.get_global_id(0) < Unary2DOp<operator_t, rhs_t>::get_size()));
+}
+template <typename operator_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Unary2DOp<operator_t, rhs_t>::value_t
+Unary2DOp<operator_t, rhs_t>::eval(
+    typename Unary2DOp<operator_t, rhs_t>::index_t i) {
+  return operator_t::eval(rhs_.eval(i));
+}
+template <typename operator_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Unary2DOp<operator_t, rhs_t>::value_t
+Unary2DOp<operator_t, rhs_t>::eval(cl::sycl::nd_item<1> ndItem) {
+  return Unary2DOp<operator_t, rhs_t>::eval(ndItem.get_global_id(0));
+}
+template <typename operator_t, typename rhs_t>
+SYCL_BLAS_INLINE void Unary2DOp<operator_t, rhs_t>::bind(cl::sycl::handler &h) {
+  rhs_.bind(h);
+}
+template <typename operator_t, typename rhs_t>
+SYCL_BLAS_INLINE void
+Unary2DOp<operator_t, rhs_t>::adjust_access_displacement() {
+  rhs_.adjust_access_displacement();
+}
+
+/*! Binary2DOp.
+ * @brief Implements a Binary Operation (x OP z) with x and z vectors.
+ */
+template <typename operator_t, typename lhs_t, typename rhs_t>
+Binary2DOp<operator_t, lhs_t, rhs_t>::Binary2DOp(lhs_t &_l, rhs_t &_r)
+    : lhs_(_l), rhs_(_r){};
+
+template <typename operator_t, typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Binary2DOp<operator_t, lhs_t, rhs_t>::index_t
+Binary2DOp<operator_t, lhs_t, rhs_t>::get_size() const {
+  return rhs_.get_size();
+}
+template <typename operator_t, typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Binary2DOp<operator_t, lhs_t, rhs_t>::index_t
+Binary2DOp<operator_t, lhs_t, rhs_t>::getSizeL() const {
+  return rhs_.get_size_row();
+}
+template <typename operator_t, typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Binary2DOp<operator_t, lhs_t, rhs_t>::index_t
+Binary2DOp<operator_t, lhs_t, rhs_t>::get_size_row() const {
+  return rhs_.get_size_row();
+}
+template <typename operator_t, typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Binary2DOp<operator_t, lhs_t, rhs_t>::index_t
+Binary2DOp<operator_t, lhs_t, rhs_t>::get_size_col() const {
+  return rhs_.get_size_col();
+}
+template <typename operator_t, typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE bool Binary2DOp<operator_t, lhs_t, rhs_t>::valid_thread(
+    cl::sycl::nd_item<1> ndItem) const {
+  return ((ndItem.get_global_id(0) < get_size()));
+}
+template <typename operator_t, typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Binary2DOp<operator_t, lhs_t, rhs_t>::value_t
+Binary2DOp<operator_t, lhs_t, rhs_t>::eval(
+    typename Binary2DOp<operator_t, lhs_t, rhs_t>::index_t i) {
+  using index_t = Binary2DOp<operator_t, lhs_t, rhs_t>::index_t;
+  const index_t nb_rows = get_size_row();
+  const index_t col = i / nb_rows;
+  const index_t row = i - nb_rows * col;
+  return operator_t::eval(lhs_.eval(col * lhs_.getSizeL() + row),
+                          rhs_.eval(col * rhs_.getSizeL() + row));
+}
+template <typename operator_t, typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Binary2DOp<operator_t, lhs_t, rhs_t>::value_t
+Binary2DOp<operator_t, lhs_t, rhs_t>::eval(cl::sycl::nd_item<1> ndItem) {
+  return Binary2DOp<operator_t, lhs_t, rhs_t>::eval(ndItem.get_global_id(0));
+}
+template <typename operator_t, typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE void Binary2DOp<operator_t, lhs_t, rhs_t>::bind(
+    cl::sycl::handler &h) {
+  lhs_.bind(h);
+  rhs_.bind(h);
+}
+template <typename operator_t, typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE void
+Binary2DOp<operator_t, lhs_t, rhs_t>::adjust_access_displacement() {
+  lhs_.adjust_access_displacement();
+  rhs_.adjust_access_displacement();
+}
+
+/*! Assign2D.
+ * @brief Assign the rhs to the lhs
+ */
+template <typename lhs_t, typename rhs_t>
+Assign2D<lhs_t, rhs_t>::Assign2D(lhs_t &_l, rhs_t _r) : lhs_(_l), rhs_(_r){};
+
+template <typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Assign2D<lhs_t, rhs_t>::index_t
+Assign2D<lhs_t, rhs_t>::get_size() const {
+  return rhs_.get_size();
+}
+template <typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Assign2D<lhs_t, rhs_t>::index_t
+Assign2D<lhs_t, rhs_t>::getSizeL() const {
+  return rhs_.get_size_row();
+}
+template <typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Assign2D<lhs_t, rhs_t>::index_t
+Assign2D<lhs_t, rhs_t>::get_size_row() const {
+  return rhs_.get_size_row();
+}
+template <typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Assign2D<lhs_t, rhs_t>::index_t
+Assign2D<lhs_t, rhs_t>::get_size_col() const {
+  return rhs_.get_size_col();
+}
+template <typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE bool Assign2D<lhs_t, rhs_t>::valid_thread(
+    cl::sycl::nd_item<1> ndItem) const {
+  return ((ndItem.get_global_id(0) < Assign2D<lhs_t, rhs_t>::get_size()));
+}
+template <typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Assign2D<lhs_t, rhs_t>::value_t
+Assign2D<lhs_t, rhs_t>::eval(typename Assign2D<lhs_t, rhs_t>::index_t i) {
+  const index_t nb_rows = get_size_row();
+  const index_t col = i / nb_rows;
+  const index_t row = i - nb_rows * col;
+  auto val = lhs_.eval(col * lhs_.getSizeL() + row) =
+      rhs_.eval(col * rhs_.getSizeL() + row);
+  return val;
+}
+template <typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE typename Assign2D<lhs_t, rhs_t>::value_t
+Assign2D<lhs_t, rhs_t>::eval(cl::sycl::nd_item<1> ndItem) {
+  return Assign2D<lhs_t, rhs_t>::eval(ndItem.get_global_id(0));
+}
+template <typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE void Assign2D<lhs_t, rhs_t>::bind(cl::sycl::handler &h) {
+  lhs_.bind(h);
+  rhs_.bind(h);
+}
+template <typename lhs_t, typename rhs_t>
+SYCL_BLAS_INLINE void Assign2D<lhs_t, rhs_t>::adjust_access_displacement() {
+  lhs_.adjust_access_displacement();
+  rhs_.adjust_access_displacement();
+}
+
+}  // namespace blas
+
 #endif  // BLAS2_TREES_HPP

--- a/src/operations/blas2_trees.hpp
+++ b/src/operations/blas2_trees.hpp
@@ -141,7 +141,7 @@ Unary2DOp<operator_t, rhs_t>::adjust_access_displacement() {
 }
 
 /*! Binary2DOp.
- * @brief Implements a Binary Operation (x OP z) with x and z vectors.
+ * @brief Implements a Binary Operation (A OP B) with A and B matrices.
  */
 template <typename operator_t, typename lhs_t, typename rhs_t>
 Binary2DOp<operator_t, lhs_t, rhs_t>::Binary2DOp(lhs_t &_l, rhs_t &_r)


### PR DESCRIPTION
I haven't created expression tests for the individual operations but used them successfully in tall & skinny gemm. Let me know if you think they should have expression tests.

These operations work very similarly to their 1D counterparts but add a notion of leading dimension and two functions for the size of rows and columns. Basically the scalar and unary operations are quite transparent and return whatever the RHS returns, except that `eval` performs the scalar or unary operations. The binary and assign operations are a bit more complex because the lhs and rhs can have different leading dimensions, so it does the index calculation and the leading dimension of the operator will be the number of rows.

Note: calling `eval` on the scalar or unary operations must take into account the leading dim, because they behave like the matrix view 1-parameter `eval` function. Technically all the operations do but the binary and assign operations have leading dim = nb rows. I could change that behavior to always return a leading dimension equal to the number of rows and remap that manually in the `eval` functions, but it would have a greater performance cost.