### PR TITLE
Remove aligned load/store functions from gemm load store

### DIFF
--- a/include/executors/executor.h
+++ b/include/executors/executor.h
@@ -74,22 +74,22 @@ class Executor {
   template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
             bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
             typename element_t, bool is_beta_zero, int GemmMemoryType,
-            int GemmAlgorithm, int VectorSize, bool Aligned>
+            int GemmAlgorithm, int VectorSize>
   typename policy_t::event_t execute(
       Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
            TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-           GemmAlgorithm, VectorSize, Aligned>
+           GemmAlgorithm, VectorSize>
           gemm_tree);
 
   // Tall and skinny Gemm specialization
   template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
             bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
             typename element_t, bool is_beta_zero, int GemmMemoryType,
-            int VectorSize, bool Aligned>
+            int VectorSize>
   typename policy_t::event_t execute(
       Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
            TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-           static_cast<int>(gemm_algorithm_t::tall_skinny), VectorSize, Aligned>
+           static_cast<int>(gemm_algorithm_t::tall_skinny), VectorSize>
           gemm_wrapper);
 
   // GemmPartial specialization

--- a/include/operations/blas3_trees.h
+++ b/include/operations/blas3_trees.h
@@ -156,7 +156,7 @@ struct Tile {
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int VectorSize, bool Aligned>
+          int GemmAlgorithm, int VectorSize>
 class Gemm {
  public:
   using value_t = element_t;
@@ -205,17 +205,17 @@ class GemmPartial {};
  */
 template <bool DoubleBuffer, bool ConflictA, bool ConflictB, int ClSize,
           typename TileType, bool TransA, bool TransB, int GemmMemoryType,
-          int GemmAlgorithm, bool is_beta_zero, int VectorSize, bool Aligned,
+          int GemmAlgorithm, bool is_beta_zero, int VectorSize,
           typename input_t, typename output_t, typename element_t,
           typename index_t>
 inline Gemm<input_t, output_t, DoubleBuffer, ConflictA, ConflictB, ClSize,
             TileType, TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-            GemmAlgorithm, VectorSize, Aligned>
+            GemmAlgorithm, VectorSize>
 make_gemm(input_t buffer_a, input_t buffer_b, output_t buffer_c,
           element_t alpha, element_t beta, index_t batch_size) {
   return Gemm<input_t, output_t, DoubleBuffer, ConflictA, ConflictB, ClSize,
               TileType, TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-              GemmAlgorithm, VectorSize, Aligned>(buffer_a, buffer_b, buffer_c,
+              GemmAlgorithm, VectorSize>(buffer_a, buffer_b, buffer_c,
                                                   alpha, beta, batch_size);
 }
 

--- a/src/executors/executor_sycl.hpp
+++ b/src/executors/executor_sycl.hpp
@@ -216,16 +216,16 @@ template <>
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int VectorSize, bool Aligned>
+          int GemmAlgorithm, int VectorSize>
 inline typename codeplay_policy::event_t
 Executor<PolicyHandler<codeplay_policy>>::execute(
     Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
          TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-         VectorSize, Aligned>
+         VectorSize>
         gemm_tree) {
   using gemm_t = Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize,
                       tile_type, TransA, TransB, element_t, is_beta_zero,
-                      GemmMemoryType, GemmAlgorithm, VectorSize, Aligned>;
+                      GemmMemoryType, GemmAlgorithm, VectorSize>;
   auto rng = gemm_tree.get_nd_range(policy_handler_.get_num_compute_units());
   return {execute_tree<
       Choose<GemmMemoryType == static_cast<int>(gemm_memory_t::local), int,
@@ -239,12 +239,12 @@ template <>
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int VectorSize, bool Aligned>
+          int VectorSize>
 inline typename codeplay_policy::event_t
 Executor<PolicyHandler<codeplay_policy>>::execute(
     Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
          TransB, element_t, is_beta_zero, GemmMemoryType,
-         static_cast<int>(gemm_algorithm_t::tall_skinny), VectorSize, Aligned>
+         static_cast<int>(gemm_algorithm_t::tall_skinny), VectorSize>
         gemm_wrapper) {
   using index_t = typename std::make_signed<typename input_t::index_t>::type;
 

--- a/src/interface/gemm_launcher.hpp
+++ b/src/interface/gemm_launcher.hpp
@@ -51,24 +51,13 @@ Gemm_Launcher<WgSize, DoubleBuffer, ConflictA, ConflictB, ClSize, TileT, TransA,
   auto buffer_a = make_matrix_view<col_major>(ex, a_, _M, _K, _lda);
   auto buffer_b = make_matrix_view<col_major>(ex, b_, _K, _N, _ldb);
   auto buffer_c = make_matrix_view<col_major>(ex, _C, _M, _N, _ldc);
-  bool is_aligned =
-      ((_M % VectorSize) + (_N % VectorSize) + (_K % VectorSize)) == 0;
 
-  if (is_aligned) {
-    auto gemm = make_gemm<DoubleBuffer, ConflictA, ConflictB, ClSize, TileT,
-                          TransA, TransB, GemmMemoryType, GemmAlgorithm,
-                          is_beta_zero, VectorSize, true>(
-        buffer_a, buffer_b, buffer_c, element_t(_alpha), element_t(_beta),
-        batch_size);
-    return ex.execute(gemm);
-  } else {
-    auto gemm = make_gemm<DoubleBuffer, ConflictA, ConflictB, ClSize, TileT,
-                          TransA, TransB, GemmMemoryType, GemmAlgorithm,
-                          is_beta_zero, VectorSize, false>(
-        buffer_a, buffer_b, buffer_c, element_t(_alpha), element_t(_beta),
-        batch_size);
-    return ex.execute(gemm);
-  }
+  auto gemm =
+      make_gemm<DoubleBuffer, ConflictA, ConflictB, ClSize, TileT, TransA,
+                TransB, GemmMemoryType, GemmAlgorithm, is_beta_zero,
+                VectorSize>(buffer_a, buffer_b, buffer_c, element_t(_alpha),
+                            element_t(_beta), batch_size);
+  return ex.execute(gemm);
 }
 
 }  // namespace blas

--- a/src/operations/blas3/gemm_local.hpp
+++ b/src/operations/blas3/gemm_local.hpp
@@ -66,20 +66,18 @@ namespace blas {
  * @tparam element_t  type of matrix elements
  * @tparam is_beta_zero True if beta == 0.
  * @tparam VectorSize The packet size to be used for vectorization.
- * @tparam Aligned True if both A and B are fully aligned aka M, N and K are
- * evenly divisible by the vector size.
  */
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename TileType, bool TransA, bool TransB,
-          typename element_t, bool is_beta_zero, int VectorSize, bool Aligned>
+          typename element_t, bool is_beta_zero, int VectorSize>
 class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType,
            TransA, TransB, element_t, is_beta_zero,
            static_cast<int>(gemm_memory_t::local),
-           static_cast<int>(gemm_algorithm_t::standard), VectorSize, Aligned> {
+           static_cast<int>(gemm_algorithm_t::standard), VectorSize> {
  public:
   using tile_type = TileType;
   using value_t = element_t;
-  using packetize_t = Packetize<Aligned, VectorSize, value_t>;
+  using packetize_t = Packetize<VectorSize, value_t>;
   using vector_t = typename packetize_t::PacketType;
   using index_t = typename std::make_signed<typename input_t::index_t>::type;
   using address_t = cl::sycl::access::address_space;

--- a/src/operations/blas3/gemm_no_local.hpp
+++ b/src/operations/blas3/gemm_no_local.hpp
@@ -53,11 +53,11 @@ namespace blas {
  */
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
-          typename element_t, bool is_beta_zero, int VectorSize, bool Aligned>
+          typename element_t, bool is_beta_zero, int VectorSize>
 class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
            TransA, TransB, element_t, is_beta_zero,
            static_cast<int>(gemm_memory_t::no_local),
-           static_cast<int>(gemm_algorithm_t::standard), VectorSize, Aligned> {
+           static_cast<int>(gemm_algorithm_t::standard), VectorSize> {
  public:
   using value_t = element_t;
   using index_t = typename std::make_signed<typename input_t::index_t>::type;

--- a/src/operations/blas3/gemm_ref.hpp
+++ b/src/operations/blas3/gemm_ref.hpp
@@ -47,14 +47,12 @@ namespace blas {
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int VectorSize, bool Aligned>
-SYCL_BLAS_INLINE
-Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
-     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm, VectorSize,
-     Aligned>::Gemm(input_t A, input_t B, output_t C, element_t alpha,
-                    element_t beta,
-                    typename std::make_signed<typename input_t::index_t>::type
-                        batch_size)
+          int GemmAlgorithm, int VectorSize>
+SYCL_BLAS_INLINE Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize,
+                      tile_type, TransA, TransB, element_t, is_beta_zero,
+                      GemmMemoryType, GemmAlgorithm, VectorSize>::
+    Gemm(input_t A, input_t B, output_t C, element_t alpha, element_t beta,
+         typename std::make_signed<typename input_t::index_t>::type batch_size)
     : a_(A),
       b_(B),
       c_(C),
@@ -70,11 +68,11 @@ Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int VectorSize, bool Aligned>
+          int GemmAlgorithm, int VectorSize>
 SYCL_BLAS_INLINE std::string
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
-     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm, VectorSize,
-     Aligned>::get_type_string() noexcept {
+     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
+     VectorSize>::get_type_string() noexcept {
   std::ostringstream str{};
   str << "ReferenceGemmFactory<" << wg_size << ", "
       << type_string<value_t>::get_value() << ">";
@@ -88,14 +86,14 @@ Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int VectorSize, bool Aligned>
+          int GemmAlgorithm, int VectorSize>
 SYCL_BLAS_INLINE
     typename Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize,
                   tile_type, TransA, TransB, element_t, is_beta_zero,
-                  GemmMemoryType, GemmAlgorithm, VectorSize, Aligned>::index_t
+                  GemmMemoryType, GemmAlgorithm, VectorSize>::index_t
     Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
          TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-         VectorSize, Aligned>::get_workgroup_cluster() const noexcept {
+         VectorSize>::get_workgroup_cluster() const noexcept {
   return ((m_ * n_ - 1) / wg_size + 1);
 }
 /*!
@@ -108,83 +106,82 @@ SYCL_BLAS_INLINE
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int VectorSize, bool Aligned>
+          int GemmAlgorithm, int VectorSize>
 SYCL_BLAS_INLINE
     typename Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize,
                   tile_type, TransA, TransB, element_t, is_beta_zero,
-                  GemmMemoryType, GemmAlgorithm, VectorSize, Aligned>::index_t
+                  GemmMemoryType, GemmAlgorithm, VectorSize>::index_t
     Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
          TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-         VectorSize, Aligned>::get_num_workgroup_cluster(index_t compute_units)
-        const noexcept {
+         VectorSize>::get_num_workgroup_cluster(index_t compute_units) const
+    noexcept {
   constexpr index_t num_gemm_per_compute_units = 4;
   return (
       (num_gemm_per_compute_units * compute_units - 1) /
           Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
                TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-               GemmAlgorithm, VectorSize, Aligned>::get_workgroup_cluster() +
+               GemmAlgorithm, VectorSize>::get_workgroup_cluster() +
       1);
 }
 
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int VectorSize, bool Aligned>
+          int GemmAlgorithm, int VectorSize>
 SYCL_BLAS_INLINE cl::sycl::nd_range<1>
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
-     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm, VectorSize,
-     Aligned>::get_nd_range(index_t compute_units) const noexcept {
+     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
+     VectorSize>::get_nd_range(index_t compute_units) const noexcept {
   const cl::sycl::range<1> nwg(
       Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
            TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-           GemmAlgorithm, VectorSize, Aligned>::get_workgroup_cluster() *
+           GemmAlgorithm, VectorSize>::get_workgroup_cluster() *
       Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
            TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-           GemmAlgorithm, VectorSize,
-           Aligned>::get_num_workgroup_cluster(compute_units));
+           GemmAlgorithm,
+           VectorSize>::get_num_workgroup_cluster(compute_units));
   const cl::sycl::range<1> wgs(wg_size);
   return cl::sycl::nd_range<1>(nwg * wgs, wgs);
 }
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int VectorSize, bool Aligned>
+          int GemmAlgorithm, int VectorSize>
 SYCL_BLAS_INLINE
     typename Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize,
                   tile_type, TransA, TransB, element_t, is_beta_zero,
-                  GemmMemoryType, GemmAlgorithm, VectorSize, Aligned>::index_t
+                  GemmMemoryType, GemmAlgorithm, VectorSize>::index_t
     Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
          TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-         VectorSize, Aligned>::get_size() const {
+         VectorSize>::get_size() const {
   return m_ * n_;
 }
 
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int VectorSize, bool Aligned>
+          int GemmAlgorithm, int VectorSize>
 SYCL_BLAS_INLINE bool
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
-     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm, VectorSize,
-     Aligned>::valid_thread(const cl::sycl::nd_item<1>& ndItem) const {
+     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
+     VectorSize>::valid_thread(const cl::sycl::nd_item<1>& ndItem) const {
   return true;
 }
 
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int VectorSize, bool Aligned>
+          int GemmAlgorithm, int VectorSize>
 SYCL_BLAS_INLINE void
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
-     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm, VectorSize,
-     Aligned>::eval(cl::sycl::nd_item<1> id) noexcept {
+     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
+     VectorSize>::eval(cl::sycl::nd_item<1> id) noexcept {
   const index_t wg_batch_id = id.get_group(0) / get_workgroup_cluster();
   // This will disable all workgroups that dont have any batch to work on
   if (wg_batch_id >= batch_size_) {
     return;
   }
-  const index_t batch_stride =
-      id.get_group_range(0) / get_workgroup_cluster();
+  const index_t batch_stride = id.get_group_range(0) / get_workgroup_cluster();
 
   const index_t a_size = trans_a ? m_ * lda_ : k_ * lda_;
   const index_t b_size = trans_b ? ldb_ * k_ : n_ * ldb_;
@@ -194,9 +191,9 @@ Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
   auto orig_B = b_.get_pointer() + (wg_batch_id * b_size);
   auto orig_C = c_.get_pointer() + (wg_batch_id * c_size);
 
-  index_t item_id = (id.get_group(0) % get_workgroup_cluster()) *
-                        (id.get_local_range(0)) +
-                    id.get_local_id(0);
+  index_t item_id =
+      (id.get_group(0) % get_workgroup_cluster()) * (id.get_local_range(0)) +
+      id.get_local_id(0);
   if (item_id >= m_ * n_) {
     return;
   }
@@ -239,11 +236,11 @@ Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int VectorSize, bool Aligned>
+          int GemmAlgorithm, int VectorSize>
 SYCL_BLAS_INLINE void
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
-     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm, VectorSize,
-     Aligned>::bind(cl::sycl::handler& h) {
+     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
+     VectorSize>::bind(cl::sycl::handler& h) {
   a_.bind(h);
   b_.bind(h);
   c_.bind(h);
@@ -252,11 +249,11 @@ Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int VectorSize, bool Aligned>
+          int GemmAlgorithm, int VectorSize>
 SYCL_BLAS_INLINE void
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
-     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm, VectorSize,
-     Aligned>::adjust_access_displacement() {
+     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
+     VectorSize>::adjust_access_displacement() {
   a_.adjust_access_displacement();
   b_.adjust_access_displacement();
   c_.adjust_access_displacement();


### PR DESCRIPTION
Removes the versions of the load/store functions in gemm_load_store.hpp which use reinterpret_cast when all matrices are aligned. These functions provide no current performance improvements on supported platforms, cause extra kernels to be generated increasing compile times, and have caused issues with other libraries which use sycl-blas. If we end up supporting another platform in future where these would make a difference it will be easy to revert this change.