### PR TITLE
Add assert to prevent non-square block sizes in GEMM local

### DIFF
--- a/src/operations/blas3/gemm_local.hpp
+++ b/src/operations/blas3/gemm_local.hpp
@@ -126,6 +126,10 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType,
                 "of the number of columns in a block\n"
                 " --- this is ensured iff: item_cols | wg_rows");
 
+  static_assert(big_tile_rows == big_tile_cols,
+                "Big tile level dimensions should be square, i.e. tl_rows * "
+                "block_rows == tl_cols * block_cols");
+
   static_assert(item_rows % packetize_t::packet_size == 0,
                 "Item rows must be a multiple of the vector packet size");
 

--- a/src/operations/blas3/gemm_no_local.hpp
+++ b/src/operations/blas3/gemm_no_local.hpp
@@ -82,9 +82,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
   static constexpr bool trans_b = TransB;
 
   static_assert(wg_cols * item_cols == item_rows * wg_rows,
-                "Work group size should be a multiple "
-                "of the number of rows in a block\n"
-                " --- this is ensured iff: item_rows | wg_cols");
+                "Block level tile should be square");
 
   input_t a_;
   input_t b_;


### PR DESCRIPTION
Previously you could compile configurations which resulted in non-square block level tiles and incorrect results. An assert has been added to gemm_local.hpp to prevent these configurations from compiling. Additionally the assert string in gemm_no_local has been updated to be more accurate.