### PR TITLE
Add temporary default constructor to BufferIterator

### DIFF
--- a/include/container/sycl_iterator.h
+++ b/include/container/sycl_iterator.h
@@ -56,6 +56,16 @@ class BufferIterator<element_t, codeplay_policy> {
       get_range_accessor(BufferIterator<scal_t, codeplay_policy> buff_iterator,
                          size_t size);
   /*!
+   * @brief Default construct a BufferIterator.
+   * This can be used to provide a placeholder BufferIterator, but it is a user
+   * error if passed into any of the SYCL-BLAS functions.
+   *
+   * Should be removed once SYCL specifies that buffers are default
+   * constructible. See:
+   * https://github.com/codeplaysoftware/standards-proposals/blob/master/default-constructed-buffers/default-constructed-buffers.md
+   */
+  BufferIterator() : offset_{0}, buffer{cl::sycl::range<1>{1}} {}
+  /*!
    * @brief See BufferIterator.
    */
   BufferIterator(const buff_t& buff, std::ptrdiff_t offset);


### PR DESCRIPTION
SYCL buffers do not need to be default constructible, but there is a
proposal to specify that they must be. It is useful to be able to
default construct `BufferIterator`s, as they can be used as a
placeholder and reassigned to a `BufferIterator` that contains a valid
SYCL buffer if needed.

As the buffer default constructor is not currently available in SYCL we
provide a temporary constructor that will construct a `BufferIterator`
but it would be a user error to pass this object into any SYCL-BLAS
function.

Once the default constructor is provided in the SYCL specification then
this temporary constructor can be removed.

See: https://github.com/codeplaysoftware/standards-proposals/blob/master/default-constructed-buffers/default-constructed-buffers.md