### PR TITLE
Only force inline functions on device

### DIFF
--- a/include/blas_meta.h
+++ b/include/blas_meta.h
@@ -118,8 +118,13 @@ static inline index_t get_power_of_two(index_t wGSize, bool rounUp) {
   return ((!rounUp) ? (wGSize - (wGSize >> 1)) : ++wGSize);
 }
 
+#ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_BLAS_ALWAYS_INLINE \
   __attribute__((flatten)) __attribute__((always_inline))
+#else
+#define SYCL_BLAS_ALWAYS_INLINE
+#endif
+
 #define SYCL_BLAS_INLINE SYCL_BLAS_ALWAYS_INLINE inline
 
 template <typename index_t>


### PR DESCRIPTION
We want to always force inline all functions in the compute kernels, to
ensure that no intermediate structures are being forced to be
constructed that are not needed. However this tends to increase compile
times and there is no need to do this in host code as well. Instead we
can force inline only when compiling for the device and leave it up to
the host compiler whether it should inline host functions.