### PR TITLE
Refactor GEMM tests to use single function

### DIFF
--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -57,7 +57,11 @@ using namespace blas;
 using test_executor_t =
     class blas::Executor<blas::PolicyHandler<blas::codeplay_policy>>;
 
-inline cl::sycl::queue make_queue() {
+/**
+ * Construct a SYCL queue using the device specified in the command line, or
+ * using the default device if not specified.
+ */
+inline cl::sycl::queue make_queue_impl() {
   std::unique_ptr<cl::sycl::device_selector> selector;
   if (args.device.empty()) {
     selector = std::unique_ptr<cl::sycl::device_selector>(
@@ -84,6 +88,15 @@ inline cl::sycl::queue make_queue() {
   utils::print_queue_information(q);
   return q;
 };
+
+/**
+ * Get a SYCL queue to use in tests.
+ */
+inline cl::sycl::queue make_queue() {
+  // Provide cached SYCL queue, to avoid recompiling kernels for each test case.
+  static cl::sycl::queue queue = make_queue_impl();
+  return queue;
+}
 
 /**
  * @fn random_data

--- a/test/unittest/blas3/blas3_gemm_batched_test.cpp
+++ b/test/unittest/blas3/blas3_gemm_batched_test.cpp
@@ -26,97 +26,35 @@
 #include "blas3_gemm_common.hpp"
 #include "blas_test.hpp"
 
-template <typename T>
-using combination_t =
-    std::tuple<int, int, int, int, char, char, T, T, int, int, int>;
+const auto BetaNonZeroLDMatch =
+    ::testing::Combine(::testing::Values(0),         // offset
+                       ::testing::Values(5),         // batch
+                       ::testing::Values(63, 128),   // m
+                       ::testing::Values(63, 128),   // n
+                       ::testing::Values(63, 128),   // k
+                       ::testing::Values('n', 't'),  // transa
+                       ::testing::Values('n', 't'),  // transb
+                       ::testing::Values(1.0),       // alpha
+                       ::testing::Values(1.0),       // beta
+                       ::testing::Values(1),         // lda_mul
+                       ::testing::Values(1),         // ldb_mul
+                       ::testing::Values(1)          // ldc_mul
+                       );
+GENERATE_GEMM_TEST(BatchGemm, BetaNonZeroLDMatch);
 
-template <typename T>
-class Aaa;
+const auto BetaNonZeroLDMultiplied =
+    ::testing::Combine(::testing::Values(0),         // offset
+                       ::testing::Values(5),         // batch
+                       ::testing::Values(63, 128),   // m
+                       ::testing::Values(63, 128),   // n
+                       ::testing::Values(63, 128),   // k
+                       ::testing::Values('n', 't'),  // transa
+                       ::testing::Values('n', 't'),  // transb
+                       ::testing::Values(1.0),       // alpha
+                       ::testing::Values(1.0),       // beta
+                       ::testing::Values(2),         // lda_mul
+                       ::testing::Values(3),         // ldb_mul
+                       ::testing::Values(4)          // ldc_mul
+                       );
+GENERATE_GEMM_TEST(BatchGemm, BetaNonZeroLDMultiplied);
 
-template <typename scalar_t>
-void run_test(const combination_t<scalar_t> combi) {
-  int batch_size;
-  int m;
-  int n;
-  int k;
-  char transa;
-  char transb;
-  scalar_t alpha;
-  scalar_t beta;
-  int lda_mul;
-  int ldb_mul;
-  int ldc_mul;
-  std::tie(batch_size, m, n, k, transa, transb, alpha, beta, lda_mul, ldb_mul,
-           ldc_mul) = combi;
-
-  const char ta_str[2] = {transa, '\0'};
-  const char tb_str[2] = {transb, '\0'};
-
-  auto _size = [=](const std::array<int, 2> &dim, int ld_mul) {
-    return dim[0] * dim[1] * batch_size * ld_mul;
-  };
-  auto _base = [=](const std::array<int, 2> &dim, int ld_mul, int bs) {
-    return dim[0] * dim[1] * ld_mul * bs;
-  };
-
-  auto q = make_queue();
-  test_executor_t ex(q);
-
-  auto policy_handler = ex.get_policy_handler();
-
-  std::array<int, 2> dim_a = {m, k};
-  std::array<int, 2> dim_b = {k, n};
-  std::array<int, 2> dim_c = {m, n};
-
-  int lda = ((transa != 'n') ? dim_a[1] : dim_a[0]) * lda_mul;
-  int ldb = ((transb != 'n') ? dim_b[1] : dim_b[0]) * ldb_mul;
-  int ldc = dim_c[0] * ldc_mul;
-
-  std::vector<scalar_t> a_m(_size(dim_a, lda_mul));
-  std::vector<scalar_t> b_m(_size(dim_b, ldb_mul));
-  std::vector<scalar_t> c_m_gpu(_size(dim_c, ldc_mul));
-  std::vector<scalar_t> c_m_cpu(_size(dim_c, ldc_mul));
-
-  fill_random(a_m);
-  fill_random(b_m);
-  fill_random(c_m_gpu);
-  std::copy(c_m_gpu.begin(), c_m_gpu.end(), c_m_cpu.begin());
-
-  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(_size(dim_a, lda_mul));
-  auto m_b_gpu = blas::make_sycl_iterator_buffer<scalar_t>(_size(dim_b, ldb_mul));
-  auto m_c_gpu = blas::make_sycl_iterator_buffer<scalar_t>(_size(dim_c, ldc_mul));
-
-  for (int bs = 0; bs < batch_size; bs++) {
-    // Use system blas to create a reference output
-    reference_blas::gemm(ta_str, tb_str, m, n, k, alpha,
-                         a_m.data() + _base(dim_a, lda_mul, bs), lda,
-                         b_m.data() + _base(dim_b, ldb_mul, bs), ldb, beta,
-                         c_m_cpu.data() + _base(dim_c, ldc_mul, bs), ldc);
-  }
-
-  policy_handler.copy_to_device(a_m.data(), m_a_gpu, _size(dim_a, lda_mul));
-  policy_handler.copy_to_device(b_m.data(), m_b_gpu, _size(dim_b, ldb_mul));
-  policy_handler.copy_to_device(c_m_gpu.data(), m_c_gpu, _size(dim_c, ldc_mul));
-
-  // SYCL BLAS batched GEMM implementation
-  _gemm_batched(ex, transa, transb, m, n, k, alpha, m_a_gpu, lda, m_b_gpu, ldb,
-                beta, m_c_gpu, ldc, batch_size);
-  auto event = policy_handler.copy_to_host(m_c_gpu, c_m_gpu.data(),
-                                           _size(dim_c, ldc_mul));
-  policy_handler.wait(event);
-
-  ASSERT_TRUE(utils::compare_vectors(c_m_gpu, c_m_cpu));
-  ex.get_policy_handler().wait();
-}
-
-class GemmFloatBatched : public ::testing::TestWithParam<combination_t<float>> {
-};
-TEST_P(GemmFloatBatched, test) { run_test<float>(GetParam()); };
-INSTANTIATE_TEST_SUITE_P(gemm, GemmFloatBatched, combi);
-
-#if DOUBLE_SUPPORT
-class GemmDoubleBatched
-    : public ::testing::TestWithParam<combination_t<double>> {};
-TEST_P(GemmDoubleBatched, test) { run_test<double>(GetParam()); };
-INSTANTIATE_TEST_SUITE_P(gemm, GemmDoubleBatched, combi);
-#endif

--- a/test/unittest/blas3/blas3_gemm_common.hpp
+++ b/test/unittest/blas3/blas3_gemm_common.hpp
@@ -30,7 +30,7 @@ using gemm_arguments_t =
     std::tuple<int, int, int, int, int, char, char, T, T, int, int, int>;
 
 template <typename scalar_t>
-void verify_gemm(const gemm_arguments_t<scalar_t> arguments) {
+inline void verify_gemm(const gemm_arguments_t<scalar_t> arguments) {
   int offset;
   int batch;
   int m;

--- a/test/unittest/blas3/blas3_gemm_common.hpp
+++ b/test/unittest/blas3/blas3_gemm_common.hpp
@@ -25,37 +25,109 @@
 
 #include "blas_test.hpp"
 
-#ifdef STRESS_TESTING
-// This takes about ~6 hours on a decent CPU. Watch out!
-const auto combi = ::testing::Combine(
-    ::testing::Values(1, 5),  // batch_size
-    ::testing::Values(1, 11, 13, 39, 64, 127, 255, 512, 1023, 1025),  // m
-    ::testing::Values(14, 63, 257, 2, 31, 65, 255, 1023, 1025),       // n
-    ::testing::Values(2, 67, 253, 65, 11, 39, 127, 511, 1023, 1025),  // k
-    ::testing::Values('n', 't', 'c'),                                 // transa
-    ::testing::Values('n', 't', 'c'),                                 // transb
-    ::testing::Values(0.0, 1.0, 1.5),                                 // alpha
-    ::testing::Values(0.0, 1.0, 1.5),                                 // beta
-    ::testing::Values(1, 2),                                          // lda_mul
-    ::testing::Values(1, 3),                                          // ldb_mul
-    ::testing::Values(1, 2)                                           // ldc_mul
-);
-#else
-// For the purpose of travis and other slower platforms, we need a faster test
-const auto combi = ::testing::Combine(::testing::Values(5),        // batch_size
-                                      ::testing::Values(11, 512),  // m
-                                      ::testing::Values(14, 49),   // n
-                                      ::testing::Values(21),       // k
-                                      ::testing::Values('n', 't'),  // transa
-                                      ::testing::Values('n', 't'),  // transb
-                                      ::testing::Values(1.5),       // alpha
-                                      ::testing::Values(0.0, 1.5),  // beta
-                                      ::testing::Values(2),         // lda_mul
-                                      ::testing::Values(3),         // ldb_mul
-                                      ::testing::Values(2)          // ldc_mul
-);
-#endif
-
 template <typename T>
-using combination_t =
-    std::tuple<int, int, int, int, char, char, T, T, int, int, int>;
+using gemm_arguments_t =
+    std::tuple<int, int, int, int, int, char, char, T, T, int, int, int>;
+
+template <typename scalar_t>
+void verify_gemm(const gemm_arguments_t<scalar_t> arguments) {
+  int offset;
+  int batch;
+  int m;
+  int n;
+  int k;
+  char transa;
+  char transb;
+  scalar_t alpha;
+  scalar_t beta;
+  int lda_mul;
+  int ldb_mul;
+  int ldc_mul;
+  std::tie(offset, batch, m, n, k, transa, transb, alpha, beta, lda_mul,
+           ldb_mul, ldc_mul) = arguments;
+
+  const char ta_str[2] = {transa, '\0'};
+  const char tb_str[2] = {transb, '\0'};
+
+  auto q = make_queue();
+  test_executor_t ex(q);
+
+  auto policy_handler = ex.get_policy_handler();
+
+  const int lda = ((transa != 'n') ? k : m) * lda_mul;
+  const int ldb = ((transb != 'n') ? n : k) * ldb_mul;
+  const int ldc = m * ldc_mul;
+
+  const int size_a = m * k * lda_mul;
+  const int size_b = k * n * ldb_mul;
+  const int size_c = m * n * ldc_mul;
+
+  const int buffer_size_a = batch * size_a + offset;
+  const int buffer_size_b = batch * size_b + offset;
+  const int buffer_size_c = batch * size_c + offset;
+
+  std::vector<scalar_t> a_m(buffer_size_a);
+  std::vector<scalar_t> b_m(buffer_size_b);
+  std::vector<scalar_t> c_m_gpu(buffer_size_c);
+
+  fill_random(a_m);
+  fill_random(b_m);
+  fill_random(c_m_gpu);
+  std::vector<scalar_t> c_m_cpu = c_m_gpu;
+
+  // Use system blas to create a reference output
+  for (int i = 0; i < batch; ++i) {
+    reference_blas::gemm(ta_str, tb_str, m, n, k, alpha,
+                         a_m.data() + i * size_a + offset, lda,
+                         b_m.data() + i * size_b + offset, ldb, beta,
+                         c_m_cpu.data() + i * size_c + offset, ldc);
+  }
+
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(buffer_size_a);
+  auto m_b_gpu = blas::make_sycl_iterator_buffer<scalar_t>(buffer_size_b);
+  auto m_c_gpu = blas::make_sycl_iterator_buffer<scalar_t>(buffer_size_c);
+
+  policy_handler.copy_to_device(a_m.data(), m_a_gpu, buffer_size_a);
+  policy_handler.copy_to_device(b_m.data(), m_b_gpu, buffer_size_b);
+  policy_handler.copy_to_device(c_m_gpu.data(), m_c_gpu, buffer_size_c);
+
+  // SYCL BLAS GEMM implementation
+  if (batch == 1) {
+    _gemm(ex, transa, transb, m, n, k, alpha, m_a_gpu + offset, lda,
+          m_b_gpu + offset, ldb, beta, m_c_gpu + offset, ldc);
+  } else {
+    _gemm_batched(ex, transa, transb, m, n, k, alpha, m_a_gpu + offset, lda,
+                  m_b_gpu + offset, ldb, beta, m_c_gpu + offset, ldc, batch);
+  }
+
+  auto event =
+      policy_handler.copy_to_host(m_c_gpu, c_m_gpu.data(), buffer_size_c);
+  policy_handler.wait(event);
+
+  ASSERT_TRUE(utils::compare_vectors(c_m_gpu, c_m_cpu));
+  ex.get_policy_handler().wait();
+}
+
+#define GENERATE_GEMM_TEST_IMPL(TESTSUITE, TESTNAME, DTYPE, COMBINATION)      \
+  class TESTNAME : public ::testing::TestWithParam<gemm_arguments_t<DTYPE>> { \
+  };                                                                          \
+  TEST_P(TESTNAME, test) { verify_gemm<DTYPE>(GetParam()); };                 \
+  INSTANTIATE_TEST_SUITE_P(TESTSUITE, TESTNAME, COMBINATION)
+
+#define GENERATE_GEMM_WITH_DTYPE(TESTSUITE, DTYPE, COMBINATION) \
+  GENERATE_GEMM_TEST_IMPL(TESTSUITE, TESTSUITE##COMBINATION, DTYPE, COMBINATION)
+
+#define GENERATE_GEMM_FLOAT(TESTSUITE, COMBINATION) \
+  GENERATE_GEMM_WITH_DTYPE(TESTSUITE, float, COMBINATION)
+
+#ifdef DOUBLE_SUPPORT
+#define GENERATE_GEMM_DOUBLE(TESTSUITE, COMBINATION) \
+  GENERATE_GEMM_WITH_DTYPE(TESTSUITE, double, COMBINATION)
+#else
+#define GENERATE_GEMM_DOUBLE(TESTSUITE, COMBINATION)
+#endif  // DOUBLE_SUPPORT
+
+#define GENERATE_GEMM_TEST(TESTSUITE, COMBINATION) \
+  GENERATE_GEMM_FLOAT(TESTSUITE, COMBINATION);     \
+  GENERATE_GEMM_DOUBLE(TESTSUITE, COMBINATION)
+

--- a/test/unittest/blas3/blas3_gemm_tall_skinny_test.cpp
+++ b/test/unittest/blas3/blas3_gemm_tall_skinny_test.cpp
@@ -23,83 +23,22 @@
  *
  **************************************************************************/
 
+#include "blas3_gemm_common.hpp"
 #include "blas_test.hpp"
 
-template <typename scalar_t>
-using combination_t =
-    std::tuple<int, int, int, char, char, scalar_t, scalar_t, int, int, int>;
+const auto BatchOneSkinny =
+    ::testing::Combine(::testing::Values(0, 10),     // offset
+                       ::testing::Values(1),         // batch
+                       ::testing::Values(7, 65),     // m
+                       ::testing::Values(9, 126),    // n
+                       ::testing::Values(5678),      // k
+                       ::testing::Values('n', 't'),  // transa
+                       ::testing::Values('n', 't'),  // transb
+                       ::testing::Values(1.5),       // alpha
+                       ::testing::Values(0.0, 0.5),  // beta
+                       ::testing::Values(3),         // lda_mul
+                       ::testing::Values(2),         // ldb_mul
+                       ::testing::Values(1, 3)       // ldc_mul
+                       );
 
-const auto combi = ::testing::Combine(::testing::Values(7, 65),      // m
-                                      ::testing::Values(9, 126),     // n
-                                      ::testing::Values(5678),       // k
-                                      ::testing::Values('n', 't'),   // transa
-                                      ::testing::Values('n', 't'),   // transb
-                                      ::testing::Values(1.5),        // alpha
-                                      ::testing::Values(0.0, 0.5),   // beta
-                                      ::testing::Values(3),          // lda_mul
-                                      ::testing::Values(2),          // ldb_mul
-                                      ::testing::Values(1, 3)        // ldc_mul
-);
-
-template <typename scalar_t>
-void run_test(const combination_t<scalar_t> combi) {
-  int m, n, k;
-  char transa, transb;
-  scalar_t alpha, beta;
-  int lda_mul, ldb_mul, ldc_mul;
-  std::tie(m, n, k, transa, transb, alpha, beta, lda_mul, ldb_mul, ldc_mul) =
-      combi;
-
-  const char ta_str[2] = {transa, '\0'};
-  const char tb_str[2] = {transb, '\0'};
-
-  auto q = make_queue();
-  test_executor_t ex(q);
-
-  auto policy_handler = ex.get_policy_handler();
-
-  int lda = ((transa != 'n') ? k : m) * lda_mul;
-  int ldb = ((transb != 'n') ? n : k) * ldb_mul;
-  int ldc = m * ldc_mul;
-
-  std::vector<scalar_t> a_m(m * k * lda_mul);
-  std::vector<scalar_t> b_m(k * n * ldb_mul);
-  std::vector<scalar_t> c_m_gpu(m * n * ldc_mul);
-  std::vector<scalar_t> c_m_cpu(m * n * ldc_mul);
-
-  fill_random(a_m);
-  fill_random(b_m);
-  fill_random(c_m_gpu);
-  std::copy(c_m_gpu.begin(), c_m_gpu.end(), c_m_cpu.begin());
-
-  reference_blas::gemm(ta_str, tb_str, m, n, k, (scalar_t)alpha, a_m.data(), lda,
-                       b_m.data(), ldb, (scalar_t)beta, c_m_cpu.data(), ldc);
-
-  {
-    auto m_a_gpu =
-        blas::make_sycl_iterator_buffer<scalar_t>(a_m, m * k * lda_mul);
-    auto m_b_gpu =
-        blas::make_sycl_iterator_buffer<scalar_t>(b_m, k * n * ldb_mul);
-    auto m_c_gpu =
-        blas::make_sycl_iterator_buffer<scalar_t>(c_m_gpu, m * n * ldc_mul);
-    try {
-      _gemm(ex, transa, transb, m, n, k, alpha, m_a_gpu, lda, m_b_gpu, ldb, beta,
-            m_c_gpu, ldc);
-    } catch (cl::sycl::exception &e) {
-      std::cerr << "Exception occured:" << std::endl;
-      std::cerr << e.what() << std::endl;
-    }
-  }
-
-  ASSERT_TRUE(utils::compare_vectors(c_m_gpu, c_m_cpu));
-}
-
-class GemmTallSkinnyFloat : public ::testing::TestWithParam<combination_t<float>> {};
-TEST_P(GemmTallSkinnyFloat, test) { run_test<float>(GetParam()); };
-INSTANTIATE_TEST_SUITE_P(tsgemm, GemmTallSkinnyFloat, combi);
-
-#if DOUBLE_SUPPORT
-class GemmTallSkinnyDouble : public ::testing::TestWithParam<combination_t<double>> {};
-TEST_P(GemmTallSkinnyDouble, test) { run_test<double>(GetParam()); };
-INSTANTIATE_TEST_SUITE_P(tsgemm, GemmTallSkinnyDouble, combi);
-#endif
+GENERATE_GEMM_TEST(TallSkinnyGemm, BatchOneSkinny);

--- a/test/unittest/blas3/blas3_gemm_tall_skinny_test.cpp
+++ b/test/unittest/blas3/blas3_gemm_tall_skinny_test.cpp
@@ -26,19 +26,65 @@
 #include "blas3_gemm_common.hpp"
 #include "blas_test.hpp"
 
-const auto BatchOneSkinny =
-    ::testing::Combine(::testing::Values(0, 10),     // offset
+const auto BetaNonZeroLDMatch =
+    ::testing::Combine(::testing::Values(0),         // offset
                        ::testing::Values(1),         // batch
                        ::testing::Values(7, 65),     // m
                        ::testing::Values(9, 126),    // n
-                       ::testing::Values(5678),      // k
+                       ::testing::Values(2049),      // k
                        ::testing::Values('n', 't'),  // transa
                        ::testing::Values('n', 't'),  // transb
                        ::testing::Values(1.5),       // alpha
-                       ::testing::Values(0.0, 0.5),  // beta
-                       ::testing::Values(3),         // lda_mul
-                       ::testing::Values(2),         // ldb_mul
-                       ::testing::Values(1, 3)       // ldc_mul
+                       ::testing::Values(0.5),       // beta
+                       ::testing::Values(1),         // lda_mul
+                       ::testing::Values(1),         // ldb_mul
+                       ::testing::Values(1)          // ldc_mul
                        );
+GENERATE_GEMM_TEST(TallSkinnyGemm, BetaNonZeroLDMatch);
 
-GENERATE_GEMM_TEST(TallSkinnyGemm, BatchOneSkinny);
+const auto BetaNonZeroLDMultiplied =
+    ::testing::Combine(::testing::Values(0),         // offset
+                       ::testing::Values(1),         // batch
+                       ::testing::Values(7, 65),     // m
+                       ::testing::Values(9, 126),    // n
+                       ::testing::Values(2049),      // k
+                       ::testing::Values('n', 't'),  // transa
+                       ::testing::Values('n', 't'),  // transb
+                       ::testing::Values(1.5),       // alpha
+                       ::testing::Values(0.5),       // beta
+                       ::testing::Values(2),         // lda_mul
+                       ::testing::Values(3),         // ldb_mul
+                       ::testing::Values(4)          // ldc_mul
+                       );
+GENERATE_GEMM_TEST(TallSkinnyGemm, BetaNonZeroLDMultiplied);
+
+const auto BetaZero = ::testing::Combine(::testing::Values(0),         // offset
+                                         ::testing::Values(1),         // batch
+                                         ::testing::Values(7),         // m
+                                         ::testing::Values(9),         // n
+                                         ::testing::Values(1026),      // k
+                                         ::testing::Values('n', 't'),  // transa
+                                         ::testing::Values('n', 't'),  // transb
+                                         ::testing::Values(1.5),       // alpha
+                                         ::testing::Values(0.0),       // beta
+                                         ::testing::Values(1),  // lda_mul
+                                         ::testing::Values(1),  // ldb_mul
+                                         ::testing::Values(1)   // ldc_mul
+                                         );
+GENERATE_GEMM_TEST(TallSkinnyGemm, BetaZero);
+
+const auto OffsetNonZero =
+    ::testing::Combine(::testing::Values(10),        // offset
+                       ::testing::Values(1),         // batch
+                       ::testing::Values(7),         // m
+                       ::testing::Values(9),         // n
+                       ::testing::Values(1026),      // k
+                       ::testing::Values('n', 't'),  // transa
+                       ::testing::Values('n', 't'),  // transb
+                       ::testing::Values(1.5),       // alpha
+                       ::testing::Values(0.5),       // beta
+                       ::testing::Values(1),         // lda_mul
+                       ::testing::Values(1),         // ldb_mul
+                       ::testing::Values(1)          // ldc_mul
+                       );
+GENERATE_GEMM_TEST(TallSkinnyGemm, OffsetNonZero);


### PR DESCRIPTION
Rather than having a duplicated verification function in each source
file, we can provide a single GEMM verification function in a header,
and then unify how the tests are registered in GTest with a single
macro. This allows different kernel parameters and test cases to be
easily added and amended.

Provide a cached SYCL queue to avoid recompiling kernels in each test
case. This can significantly improve test runtime.