### PR TITLE
Vectorizing gemm no_local memory kernel

### DIFF
--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -156,7 +156,7 @@ elseif(${TARGET} STREQUAL "AMD_GPU")  # need investigation
   endif()
 else() # default cpu backend
   set(gemm_configuration_0 "float"  64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "naive" 1)
-  set(gemm_configuration_1 "float"  64 "false" "false" "false" 64 8 8 8 8 1 1 "local" "standard" 1)
+  set(gemm_configuration_1 "float"  64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" 1)
   set(gemm_configuration_2 "double" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "naive" 1)
   set(gemm_configuration_3 "double" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" 1)
 

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -155,10 +155,10 @@ elseif(${TARGET} STREQUAL "AMD_GPU")  # need investigation
     endif()
   endif()
 else() # default cpu backend
-  set(gemm_configuration_0 "float"  64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "naive" 8)
-  set(gemm_configuration_1 "float"  64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" 8)
-  set(gemm_configuration_2 "double" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "naive" 8)
-  set(gemm_configuration_3 "double" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" 8)
+  set(gemm_configuration_0 "float"  64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "naive" 1)
+  set(gemm_configuration_1 "float"  64 "false" "false" "false" 64 8 8 8 8 1 1 "local" "standard" 1)
+  set(gemm_configuration_2 "double" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "naive" 1)
+  set(gemm_configuration_3 "double" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" 1)
 
   if(NAIVE_GEMM)
     list(APPEND gemm_configuration_lists gemm_configuration_0)

--- a/src/interface/blas3/backend/default_cpu.hpp
+++ b/src/interface/blas3/backend/default_cpu.hpp
@@ -49,7 +49,7 @@ typename executor_t::policy_t::event_t _gemm(
       64, false, false, false, 64, Tile<8, 8, 8, 8>, _t_a, _t_b,
       static_cast<int>(gemm_memory_t::no_local),
       static_cast<int>(gemm_algorithm_t::standard), is_beta_zero,
-      8>::template _select_gemm(ex, _M, _N, _K, _alpha, _a, _lda, _b, _ldb,
+      1>::template _select_gemm(ex, _M, _N, _K, _alpha, _a, _lda, _b, _ldb,
                                 _beta, _c, _ldc, batch_size);
 #endif
 }

--- a/src/operations/blas3/gemm_load_store.hpp
+++ b/src/operations/blas3/gemm_load_store.hpp
@@ -35,9 +35,11 @@ packet size. SFINAE is used to select the appropriate method when called.
 * @tparam vector_size The desired vector size to be used. If
 GEMM_VECTORIZATION_SUPPORT is not enabled in CMake a vector_size of 1 will be
 used no matter what value is passed here.
-* @tparam The type of the matrix data (typically float or double, if supported).
+* @tparam value_t The type of the matrix data (typically float or double, if
+supported).
+* @tparam index_t The type of the matrix indices.
 */
-template <bool aligned, size_t vector_size, typename value_t>
+template <bool aligned, size_t vector_size, typename value_t, typename index_t>
 struct Packetize {
 #ifdef GEMM_VECTORIZATION_SUPPORT
   using PacketType = cl::sycl::vec<value_t, vector_size>;
@@ -55,13 +57,13 @@ struct Packetize {
    * checking is required.
    * @tparam ld The leading dimension of the destination memory.
    */
-  template <bool trans, bool internal, int ld, typename packet_t = PacketType,
-            typename SrcPointerType, typename DestPointerType, typename index_t,
-            typename EdgePredicate, bool align = aligned>
+  template <bool trans, bool internal, int ld, typename SrcPointerType,
+            typename DestPointerType, typename EdgePredicate,
+            bool align = aligned>
   static SYCL_BLAS_INLINE typename std::enable_if<(!internal)>::type load(
-      const bool in_range, SrcPointerType src, const index_t &src_offset,
-      DestPointerType dest, const index_t &dest_offset, EdgePredicate) {
-    *(dest + dest_offset) = in_range ? *(src + src_offset) : value_t{0};
+      const bool in_range, SrcPointerType src, DestPointerType dest,
+      EdgePredicate) {
+    *(dest) = in_range ? *(src) : value_t{0};
   }
   /*! @brief Performs a vectorised load using sycl::vec::load when the current
    * block is internal and the memory is not aligned. In the case where k < the
@@ -71,38 +73,36 @@ struct Packetize {
    * @tparam internal True if the current block is internal and no bounds
    * checking is required.
    * @tparam ld The leading dimension of the destination memory. */
-  template <bool trans, bool internal, int ld, typename packet_t = PacketType,
-            typename SrcPointerType, typename DestPointerType, typename index_t,
-            typename EdgePredicate, bool align = aligned>
+  template <bool trans, bool internal, int ld, typename SrcPointerType,
+            typename DestPointerType, typename EdgePredicate,
+            bool align = aligned>
   static SYCL_BLAS_INLINE typename std::enable_if<(internal && !align)>::type
-  load(const bool in_range, SrcPointerType src, const index_t &src_offset,
-       DestPointerType dest, const index_t &dest_offset,
+  load(const bool in_range, SrcPointerType src, DestPointerType dest,
        EdgePredicate edge_in_range) {
-    packet_t packet{0};
+    PacketType packet{0};
     if (in_range) {
       using address_t = cl::sycl::access::address_space;
-      packet.template load<address_t::global_space>(0, src + src_offset);
+      packet.template load<address_t::global_space>(0, src);
     } else {
 #pragma unroll
       for (index_t i = 0; i < packet_size; i++) {
         reinterpret_cast<value_t *>(&packet)[i] =
-            edge_in_range(i) ? *(src + src_offset + i) : 0;
+            edge_in_range(i) ? *(src + i) : 0;
       }
     }
-    store<trans, ld>(packet, dest, dest_offset);
+    store<trans, ld>(packet, dest);
   }
   /*! @brief Store a vector packet into local memory when the source is
    * transposed. This will untranspose the elements individually when storing so
    * the data in local memory is always consistent.
    * @tparam trans Whether the source matrix is transposed or not.
    * @tparam ld The leading dimension of the destination memory.*/
-  template <bool trans, int ld, typename packet_t = PacketType,
-            typename DestPointerType, typename index_t>
+  template <bool trans, int ld, typename DestPointerType>
   static SYCL_BLAS_INLINE typename std::enable_if<trans>::type store(
-      packet_t &packet, DestPointerType dest, const index_t &dest_offset) {
+      PacketType &packet, DestPointerType dest) {
 #pragma unroll
     for (index_t i = 0; i < packet_size; i++) {
-      *(dest + dest_offset + ld * i) = reinterpret_cast<value_t *>(&packet)[i];
+      *(dest + ld * i) = reinterpret_cast<value_t *>(&packet)[i];
     }
   }
 
@@ -110,12 +110,11 @@ struct Packetize {
    * transposed. This will use sycl::vec::store function.
    * @tparam trans Whether the source matrix is transposed or not.
    * @tparam ld The leading dimension of the destination memory.*/
-  template <bool trans, int ld, typename packet_t = PacketType,
-            typename DestPointerType, typename index_t>
+  template <bool trans, int ld, typename DestPointerType>
   static SYCL_BLAS_INLINE typename std::enable_if<!trans>::type store(
-      packet_t &packet, DestPointerType dest, const index_t &dest_offset) {
+      PacketType &packet, DestPointerType dest) {
     using address_t = cl::sycl::access::address_space;
-    packet.template store<address_t::local_space>(0, dest + dest_offset);
+    packet.template store<address_t::local_space>(0, dest);
   }
 
   // Aligned versions of functions
@@ -128,24 +127,20 @@ struct Packetize {
    * @tparam internal True if the current block is internal and no bounds
    * checking is required.
    * @tparam ld The leading dimension of the destination memory. */
-  template <bool trans, bool internal, int ld, typename packet_t = PacketType,
-            typename SrcPointerType, typename DestPointerType, typename index_t,
-            typename EdgePredicate, bool align = aligned>
+  template <bool trans, bool internal, int ld, typename SrcPointerType,
+            typename DestPointerType, typename EdgePredicate,
+            bool align = aligned>
   static SYCL_BLAS_INLINE
       typename std::enable_if<(internal && !trans && align)>::type
-      load(const bool in_range, SrcPointerType src, const index_t &src_offset,
-           DestPointerType dest, const index_t &dest_offset,
+      load(const bool in_range, SrcPointerType src, DestPointerType dest,
            EdgePredicate edge_in_range) {
     if (in_range) {
-      *reinterpret_cast<packet_t *>(
-          static_cast<value_t *>(dest + dest_offset)) =
-          *reinterpret_cast<packet_t *>(
-              static_cast<value_t *>(src + src_offset));
+      *reinterpret_cast<PacketType *>(static_cast<value_t *>(dest)) =
+          *reinterpret_cast<PacketType *>(static_cast<value_t *>(src));
     } else {
 #pragma unroll
       for (index_t i = 0; i < packet_size; i++) {
-        *(dest + dest_offset) =
-            edge_in_range(i) ? *(src + src_offset + i) : value_t{0};
+        *(dest) = edge_in_range(i) ? *(src + i) : value_t{0};
       }
     }
   }
@@ -157,26 +152,24 @@ struct Packetize {
    * @tparam internal True if the current block is internal and no bounds
    * checking is required.
    * @tparam ld The leading dimension of the destination memory. */
-  template <bool trans, bool internal, int ld, typename packet_t = PacketType,
-            typename SrcPointerType, typename DestPointerType, typename index_t,
-            typename EdgePredicate, bool align = aligned>
+  template <bool trans, bool internal, int ld, typename SrcPointerType,
+            typename DestPointerType, typename EdgePredicate,
+            bool align = aligned>
   static SYCL_BLAS_INLINE
       typename std::enable_if<(internal && trans && align)>::type
-      load(const bool in_range, SrcPointerType src, const index_t &src_offset,
-           DestPointerType dest, const index_t &dest_offset,
+      load(const bool in_range, SrcPointerType src, DestPointerType dest,
            EdgePredicate edge_in_range) {
-    packet_t packet{0};
+    PacketType packet{0};
     if (in_range) {
-      packet = *reinterpret_cast<packet_t *>(
-          static_cast<value_t *>(src + src_offset));
-      store<trans, ld>(packet, dest, dest_offset);
+      packet = *reinterpret_cast<PacketType *>(static_cast<value_t *>(src));
+      store<trans, ld>(packet, dest);
     } else {
 #pragma unroll
       for (index_t i = 0; i < packet_size; i++) {
         reinterpret_cast<value_t *>(&packet)[i] =
-            edge_in_range(i) ? *(src + src_offset + i) : 0;
+            edge_in_range(i) ? *(src + i) : 0;
       }
-      store<trans, ld>(packet, dest, dest_offset);
+      store<trans, ld>(packet, dest);
     }
   }
 };

--- a/src/operations/blas3/gemm_load_store.hpp
+++ b/src/operations/blas3/gemm_load_store.hpp
@@ -39,9 +39,7 @@ used no matter what value is passed here.
 supported).
 * @tparam index_t The type of the matrix indices.
 */
-template <bool aligned, size_t vector_size, typename value_t, typename index_t,
-          cl::sycl::access::address_space src_space,
-          cl::sycl::access::address_space dst_space>
+template <bool aligned, size_t vector_size, typename value_t, typename index_t>
 struct Packetize {
 #ifdef GEMM_VECTORIZATION_SUPPORT
   using PacketType = cl::sycl::vec<value_t, vector_size>;
@@ -65,7 +63,6 @@ struct Packetize {
   static SYCL_BLAS_INLINE typename std::enable_if<(!internal)>::type load(
       const bool in_range, SrcPointerType src, DestPointerType dest,
       EdgePredicate) {
-    // printf("LOAD in_range: %d src: %f\n", in_range, *src);
     *(dest) = in_range ? *(src) : value_t{0};
   }
   /*! @brief Performs a vectorised load using sycl::vec::load when the current
@@ -84,7 +81,8 @@ struct Packetize {
        EdgePredicate edge_in_range) {
     PacketType packet{0};
     if (in_range) {
-      packet.template load<src_space>(0, src);
+      using address_t = cl::sycl::access::address_space;
+      packet.template load<address_t::global_space>(0, src);
     } else {
 #pragma unroll
       for (index_t i = 0; i < packet_size; i++) {
@@ -116,7 +114,7 @@ struct Packetize {
   static SYCL_BLAS_INLINE typename std::enable_if<!trans>::type store(
       PacketType &packet, DestPointerType dest) {
     using address_t = cl::sycl::access::address_space;
-    packet.template store<dst_space>(0, dest);
+    packet.template store<address_t::local_space>(0, dest);
   }
 
   // Aligned versions of functions

--- a/src/operations/blas3/gemm_load_store.hpp
+++ b/src/operations/blas3/gemm_load_store.hpp
@@ -28,7 +28,7 @@
 namespace blas {
 
 /*! @brief Contains static methods for loading and storing vector packets
-from/to non-vectorised memory as well as some constants for the vector type and
+from/to non-vectorized memory as well as some constants for the vector type and
 packet size. SFINAE is used to select the appropriate method when called.
 * @tparam aligned If both matrix's memory is aligned then this will control the
 * use of reinterpret_cast instead of vload/vstore.
@@ -50,7 +50,7 @@ struct Packetize {
   static constexpr size_t packet_size = 1;
 #endif
 
-  /*! @brief Performs a coalesced non-vectorised load when the current block is
+  /*! @brief Performs a coalesced non-vectorized load when the current block is
    * not internal.
    * @tparam trans Whether the source matrix is transposed or not.
    * @tparam internal True if the current block is internal and no bounds
@@ -65,7 +65,7 @@ struct Packetize {
       EdgePredicate) {
     *(dest) = in_range ? *(src) : value_t{0};
   }
-  /*! @brief Performs a vectorised load using sycl::vec::load when the current
+  /*! @brief Performs a vectorized load using sycl::vec::load when the current
    * block is internal and the memory is not aligned. In the case where k < the
    * number of elements being loaded then edge loads will be element wise with
    * additional bounds checking.
@@ -119,7 +119,7 @@ struct Packetize {
 
   // Aligned versions of functions
 
-  /*! @brief Performs a vectorised load using reinterpret_cast when the current
+  /*! @brief Performs a vectorized load using reinterpret_cast when the current
    * block is internal, the memory is aligned and the source is not transposed.
    * In the case where k < the number of elements being loaded then edge loads
    * will be element wise with additional bounds checking.
@@ -144,7 +144,7 @@ struct Packetize {
       }
     }
   }
-  /*! @brief Performs a vectorised load using sycl::vec load when the current
+  /*! @brief Performs a vectorized load using sycl::vec load when the current
    * block is internal, the memory is aligned and the source is transposed.
    * In the case where k < the number of elements being loaded then edge loads
    * will be element wise with additional bounds checking.

--- a/src/operations/blas3/gemm_local.hpp
+++ b/src/operations/blas3/gemm_local.hpp
@@ -76,11 +76,9 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType,
   using tile_type = TileType;
   using value_t = element_t;
   using index_t = typename std::make_signed<typename input_t::index_t>::type;
-  using address_t = cl::sycl::access::address_space;
-  using packetize_t =
-      Packetize<Aligned, VectorSize, value_t, index_t, address_t::global_space,
-                address_t::local_space>;
+  using packetize_t = Packetize<Aligned, VectorSize, value_t, index_t>;
   using vector_t = typename packetize_t::PacketType;
+  using address_t = cl::sycl::access::address_space;
 
   // enable easier access to tile dimensions
   static constexpr index_t item_rows = tile_type::item_rows;

--- a/src/operations/blas3/gemm_local.hpp
+++ b/src/operations/blas3/gemm_local.hpp
@@ -29,10 +29,6 @@
 #include "gemm_load_store.hpp"
 
 namespace blas {
-#define SHOULD_PRINT
-#define ID_TO_PRINT 0
-#define WG_TO_PRINT 0
-// Vectorization stuff
 
 /*!
  * @brief GemmFactory is a template class whose instantiations provide

--- a/src/operations/blas3/gemm_local.hpp
+++ b/src/operations/blas3/gemm_local.hpp
@@ -76,9 +76,11 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType,
   using tile_type = TileType;
   using value_t = element_t;
   using index_t = typename std::make_signed<typename input_t::index_t>::type;
-  using packetize_t = Packetize<Aligned, VectorSize, value_t, index_t>;
-  using vector_t = typename packetize_t::PacketType;
   using address_t = cl::sycl::access::address_space;
+  using packetize_t =
+      Packetize<Aligned, VectorSize, value_t, index_t, address_t::global_space,
+                address_t::local_space>;
+  using vector_t = typename packetize_t::PacketType;
 
   // enable easier access to tile dimensions
   static constexpr index_t item_rows = tile_type::item_rows;

--- a/src/operations/blas3/gemm_no_local.hpp
+++ b/src/operations/blas3/gemm_no_local.hpp
@@ -63,9 +63,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
   using value_t = element_t;
   using index_t = typename std::make_signed<typename input_t::index_t>::type;
   using address_t = cl::sycl::access::address_space;
-  using packetize_t =
-      Packetize<Aligned, VectorSize, value_t, index_t, address_t::global_space,
-                address_t::private_space>;
+  using packetize_t = Packetize<Aligned, VectorSize, value_t, index_t>;
   static constexpr int local_memory_size = 0;
   /*! @brief The number of rows processed by each work item */
   static constexpr index_t item_rows = tile_type::item_rows;

--- a/src/operations/blas3/gemm_no_local.hpp
+++ b/src/operations/blas3/gemm_no_local.hpp
@@ -208,9 +208,9 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
     const bool is_internal_block =
         (m - wg_row >= block_rows) && (n - wg_col >= block_cols);
 
-    /// Packet size for A. It can only be vectorised if it is not transposed.
+    /// Packet size for A. It can only be vectorized if it is not transposed.
     constexpr index_t a_packet_size = (trans_a ? 1 : packetize_t::packet_size);
-    /// Packet size for B. It can only be vectorised if it is transposed.
+    /// Packet size for B. It can only be vectorized if it is transposed.
     constexpr index_t b_packet_size = (trans_b ? packetize_t::packet_size : 1);
 
     /* work item id per row */

--- a/src/operations/blas3/gemm_no_local.hpp
+++ b/src/operations/blas3/gemm_no_local.hpp
@@ -452,8 +452,11 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
     if (out_of_range) {
       return;
     }
+    // Work done in this loop is reduced proportionally to the work done per
+    // load (vector packet size).
 #pragma unroll
     for (int i = 0; i < item_size / work_per_load; i++) {
+      // Check that the last element of the packet loaded is in range
       bool in_range =
           do_check<check_block>(chk_boundary(index + (work_per_load - 1)));
 
@@ -463,6 +466,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
       }
       in_vec.template store<address_t::private_space>(0, reg);
 
+      // Move pointers and update index for next load
       ptr += ld;
       index += next_element;
       reg += work_per_load;
@@ -533,7 +537,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
       return;
     }
 #pragma unroll
-    for (int i = 0; i < item_cols; ++i) {
+    for (int i = 0; i < item_cols; i++) {
 #pragma unroll
       for (int j = 0; j < item_rows / a_packet_size; j++) {
         if (do_check<check_block>(chk_boundary(dim_m_c_start + j * wg_rows,
@@ -553,7 +557,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
                 : ldc);
     }
   }
-};  // namespace blas
+};  // end class Gemm
 
 }  // namespace blas
 

--- a/src/operations/blas3/gemm_no_local.hpp
+++ b/src/operations/blas3/gemm_no_local.hpp
@@ -208,10 +208,9 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
     const bool is_internal_block =
         (m - wg_row >= block_rows) && (n - wg_col >= block_cols);
 
-    /* @brief Packet sizes for A and B. A can only be vectorised if it is not
-     * transposed and vice-versa with B
-     */
+    /// Packet size for A. It can only be vectorised if it is not transposed.
     constexpr index_t a_packet_size = (trans_a ? 1 : packetize_t::packet_size);
+    /// Packet size for B. It can only be vectorised if it is transposed.
     constexpr index_t b_packet_size = (trans_b ? packetize_t::packet_size : 1);
 
     /* work item id per row */


### PR DESCRIPTION
Vectorizes the no_local memory gemm kernel. Currently it is slightly limited in that A is only vectorized when not transposed and B is only vectorized when it is transposed. This still provides good performance on Intel GPU. Default CPU backend vector size has been set to 1 as the likely increased register pressure hurts performance.