### PR TITLE
Fix memory type in GEMM autotuner

### DIFF
--- a/tools/auto_tuner/include/gemm_tuner.hpp
+++ b/tools/auto_tuner/include/gemm_tuner.hpp
@@ -258,7 +258,7 @@ void run_tune_gemm(int seed, int m, int k, int n, int batch_size, int rep) {
   using Local = GemmConfig<TransA, TransB, data_t, gemm_memory_t::local,
                            gemm_algorithm_t::standard>;
   using NonLocal =
-      GemmConfig<TransA, TransB, data_t, gemm_memory_t::no_local_memory,
+      GemmConfig<TransA, TransB, data_t, gemm_memory_t::no_local,
                  gemm_algorithm_t::standard>;
   using Naive = GemmConfig<TransA, TransB, data_t,
                            gemm_memory_t::no_local, gemm_algorithm_t::naive>;


### PR DESCRIPTION
One of the memory type enums in the auto tuner was missed when `Gemm_t`
was split into `gemm_memory_t` and `gemm_algorithm_t`, which causes
compile errors.