### PR TITLE
Remove the unused OpenBLAS submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "external/py_gen"]
 	path = external/py_gen
 	url = https://github.com/codeplaysoftware/py_gen.git
-[submodule "external/openblas"]
-	path = external/openblas
-	url = https://github.com/xianyi/OpenBLAS.git


### PR DESCRIPTION
The OpenBLAS submodule is not used in this repo, so we can remove it.