### PR TITLE
Fix compile problems with GEMM auto tuners

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 
 option(BLAS_ENABLE_AUTO_TUNERS "Whether to enable building GEMM auto tuners" OFF)
 if(${BUILD_AUTO_TUNERS})
-  # Note that the auto tuners are very slow to compiler, so we avoid adding
+  # Note that the auto tuners are very slow to compile, so we avoid adding
   # them to the ALL target.
   add_subdirectory(tools/auto_tuner EXCLUDE_FROM_ALL)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,3 +123,10 @@ option(BUILD_EXPRESSION_BENCHMARKS "Whether to build the expression benchmarks" 
 if(${BLAS_ENABLE_BENCHMARK})
   add_subdirectory(benchmark)
 endif()
+
+option(BLAS_ENABLE_AUTO_TUNERS "Whether to enable building GEMM auto tuners" OFF)
+if(${BUILD_AUTO_TUNERS})
+  # Note that the auto tuners are very slow to compiler, so we avoid adding
+  # them to the ALL target.
+  add_subdirectory(tools/auto_tuner EXCLUDE_FROM_ALL)
+endif()

--- a/src/operations/blas3/gemm_ref.hpp
+++ b/src/operations/blas3/gemm_ref.hpp
@@ -178,13 +178,13 @@ SYCL_BLAS_INLINE void
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
      TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm, VectorSize,
      Aligned>::eval(cl::sycl::nd_item<1> id) noexcept {
-  const index_t wg_batch_id = id.get_group(0) / get_workgroup_cluster(m_, n_);
+  const index_t wg_batch_id = id.get_group(0) / get_workgroup_cluster();
   // This will disable all workgroups that dont have any batch to work on
   if (wg_batch_id >= batch_size_) {
     return;
   }
   const index_t batch_stride =
-      id.get_group_range(0) / get_workgroup_cluster(m_, n_);
+      id.get_group_range(0) / get_workgroup_cluster();
 
   const index_t a_size = trans_a ? m_ * lda_ : k_ * lda_;
   const index_t b_size = trans_b ? ldb_ * k_ : n_ * ldb_;
@@ -194,7 +194,7 @@ Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
   auto orig_B = b_.get_pointer() + (wg_batch_id * b_size);
   auto orig_C = c_.get_pointer() + (wg_batch_id * c_size);
 
-  index_t item_id = (id.get_group(0) % get_workgroup_cluster(m_, n_)) *
+  index_t item_id = (id.get_group(0) % get_workgroup_cluster()) *
                         (id.get_local_range(0)) +
                     id.get_local_id(0);
   if (item_id >= m_ * n_) {

--- a/tools/auto_tuner/CMakeLists.txt
+++ b/tools/auto_tuner/CMakeLists.txt
@@ -41,6 +41,10 @@ foreach(blas_tuner ${SYCL_AUTO_TUNNER_SRCS})
   set(TARGET tuner_exec ${blas_tuner})
   add_executable(${tuner_exec} ${blas_tuner})
   target_link_libraries(${tuner_exec} PRIVATE m blas::blas)
+  target_include_directories(${tuner_exec} PRIVATE
+    ${SYCLBLAS_INCLUDE}
+    ${COMPUTECPP_SDK_INCLUDE}
+  )
   add_dependencies(${tuner_exec} generate_combinations)
   add_sycl_to_target(
     TARGET ${tuner_exec}

--- a/tools/auto_tuner/include/gemm_tuner.hpp
+++ b/tools/auto_tuner/include/gemm_tuner.hpp
@@ -145,7 +145,7 @@ void tune(int r, GemmArgs<T, Container, Executor> a) {
       Gemm<typename Config::data_t, typename Config::data_t, DoubleBuffer, Nbca,
            Nbcb, Cls, Tile, Config::TransA, Config::TransB, T, false,
            static_cast<int>(Config::MemoryMode),
-           static_cast<int>(Config::ShapeMode)>;
+           static_cast<int>(Config::ShapeMode), 1, false>;
 
   using etype = typename Gemm::value_t;
   a.results.emplace_back(Gemm::get_type_string());


### PR DESCRIPTION
Recent changes to the build system and GEMM kernels caused problems with
the auto tuners. Some small fixes are needed to make them compile.

For now we use a hardcoded vector size of 1, but we should look into
extending the tuners to try different vector sizes to get optimal
performance.