### PR TITLE
Add items/bytes per second field to GEMM benchmark

### DIFF
--- a/benchmark/syclblas/blas3/gemm.cpp
+++ b/benchmark/syclblas/blas3/gemm.cpp
@@ -49,25 +49,6 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
   index_t ldb = t_b[0] == 'n' ? k : n;
   index_t ldc = m;
 
-  // The counters are double. We convert m, n and k to double to avoid
-  // integer overflows for n_fl_ops and bytes_processed
-  double m_d = static_cast<double>(m);
-  double n_d = static_cast<double>(n);
-  double k_d = static_cast<double>(k);
-
-  state.counters["m"] = m_d;
-  state.counters["k"] = k_d;
-  state.counters["n"] = n_d;
-
-  {
-    double mem_readA = m_d * k_d;
-    double mem_readB = k_d * n_d;
-    double mem_writeC = m_d * n_d;
-    double mem_readC = (beta != 0) ? m_d * n_d : 0;
-    state.counters["bytes_processed"] =
-        (mem_readA + mem_readB + mem_readC + mem_writeC) * sizeof(scalar_t);
-  }
-
   ExecutorType& ex = *executorPtr;
 
   // Matrices
@@ -123,7 +104,27 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
     // Report
     blas_benchmark::utils::update_counters(state, times);
   }
+
   {
+    // The counters are double. We convert m, n and k to double to avoid
+    // integer overflows for n_fl_ops and bytes_processed
+    double m_d = static_cast<double>(m);
+    double n_d = static_cast<double>(n);
+    double k_d = static_cast<double>(k);
+
+    state.counters["m"] = m_d;
+    state.counters["k"] = k_d;
+    state.counters["n"] = n_d;
+
+    double mem_readA = m_d * k_d;
+    double mem_readB = k_d * n_d;
+    double mem_writeC = m_d * n_d;
+    double mem_readC = (beta != 0) ? m_d * n_d : 0;
+    double total_mem =
+        (mem_readA + mem_readB + mem_readC + mem_writeC) * sizeof(scalar_t);
+    state.counters["bytes_processed"] = total_mem;
+    state.SetBytesProcessed(state.iterations() * total_mem);
+
     double nflops_AtimesB = (2 * k_d - 1) * m_d * n_d;
     double nflops_timesAlpha = m_d * n_d;
     double nflops_addBetaC = (beta != 0) ? 2 * m_d * n_d : 0;

--- a/benchmark/syclblas/blas3/gemm.cpp
+++ b/benchmark/syclblas/blas3/gemm.cpp
@@ -60,13 +60,6 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
   state.counters["n"] = n_d;
 
   {
-    double nflops_AtimesB = (2 * k_d - 1) * m_d * n_d;
-    double nflops_timesAlpha = m_d * n_d;
-    double nflops_addBetaC = (beta != 0) ? 2 * m_d * n_d : 0;
-    state.counters["n_fl_ops"] =
-        nflops_AtimesB + nflops_timesAlpha + nflops_addBetaC;
-  }
-  {
     double mem_readA = m_d * k_d;
     double mem_readB = k_d * n_d;
     double mem_writeC = m_d * n_d;
@@ -130,6 +123,14 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
     // Report
     blas_benchmark::utils::update_counters(state, times);
   }
+  {
+    double nflops_AtimesB = (2 * k_d - 1) * m_d * n_d;
+    double nflops_timesAlpha = m_d * n_d;
+    double nflops_addBetaC = (beta != 0) ? 2 * m_d * n_d : 0;
+    double nflops = nflops_AtimesB + nflops_timesAlpha + nflops_addBetaC;
+    state.counters["n_fl_ops"] = nflops;
+    state.SetItemsProcessed(state.iterations() * nflops);
+  }
 
   blas_benchmark::utils::calc_avg_counters(state);
 };
@@ -154,7 +155,8 @@ void register_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
     };
     benchmark::RegisterBenchmark(get_name<scalar_t>(t1s, t2s, m, k, n).c_str(),
                                  BM_lambda, exPtr, t1, t2, m, k, n, alpha, beta,
-                                 success);
+                                 success)
+        ->UseRealTime();
   }
 }
 


### PR DESCRIPTION
Google benchmark provides a field for items per second. We can use this
to give the number of flops per second achieved by the benchmark, to
allow users to easily compare benchmark results and avoid having to
compute this value themselves.