### PR TITLE
Fix compile problem with GEMV

### DIFF
--- a/include/operations/blas2_trees.h
+++ b/include/operations/blas2_trees.h
@@ -62,7 +62,7 @@ template <typename lhs_t, typename matrix_t, typename vector_t,
           uint32_t local_range, bool is_transposed, int cache_line_size,
           int work_per_thread>
 struct Gemv {
-  using value_t = typename vector_t::value_t;
+  using value_t = typename std::remove_cv<typename vector_t::value_t>::type;
   using index_t = typename vector_t::index_t;
   lhs_t lhs_;
   matrix_t matrix_a_;


### PR DESCRIPTION
A user might want to provide a buffer of `const` values as an input of
GEMV, however the current kernel will infer that the value to use for all
inermediates should then be `const`. By removing the `const` from the type
we can use `const` inputs and have mutable intermediates.