### PR TITLE
Enabling benchmark verification by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ if(${BLAS_ENABLE_TESTING})
 endif()
 
 option(BLAS_ENABLE_BENCHMARK "Whether to enable benchmarking" ON)
-option(BLAS_VERIFY_BENCHMARK "Whether to verify the results of benchmarks" OFF)
+option(BLAS_VERIFY_BENCHMARK "Whether to verify the results of benchmarks" ON)
 option(BUILD_CLBLAST_BENCHMARKS "Whether to build CLBLAST benchmarks" OFF)
 option(BUILD_ACL_BENCHMARKS "Whether to build ARM Compute Library benchmarks" OFF)
 option(BUILD_EXPRESSION_BENCHMARKS "Whether to build the expression benchmarks" OFF)

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ the project.
     * [Executors](#executors)
     * [Interface](#interface)
   * [API description](#api-description)
-    * [BLAS 1](#blas1)
-    * [BLAS 2](#blas2)
-    * [BLAS 3](#blas3)
+    * [BLAS 1](#blas-1)
+    * [BLAS 2](#blas-2)
+    * [BLAS 3](#blas-3)
   * [Requirements](#requirements)
   * [Setup](#setup)
     * [How to compile](#how-to-compile)
@@ -323,7 +323,7 @@ Some of the supported options are:
 | `CMAKE_INSTALL_PREFIX` | path | Specify the install location, used when invoking `ninja install` |
 | `BLAS_ENABLE_STATIC_LIBRARY` | `ON`/`OFF` | Build as a static library (`OFF` by default) |
 | `ENABLE_EXPRESSION_TESTS` | `ON`/`OFF` | Build additional tests that use the header-only framework (e.g to test expression trees); `OFF` by default |
-| `BLAS_VERIFY_BENCHMARK` | `ON`/`OFF` | Verify the results of the benchmarks instead of only measuring the performance. See the documentation of the benchmarks for more details. `OFF` by default |
+| `BLAS_VERIFY_BENCHMARK` | `ON`/`OFF` | Verify the results of the benchmarks instead of only measuring the performance. See the documentation of the benchmarks for more details. `ON` by default |
 
 
 ### Cross-Compile

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -29,12 +29,13 @@ After the compilation, the binaries will be available:
     `CMAKE_INSTALL_PREFIX`, and run the installation command, e.g
     `ninja install`, in your installation folder, in `sycl_blas/bin/`
 
-A verification of the results can be enabled with the CMake option
-`BLAS_VERIFY_BENCHMARK`. The verification will be run a small number of times
-(more than once because of the way the benchmark library works, but much less
-then the usual number of iterations of the benchmarks). The verification
-requires that a reference implementation of BLAS like OpenBLAS is installed,
-which path can be given with the `SYSTEM_BLAS_ROOT` CMake parameter.
+A verification of the results is enabled by default and can be disabled with the
+CMake option `BLAS_VERIFY_BENCHMARK` set to `OFF` or `0`. The verification will
+be run a small number of times (more than once because of the way the benchmark
+library works, but much less then the usual number of iterations of the
+benchmarks). The verification requires that a reference implementation of BLAS
+like OpenBLAS is installed, which path can be given with the `SYSTEM_BLAS_ROOT`
+CMake parameter.
 
 ## How to run the benchmarks
 


### PR DESCRIPTION
The default behavior of the benchmarks should be to verify the results, so we are certain that the performance data is reliable. This can still be disabled with a CMake option.