### PR TITLE
Use STATUS mode in cmake messages

### DIFF
--- a/benchmark/acl/CMakeLists.txt
+++ b/benchmark/acl/CMakeLists.txt
@@ -27,7 +27,7 @@ foreach(acl_benchmark ${sources})
     target_compile_definitions(bench_acl_${acl_bench_exec} PRIVATE ACL_BACKEND_OPENCL)
   endif()
 
-  message("-- Created benchmark: ${acl_bench_exec}")
+  message(STATUS "Created benchmark: ${acl_bench_exec}")
   install(TARGETS bench_acl_${acl_bench_exec}
     RUNTIME
       DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/benchmark/clblast/CMakeLists.txt
+++ b/benchmark/clblast/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(clblast_benchmark ${sources})
     target_compile_definitions(bench_clblast_${clblast_bench_exec} PRIVATE BLAS_VERIFY_BENCHMARK)
   endif()
 
-  message("-- Created benchmark: ${clblast_bench_exec}")
+  message(STATUS "Created benchmark: ${clblast_bench_exec}")
   install(TARGETS bench_clblast_${clblast_bench_exec}
     RUNTIME
       DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -34,7 +34,7 @@ foreach(syclblas_bench ${sources})
     target_link_libraries(bench_${bench_exec} PRIVATE blas::blas)
   endif()
 
-  message("-- Created benchmark: ${bench_exec}")
+  message(STATUS "Created benchmark: ${bench_exec}")
   install(TARGETS bench_${bench_exec}
     RUNTIME
       DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -61,7 +61,7 @@ if(BUILD_EXPRESSION_BENCHMARKS)
       target_link_libraries(bench_${bench_exec} PRIVATE blas::blas)
     endif()
 
-    message("-- Created expression benchmark: ${bench_exec}")
+    message(STATUS "Created expression benchmark: ${bench_exec}")
     install(TARGETS bench_${bench_exec}
       RUNTIME
         DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/test/exprtest/CMakeLists.txt
+++ b/test/exprtest/CMakeLists.txt
@@ -48,7 +48,7 @@ foreach(blas_test ${SYCL_EXPRTEST_SRCS})
   else()
     add_test(NAME ${test_exec} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${test_exec})
   endif()
-  message("-- Created google test ${test_exec}")
+  message(STATUS "Created google test ${test_exec}")
   install(TARGETS ${test_exec}
     RUNTIME
       DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -71,7 +71,7 @@ foreach(blas_test ${SYCL_UNITTEST_SRCS})
   else()
     add_test(NAME ${test_exec} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${test_exec})
   endif()
-  message("-- Created google test ${test_exec}")
+  message(STATUS "Created google test ${test_exec}")
   install(TARGETS ${test_exec}
     RUNTIME
       DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
Messages without any mode are considered important by cmake, so will
always be shown through stderr. STATUS messages are less important,
shown through stdout and are prefixed by "-- ". None of the test and
benchmark creation messages are errors or especially important, so
should use STATUS rather trying to mimic the message format.