### PR TITLE
WIP: Add MiniBatchSize parameter

### DIFF
--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -45,28 +45,28 @@ set(gemm_configuration_lists "")
 
 #intel GPU
 if(${TARGET} STREQUAL "INTEL_GPU")
-  set(gemm_configuration_0 "float" 64 "true" "false" "false" 64 4 4 8 8 1 1 "local" "standard" "full" 4)
-  set(gemm_configuration_1 "float" 64 "false" "false" "false" 64 8 8 8 8 1 1 "local" "standard" "full" 4)
-  set(gemm_configuration_2 "float" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" "partial" 4)
+  set(gemm_configuration_0 "float" 64 "true" "false" "false" 64 4 4 8 8 1 1 "local" "standard" "full" 4 1)
+  set(gemm_configuration_1 "float" 64 "false" "false" "false" 64 8 8 8 8 1 1 "local" "standard" "full" 4 1)
+  set(gemm_configuration_2 "float" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" "partial" 4 1)
 
-  set(gemm_configuration_3 "float" 16 "true" "false" "false" 64 1 1 4 4 1 1 "local" "tall_skinny" "none" 4)
-  set(gemm_configuration_4 "float" 16 "true" "false" "false" 64 2 2 4 4 1 1 "local" "tall_skinny" "none" 4)
-  set(gemm_configuration_5 "float" 64 "true" "true" "true" 64 2 2 8 8 1 1 "local" "tall_skinny" "none" 4)
-  set(gemm_configuration_6 "float" 64 "true" "true" "true" 64 4 4 8 8 1 1 "local" "tall_skinny" "none" 4)
-  set(gemm_configuration_7 "float" 256 "true" "true" "true" 64 4 4 16 16 1 1 "local" "tall_skinny" "none" 4)
-  set(gemm_configuration_8 "float" 32 "true" "true" "true" 64 2 1 8 4 1 1 "local" "tall_skinny" "none" 4)
-  set(gemm_configuration_9 "float" 32 "true" "true" "true" 64 2 2 8 4 1 1 "local" "tall_skinny" "none" 4)
+  set(gemm_configuration_3 "float" 16 "true" "false" "false" 64 1 1 4 4 1 1 "local" "tall_skinny" "none" 4 1)
+  set(gemm_configuration_4 "float" 16 "true" "false" "false" 64 2 2 4 4 1 1 "local" "tall_skinny" "none" 4 1)
+  set(gemm_configuration_5 "float" 64 "true" "true" "true" 64 2 2 8 8 1 1 "local" "tall_skinny" "none" 4 1)
+  set(gemm_configuration_6 "float" 64 "true" "true" "true" 64 4 4 8 8 1 1 "local" "tall_skinny" "none" 4 1)
+  set(gemm_configuration_7 "float" 256 "true" "true" "true" 64 4 4 16 16 1 1 "local" "tall_skinny" "none" 4 1)
+  set(gemm_configuration_8 "float" 32 "true" "true" "true" 64 2 1 8 4 1 1 "local" "tall_skinny" "none" 4 1)
+  set(gemm_configuration_9 "float" 32 "true" "true" "true" 64 2 2 8 4 1 1 "local" "tall_skinny" "none" 4 1)
 
-  set(gemm_configuration_10 "double" 64 "true" "false" "false" 64 4 4 8 8 1 1 "local" "standard" "full" 4)
-  set(gemm_configuration_11 "double" 64 "true" "false" "false" 64 8 8 8 8 1 1 "local" "standard" "full" 4)
-  set(gemm_configuration_12 "double" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" "partial" 4)
+  set(gemm_configuration_10 "double" 64 "true" "false" "false" 64 4 4 8 8 1 1 "local" "standard" "full" 4 1)
+  set(gemm_configuration_11 "double" 64 "true" "false" "false" 64 8 8 8 8 1 1 "local" "standard" "full" 4 1)
+  set(gemm_configuration_12 "double" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" "partial" 4 1)
 
-  set(gemm_configuration_13 "double" 16 "true" "false" "false" 64 1 1 4 4 1 1 "local" "tall_skinny" "none" 4)
-  set(gemm_configuration_14 "double" 16 "true" "false" "false" 64 2 2 4 4 1 1 "local" "tall_skinny" "none" 4)
-  set(gemm_configuration_15 "double" 64 "true" "true" "true" 64 2 2 8 8 1 1 "local" "tall_skinny" "none" 4)
-  set(gemm_configuration_16 "double" 64 "true" "true" "true" 64 4 4 8 8 1 1 "local" "tall_skinny" "none" 4)
-  set(gemm_configuration_17 "double" 32 "true" "true" "true" 64 2 1 8 4 1 1 "local" "tall_skinny" "none" 4)
-  set(gemm_configuration_18 "double" 32 "true" "true" "true" 64 2 2 8 4 1 1 "local" "tall_skinny" "none" 4)
+  set(gemm_configuration_13 "double" 16 "true" "false" "false" 64 1 1 4 4 1 1 "local" "tall_skinny" "none" 4 1)
+  set(gemm_configuration_14 "double" 16 "true" "false" "false" 64 2 2 4 4 1 1 "local" "tall_skinny" "none" 4 1)
+  set(gemm_configuration_15 "double" 64 "true" "true" "true" 64 2 2 8 8 1 1 "local" "tall_skinny" "none" 4 1)
+  set(gemm_configuration_16 "double" 64 "true" "true" "true" 64 4 4 8 8 1 1 "local" "tall_skinny" "none" 4 1)
+  set(gemm_configuration_17 "double" 32 "true" "true" "true" 64 2 1 8 4 1 1 "local" "tall_skinny" "none" 4 1)
+  set(gemm_configuration_18 "double" 32 "true" "true" "true" 64 2 2 8 4 1 1 "local" "tall_skinny" "none" 4 1)
 
   list(APPEND gemm_configuration_lists gemm_configuration_0 gemm_configuration_1
                                        gemm_configuration_2)
@@ -99,44 +99,47 @@ if(${TARGET} STREQUAL "INTEL_GPU")
   endif()
 elseif(${TARGET} STREQUAL "RCAR") # need investigation
 
-  set(gemm_configuration_0 "float" 32 "false" "false" "false" 128 4 8 8 4 1 1 "local" "standard" "full" 4)
-  set(gemm_configuration_1 "float" 32 "false" "false" "false" 128 8 4 4 8 1 1 "local" "standard" "full" 4)
+  set(gemm_configuration_0 "float" 32 "false" "false" "false" 128 4 8 8 4 1 1 "local" "standard" "full" 4 1)
+  set(gemm_configuration_1 "float" 32 "false" "false" "false" 128 8 4 4 8 1 1 "local" "standard" "full" 4 1)
 
   list(APPEND gemm_configuration_lists gemm_configuration_0 gemm_configuration_1)
 elseif(${TARGET} STREQUAL "ARM_GPU")
-  set(gemm_configuration_0 "float" 64 "false" "false" "false" 64 4 4 8 8 1 1 "no_local" "standard" "partial" 4)
-  set(gemm_configuration_1 "float" 128 "false" "false" "false" 64 4 8 16 8 1 1 "no_local" "standard" "partial" 4)
-  set(gemm_configuration_2 "float" 32 "false" "false" "false" 64 8 4 4 8 1 1 "no_local" "standard" "partial" 4)
+  set(gemm_configuration_0 "float" 64 "false" "false" "false" 64 4 4 8 8 1 1 "no_local" "standard" "partial" 4 1)
+  set(gemm_configuration_1 "float" 128 "false" "false" "false" 64 4 8 16 8 1 1 "no_local" "standard" "partial" 4 1)
+  set(gemm_configuration_2 "float" 128 "false" "false" "false" 64 4 8 16 8 1 1 "no_local" "standard" "partial" 4 4)
+  set(gemm_configuration_3 "float" 32 "false" "false" "false" 64 8 4 4 8 1 1 "no_local" "standard" "partial" 4 1)
+  set(gemm_configuration_4 "float" 32 "false" "false" "false" 64 8 4 4 8 1 1 "no_local" "standard" "partial" 4 4)
 
   list(APPEND gemm_configuration_lists gemm_configuration_0 gemm_configuration_1
-                                       gemm_configuration_2)
+                                       gemm_configuration_2 gemm_configuration_3
+                                       gemm_configuration_4)
 elseif(${TARGET} STREQUAL "POWER_VR")
-  set(gemm_configuration_0 "float" 96 "true" "false" "false" 16 4 6 12 8 1 1 "local" "standard" "full" 1)
-  set(gemm_configuration_1 "float" 64 "false" "false" "false" 128 1 1 8 8 1 1 "local" "standard" "full" 1)
-  set(gemm_configuration_2 "float" 64 "false" "false" "false" 64 4 4 8 8 1 1 "no_local" "standard" "full" 1)
-  set(gemm_configuration_3 "float" 128 "false" "false" "false" 16 4 8 16 8 1 1 "local" "standard" "full" 1)
-  set(gemm_configuration_4 "float" 64 "false" "false" "false" 32 4 4 8 8 1 1 "local" "standard" "full" 1)
+  set(gemm_configuration_0 "float" 96 "true" "false" "false" 16 4 6 12 8 1 1 "local" "standard" "full" 1 1)
+  set(gemm_configuration_1 "float" 64 "false" "false" "false" 128 1 1 8 8 1 1 "local" "standard" "full" 1 1)
+  set(gemm_configuration_2 "float" 64 "false" "false" "false" 64 4 4 8 8 1 1 "no_local" "standard" "full" 1 1)
+  set(gemm_configuration_3 "float" 128 "false" "false" "false" 16 4 8 16 8 1 1 "local" "standard" "full" 1 1)
+  set(gemm_configuration_4 "float" 64 "false" "false" "false" 32 4 4 8 8 1 1 "local" "standard" "full" 1 1)
   list(APPEND gemm_configuration_lists gemm_configuration_0 gemm_configuration_1
                                     gemm_configuration_2 gemm_configuration_3
                                     gemm_configuration_4)
 elseif(${TARGET} STREQUAL "AMD_GPU")  # need investigation
-  set(gemm_configuration_0 "float" 256 "false" "false" "false" 64 1 1 16 16 1 1 "local" "standard" "full" 1)
-  set(gemm_configuration_1 "float" 256 "false" "false" "false" 64 4 4 16 16 1 1 "local" "standard" "full" 2)
+  set(gemm_configuration_0 "float" 256 "false" "false" "false" 64 1 1 16 16 1 1 "local" "standard" "full" 1 1)
+  set(gemm_configuration_1 "float" 256 "false" "false" "false" 64 4 4 16 16 1 1 "local" "standard" "full" 2 1)
 
-  set(gemm_configuration_2 "float" 256 "true" "true" "true" 64 1 1 16 16 1 1 "local" "tall_skinny" "none" 2)
-  set(gemm_configuration_3 "float" 256 "true" "true" "true" 64 2 2 16 16 1 1 "local" "tall_skinny" "none" 2)
-  set(gemm_configuration_4 "float" 256 "true" "true" "true" 64 4 4 16 16 1 1 "local" "tall_skinny" "none" 2)
-  set(gemm_configuration_5 "float" 256 "true" "true" "true" 64 1 4 16 16 1 1 "local" "tall_skinny" "none" 2)
-  set(gemm_configuration_6 "float" 256 "true" "true" "true" 64 4 1 16 16 1 1 "local" "tall_skinny" "none" 2)
+  set(gemm_configuration_2 "float" 256 "true" "true" "true" 64 1 1 16 16 1 1 "local" "tall_skinny" "none" 2 1)
+  set(gemm_configuration_3 "float" 256 "true" "true" "true" 64 2 2 16 16 1 1 "local" "tall_skinny" "none" 2 1)
+  set(gemm_configuration_4 "float" 256 "true" "true" "true" 64 4 4 16 16 1 1 "local" "tall_skinny" "none" 2 1)
+  set(gemm_configuration_5 "float" 256 "true" "true" "true" 64 1 4 16 16 1 1 "local" "tall_skinny" "none" 2 1)
+  set(gemm_configuration_6 "float" 256 "true" "true" "true" 64 4 1 16 16 1 1 "local" "tall_skinny" "none" 2 1)
 
-  set(gemm_configuration_7 "double" 256 "false" "false" "false" 64 1 1 8 8 1 1 "local" "standard" "full" 1)
-  set(gemm_configuration_8 "double" 256 "false" "false" "false" 64 4 4 8 8 1 1 "local" "standard" "full" 2)
+  set(gemm_configuration_7 "double" 256 "false" "false" "false" 64 1 1 8 8 1 1 "local" "standard" "full" 1 1)
+  set(gemm_configuration_8 "double" 256 "false" "false" "false" 64 4 4 8 8 1 1 "local" "standard" "full" 2 1)
 
-  set(gemm_configuration_9 "double" 256 "true" "true" "true" 64 1 1 8 8 1 1 "local" "tall_skinny" "none" 2)
-  set(gemm_configuration_10 "double" 256 "true" "true" "true" 64 2 2 8 8 1 1 "local" "tall_skinny" "none" 2)
-  set(gemm_configuration_11 "double" 256 "true" "true" "true" 64 4 4 8 8 1 1 "local" "tall_skinny" "none" 2)
-  set(gemm_configuration_12 "double" 256 "true" "true" "true" 64 1 4 8 8 1 1 "local" "tall_skinny" "none" 2)
-  set(gemm_configuration_13 "double" 256 "true" "true" "true" 64 4 1 8 8 1 1 "local" "tall_skinny" "none" 2)
+  set(gemm_configuration_9 "double" 256 "true" "true" "true" 64 1 1 8 8 1 1 "local" "tall_skinny" "none" 2 1)
+  set(gemm_configuration_10 "double" 256 "true" "true" "true" 64 2 2 8 8 1 1 "local" "tall_skinny" "none" 2 1)
+  set(gemm_configuration_11 "double" 256 "true" "true" "true" 64 4 4 8 8 1 1 "local" "tall_skinny" "none" 2 1)
+  set(gemm_configuration_12 "double" 256 "true" "true" "true" 64 1 4 8 8 1 1 "local" "tall_skinny" "none" 2 1)
+  set(gemm_configuration_13 "double" 256 "true" "true" "true" 64 4 1 8 8 1 1 "local" "tall_skinny" "none" 2 1)
 
   list(APPEND gemm_configuration_lists gemm_configuration_0 gemm_configuration_1)
 
@@ -164,12 +167,12 @@ elseif(${TARGET} STREQUAL "AMD_GPU")  # need investigation
     endif()
   endif()
 else() # default cpu backend
-  set(gemm_configuration_0 "float"  64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "naive" "none" 1)
-  set(gemm_configuration_1 "float"  64 "false" "false" "false" 64 2 2 8 8 1 1 "no_local" "standard" "full" 2)
-  set(gemm_configuration_2 "float"  64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" "partial" 1)
-  set(gemm_configuration_3 "double" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "naive" "none" 1)
-  set(gemm_configuration_4 "double" 64 "false" "false" "false" 64 2 2 8 8 1 1 "no_local" "standard" "full" 2)
-  set(gemm_configuration_5 "double" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" "partial" 1)
+  set(gemm_configuration_0 "float"  64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "naive" "none" 1 1)
+  set(gemm_configuration_1 "float"  64 "false" "false" "false" 64 2 2 8 8 1 1 "no_local" "standard" "full" 2 1)
+  set(gemm_configuration_2 "float"  64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" "partial" 1 1)
+  set(gemm_configuration_3 "double" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "naive" "none" 1 1)
+  set(gemm_configuration_4 "double" 64 "false" "false" "false" 64 2 2 8 8 1 1 "no_local" "standard" "full" 2 1)
+  set(gemm_configuration_5 "double" 64 "false" "false" "false" 64 8 8 8 8 1 1 "no_local" "standard" "partial" 1 1)
 
   if(NAIVE_GEMM)
     list(APPEND gemm_configuration_lists gemm_configuration_0)
@@ -430,10 +433,12 @@ set(LOCATION "${SYCLBLAS_GENERATED_SRC}/${blas_level}/${func}/")
                     list(GET ${gemm_list} 13 gemm_shape_type)
                     list(GET ${gemm_list} 14 gemm_vectorize_type)
                     list(GET ${gemm_list} 15 vector_size)
+                    list(GET ${gemm_list} 16 mini_batch_size)
                     set(file_name "${func}_${double_buffer}_${conflict_a}_"
                                   "${conflict_b}_${trans_a}_${trans_b}_"
                                   "${is_beta_zero}_${gemm_memory_type}_"
-                                  "${gemm_shape_type}_${gemm_vectorize_type}_${vector_size}_${executor}_"
+                                  "${gemm_shape_type}_${gemm_vectorize_type}_"
+                                  "${vector_size}_${mini_batch_size}_${executor}_"
                                   "${data}_${index}_${tir}_${tic}_${twr}_"
                                   "${twc}_${tlr}_${tlc}_${wg_size}_"
                                   "${cl_size}.cpp")
@@ -468,6 +473,7 @@ set(LOCATION "${SYCLBLAS_GENERATED_SRC}/${blas_level}/${func}/")
                         ${file_name}
                         ${vector_size}
                         ${gemm_vectorize_type}
+                        ${mini_batch_size}
                       MAIN_DEPENDENCY ${SYCLBLAS_SRC}/interface/${blas_level}/${func}.cpp.in
                       DEPENDS ${SYCLBLAS_SRC_GENERATOR}/py_gen_blas_gemm_launcher.py
                       WORKING_DIRECTORY ${PROJECT_BINARY_DIR}

--- a/include/executors/executor.h
+++ b/include/executors/executor.h
@@ -74,23 +74,24 @@ class Executor {
   template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
             bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
             typename element_t, bool is_beta_zero, int GemmMemoryType,
-            int GemmAlgorithm, int GemmVectorization, int VectorSize>
+            int GemmAlgorithm, int GemmVectorization, int VectorSize,
+            int MiniBatchSize>
   typename policy_t::event_t execute(
       Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
            TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-           GemmAlgorithm, GemmVectorization, VectorSize>
+           GemmAlgorithm, GemmVectorization, VectorSize, MiniBatchSize>
           gemm_tree);
 
   // Tall and skinny Gemm specialization
   template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
             bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
             typename element_t, bool is_beta_zero, int GemmMemoryType,
-            int GemmVectorization, int VectorSize>
+            int GemmVectorization, int VectorSize, int MiniBatchSize>
   typename policy_t::event_t execute(
       Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
            TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
            static_cast<int>(gemm_algorithm_t::tall_skinny), GemmVectorization,
-           VectorSize>
+           VectorSize, MiniBatchSize>
           gemm_wrapper);
 
   // GemmPartial specialization

--- a/include/interface/gemm_launcher.h
+++ b/include/interface/gemm_launcher.h
@@ -37,7 +37,7 @@ namespace blas {
 template <int WgSize, bool DoubleBuffer, bool ConflictA, bool ConflictB,
           int ClSize, typename TileT, bool TransA, bool TransB,
           int GemmMemoryType, int GemmAlgorithm, int GemmVectorization,
-          bool is_beta_zero, int VectorSize>
+          bool is_beta_zero, int VectorSize, int MiniBatchSize = 1>
 struct Gemm_Launcher {
   template <typename executor_t, typename container_0_t, typename container_1_t,
             typename container_2_t, typename element_t, typename index_t>

--- a/include/operations/blas3_trees.h
+++ b/include/operations/blas3_trees.h
@@ -163,7 +163,8 @@ struct Tile {
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int GemmVectorization, int VectorSize>
+          int GemmAlgorithm, int GemmVectorization, int VectorSize,
+          int MiniBatchSize>
 class Gemm {
  public:
   using value_t = element_t;
@@ -226,16 +227,16 @@ class GemmPartial {};
 template <bool DoubleBuffer, bool ConflictA, bool ConflictB, int ClSize,
           typename TileType, bool TransA, bool TransB, int GemmMemoryType,
           int GemmAlgorithm, int GemmVectorization, bool is_beta_zero,
-          int VectorSize, typename input_t, typename output_t,
-          typename element_t, typename index_t>
+          int VectorSize, int MiniBatchSize, typename input_t,
+          typename output_t, typename element_t, typename index_t>
 inline Gemm<input_t, output_t, DoubleBuffer, ConflictA, ConflictB, ClSize,
             TileType, TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-            GemmAlgorithm, GemmVectorization, VectorSize>
+            GemmAlgorithm, GemmVectorization, VectorSize, MiniBatchSize>
 make_gemm(input_t buffer_a, input_t buffer_b, output_t buffer_c,
           element_t alpha, element_t beta, index_t batch_size) {
   return Gemm<input_t, output_t, DoubleBuffer, ConflictA, ConflictB, ClSize,
               TileType, TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-              GemmAlgorithm, GemmVectorization, VectorSize>(
+              GemmAlgorithm, GemmVectorization, VectorSize, MiniBatchSize>(
       buffer_a, buffer_b, buffer_c, alpha, beta, batch_size);
 }
 

--- a/python_generator/py_gen_blas_gemm_launcher.py
+++ b/python_generator/py_gen_blas_gemm_launcher.py
@@ -59,6 +59,7 @@ if __name__ == '__main__':
     file_name = sys.argv[25]
     vector_size = sys.argv[26]
     gemm_vectorize_type = sys.argv[27]
+    mini_batch_size = sys.argv[28]
     source = 'generated_src/' + blas_level_name + '/' + blas_function_name + '/'
 
     if not os.path.exists(source):
@@ -170,6 +171,11 @@ if __name__ == '__main__':
         Iterable(
             key='GEMM_VECTORIZE_TYPE',
             vals=[gemm_vectorize_type],
+            itermode=Itermode.combinations,
+            iter_modifier=1),
+        Iterable(
+            key='MINI_BATCH_SIZE',
+            vals=[mini_batch_size],
             itermode=Itermode.combinations,
             iter_modifier=1)
     ]

--- a/src/executors/executor_sycl.hpp
+++ b/src/executors/executor_sycl.hpp
@@ -216,17 +216,18 @@ template <>
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int GemmVectorization, int VectorSize>
+          int GemmAlgorithm, int GemmVectorization, int VectorSize,
+          int MiniBatchSize>
 inline typename codeplay_policy::event_t
 Executor<PolicyHandler<codeplay_policy>>::execute(
     Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
          TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-         GemmVectorization, VectorSize>
+         GemmVectorization, VectorSize, MiniBatchSize>
         gemm_tree) {
   using gemm_t =
       Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
            TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-           GemmAlgorithm, GemmVectorization, VectorSize>;
+           GemmAlgorithm, GemmVectorization, VectorSize, MiniBatchSize>;
   auto rng = gemm_tree.get_nd_range(policy_handler_.get_num_compute_units());
   return {execute_tree<
       Choose<GemmMemoryType == static_cast<int>(gemm_memory_t::local), int,
@@ -240,13 +241,13 @@ template <>
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmVectorization, int VectorSize>
+          int GemmVectorization, int VectorSize, int MiniBatchSize>
 inline typename codeplay_policy::event_t
 Executor<PolicyHandler<codeplay_policy>>::execute(
     Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
          TransB, element_t, is_beta_zero, GemmMemoryType,
          static_cast<int>(gemm_algorithm_t::tall_skinny), GemmVectorization,
-         VectorSize>
+         VectorSize, MiniBatchSize>
         gemm_wrapper) {
   using index_t = typename std::make_signed<typename input_t::index_t>::type;
 

--- a/src/interface/blas3/backend/arm_gpu.hpp
+++ b/src/interface/blas3/backend/arm_gpu.hpp
@@ -36,30 +36,58 @@ typename executor_t::policy_t::event_t _gemm(
     executor_t& ex, index_t _M, index_t _N, index_t _K, element_t _alpha,
     container_0_t _a, index_t _lda, container_1_t _b, index_t _ldb,
     element_t _beta, container_2_t _c, index_t _ldc, index_t batch_size) {
+  static constexpr int GemmMemoryType =
+      static_cast<int>(gemm_memory_t::no_local);
+  static constexpr int GemmAlgorithm =
+      static_cast<int>(gemm_algorithm_t::standard);
+  static constexpr int GemmVectorization =
+      static_cast<int>(gemm_vectorization_t::partial);
+  static constexpr int ClSize = 64;
+  static constexpr int VectorSize = 4;
+  static constexpr int MiniBatchSize = 4;
   if (_M == 512 && _N == 49 && _K == 512) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b,
-        static_cast<int>(gemm_memory_t::no_local),
-        static_cast<int>(gemm_algorithm_t::standard),
-        static_cast<int>(gemm_vectorization_t::partial), is_beta_zero,
-        4>::template _select_gemm(ex, _M, _N, _K, _alpha, _a, _lda, _b, _ldb,
-                                  _beta, _c, _ldc, batch_size);
+        /* WgSize= */ 64, false, false, false, ClSize, Tile<4, 4, 8, 8>, _t_a,
+        _t_b, GemmMemoryType, GemmAlgorithm, GemmVectorization, is_beta_zero,
+        VectorSize, 1>::template _select_gemm(ex, _M, _N, _K, _alpha, _a, _lda,
+                                              _b, _ldb, _beta, _c, _ldc,
+                                              batch_size);
   } else if (_t_a) {
-    return blas::Gemm_Launcher<
-        128, false, false, false, 64, Tile<4, 8, 16, 8>, _t_a, _t_b,
-        static_cast<int>(gemm_memory_t::no_local),
-        static_cast<int>(gemm_algorithm_t::standard),
-        static_cast<int>(gemm_vectorization_t::partial), is_beta_zero,
-        4>::template _select_gemm(ex, _M, _N, _K, _alpha, _a, _lda, _b, _ldb,
-                                  _beta, _c, _ldc, batch_size);
+    if (batch_size % MiniBatchSize == 0) {
+      return blas::Gemm_Launcher<
+          /* WgSize= */ 128, false, false, false, ClSize, Tile<4, 8, 16, 8>,
+          _t_a, _t_b, GemmMemoryType, GemmAlgorithm, GemmVectorization,
+          is_beta_zero, VectorSize,
+          MiniBatchSize>::template _select_gemm(ex, _M, _N, _K, _alpha, _a,
+                                                _lda, _b, _ldb, _beta, _c, _ldc,
+                                                batch_size);
+    } else {
+      return blas::Gemm_Launcher<
+          /* WgSize= */ 128, false, false, false, ClSize, Tile<4, 8, 16, 8>,
+          _t_a, _t_b, GemmMemoryType, GemmAlgorithm, GemmVectorization,
+          is_beta_zero, VectorSize, 1>::template _select_gemm(ex, _M, _N, _K,
+                                                              _alpha, _a, _lda,
+                                                              _b, _ldb, _beta,
+                                                              _c, _ldc,
+                                                              batch_size);
+    }
   } else {
-    return blas::Gemm_Launcher<
-        32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b,
-        static_cast<int>(gemm_memory_t::no_local),
-        static_cast<int>(gemm_algorithm_t::standard),
-        static_cast<int>(gemm_vectorization_t::partial), is_beta_zero,
-        4>::template _select_gemm(ex, _M, _N, _K, _alpha, _a, _lda, _b, _ldb,
-                                  _beta, _c, _ldc, batch_size);
+    if (batch_size % MiniBatchSize == 0) {
+      return blas::Gemm_Launcher<
+          /* WgSize= */ 32, false, false, false, ClSize, Tile<8, 4, 4, 8>, _t_a,
+          _t_b, GemmMemoryType, GemmAlgorithm, GemmVectorization, is_beta_zero,
+          VectorSize, MiniBatchSize>::template _select_gemm(ex, _M, _N, _K,
+                                                            _alpha, _a, _lda,
+                                                            _b, _ldb, _beta, _c,
+                                                            _ldc, batch_size);
+    } else {
+      return blas::Gemm_Launcher<
+          /* WgSize= */ 32, false, false, false, ClSize, Tile<8, 4, 4, 8>, _t_a,
+          _t_b, GemmMemoryType, GemmAlgorithm, GemmVectorization, is_beta_zero,
+          VectorSize, 1>::template _select_gemm(ex, _M, _N, _K, _alpha, _a,
+                                                _lda, _b, _ldb, _beta, _c, _ldc,
+                                                batch_size);
+    }
   }
 }
 }  // namespace backend

--- a/src/interface/blas3/gemm_launcher.cpp.in
+++ b/src/interface/blas3/gemm_launcher.cpp.in
@@ -39,13 +39,17 @@ template class Gemm_Launcher<
     ${WG_SIZE}, ${DOUBLE_BUFFER}, ${CONFLICT_A}, ${CONFLICT_B}, ${CL_SIZE},
     Tile<${TIR}, ${TIC}, ${TWR}, ${TWC}, ${TLR}, ${TLC}>, ${TRANS_A},
     ${TRANS_B}, static_cast<int>(gemm_memory_t::${GEMM_MEMORY_TYPE}),
-    static_cast<int>(gemm_algorithm_t::${GEMM_SHAPE_TYPE}),static_cast<int>(gemm_vectorization_t::${GEMM_VECTORIZE_TYPE}), ${IS_BETA_ZERO}, ${VECTOR_SIZE}>;
+    static_cast<int>(gemm_algorithm_t::${GEMM_SHAPE_TYPE}),
+    static_cast<int>(gemm_vectorization_t::${GEMM_VECTORIZE_TYPE}),
+    ${IS_BETA_ZERO}, ${VECTOR_SIZE}, ${MINI_BATCH_SIZE}>;
 
 template typename Executor<${EXECUTOR}>::policy_t::event_t Gemm_Launcher<
     ${WG_SIZE}, ${DOUBLE_BUFFER}, ${CONFLICT_A}, ${CONFLICT_B}, ${CL_SIZE},
     Tile<${TIR}, ${TIC}, ${TWR}, ${TWC}, ${TLR}, ${TLC}>, ${TRANS_A},
     ${TRANS_B}, static_cast<int>(gemm_memory_t::${GEMM_MEMORY_TYPE}),
-    static_cast<int>(gemm_algorithm_t::${GEMM_SHAPE_TYPE}), static_cast<int>(gemm_vectorization_t::${GEMM_VECTORIZE_TYPE}), ${IS_BETA_ZERO}, ${VECTOR_SIZE}>::
+    static_cast<int>(gemm_algorithm_t::${GEMM_SHAPE_TYPE}),
+    static_cast<int>(gemm_vectorization_t::${GEMM_VECTORIZE_TYPE}),
+    ${IS_BETA_ZERO}, ${VECTOR_SIZE}, ${MINI_BATCH_SIZE}>::
     _select_gemm<Executor<${EXECUTOR}>,
                  BufferIterator<${DATA_TYPE}, codeplay_policy>,
                  BufferIterator<${DATA_TYPE}, codeplay_policy>,

--- a/src/interface/gemm_launcher.hpp
+++ b/src/interface/gemm_launcher.hpp
@@ -36,26 +36,27 @@ namespace blas {
 template <int WgSize, bool DoubleBuffer, bool ConflictA, bool ConflictB,
           int ClSize, typename TileT, bool TransA, bool TransB,
           int GemmMemoryType, int GemmAlgorithm, int GemmVectorization,
-          bool is_beta_zero, int VectorSize>
+          bool is_beta_zero, int VectorSize, int MiniBatchSize>
 template <typename Executor, typename container_t0, typename container_t1,
           typename container_t2, typename element_t, typename index_t>
 typename Executor::policy_t::event_t Gemm_Launcher<
     WgSize, DoubleBuffer, ConflictA, ConflictB, ClSize, TileT, TransA, TransB,
-    GemmMemoryType, GemmAlgorithm, GemmVectorization, is_beta_zero,
-    VectorSize>::_select_gemm(Executor& ex, index_t _M, index_t _N, index_t _K,
-                              element_t _alpha, container_t0 a_, index_t _lda,
-                              container_t1 b_, index_t _ldb, element_t _beta,
-                              container_t2 _C, index_t _ldc,
-                              index_t batch_size) {
+    GemmMemoryType, GemmAlgorithm, GemmVectorization, is_beta_zero, VectorSize,
+    MiniBatchSize>::_select_gemm(Executor& ex, index_t _M, index_t _N,
+                                 index_t _K, element_t _alpha, container_t0 a_,
+                                 index_t _lda, container_t1 b_, index_t _ldb,
+                                 element_t _beta, container_t2 _C, index_t _ldc,
+                                 index_t batch_size) {
   auto buffer_a = make_matrix_view<col_major>(ex, a_, _M, _K, _lda);
   auto buffer_b = make_matrix_view<col_major>(ex, b_, _K, _N, _ldb);
   auto buffer_c = make_matrix_view<col_major>(ex, _C, _M, _N, _ldc);
 
-  auto gemm = make_gemm<DoubleBuffer, ConflictA, ConflictB, ClSize, TileT,
-                        TransA, TransB, GemmMemoryType, GemmAlgorithm,
-                        GemmVectorization, is_beta_zero, VectorSize>(
-      buffer_a, buffer_b, buffer_c, element_t(_alpha), element_t(_beta),
-      batch_size);
+  auto gemm =
+      make_gemm<DoubleBuffer, ConflictA, ConflictB, ClSize, TileT, TransA,
+                TransB, GemmMemoryType, GemmAlgorithm, GemmVectorization,
+                is_beta_zero, VectorSize, MiniBatchSize>(
+          buffer_a, buffer_b, buffer_c, element_t(_alpha), element_t(_beta),
+          batch_size);
   return ex.execute(gemm);
 }
 

--- a/src/operations/blas3/gemm_local.hpp
+++ b/src/operations/blas3/gemm_local.hpp
@@ -66,11 +66,11 @@ namespace blas {
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename TileType, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int VectorSize>
-class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType,
-           TransA, TransB, element_t, is_beta_zero,
-           static_cast<int>(gemm_memory_t::local),
-           static_cast<int>(gemm_algorithm_t::standard),
-           static_cast<int>(gemm_vectorization_t::full), VectorSize> {
+class Gemm<
+    input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType, TransA,
+    TransB, element_t, is_beta_zero, static_cast<int>(gemm_memory_t::local),
+    static_cast<int>(gemm_algorithm_t::standard),
+    static_cast<int>(gemm_vectorization_t::full), VectorSize, /* MiniBatchSize= */ 1> {
  public:
   using tile_type = TileType;
   using value_t = element_t;

--- a/src/operations/blas3/gemm_no_local_full_vec.hpp
+++ b/src/operations/blas3/gemm_no_local_full_vec.hpp
@@ -55,11 +55,11 @@ namespace blas {
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int VectorSize>
-class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
-           TransA, TransB, element_t, is_beta_zero,
-           static_cast<int>(gemm_memory_t::no_local),
-           static_cast<int>(gemm_algorithm_t::standard),
-           static_cast<int>(gemm_vectorization_t::full), VectorSize> {
+class Gemm<
+    input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
+    TransB, element_t, is_beta_zero, static_cast<int>(gemm_memory_t::no_local),
+    static_cast<int>(gemm_algorithm_t::standard),
+    static_cast<int>(gemm_vectorization_t::full), VectorSize, /* MiniBatchSize= */ 1> {
  public:
   using value_t = element_t;
   using index_t = typename std::make_signed<typename input_t::index_t>::type;

--- a/src/operations/blas3/gemm_no_local_partial_vec.hpp
+++ b/src/operations/blas3/gemm_no_local_partial_vec.hpp
@@ -527,7 +527,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
   }
 
   /*!
-   * @brief For each work item the following function store the computed block
+   * @brief For each work item the following function stores the computed block
    * of GEMM reg_res into output matrix C
    * @tparam check_block: determined whether or not the requested block is
    * internal. false means no need to check the boundaries

--- a/src/operations/blas3/gemm_ref.hpp
+++ b/src/operations/blas3/gemm_ref.hpp
@@ -47,11 +47,12 @@ namespace blas {
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int GemmVectorization, int VectorSize>
+          int GemmAlgorithm, int GemmVectorization, int VectorSize,
+          int MiniBatchSize>
 SYCL_BLAS_INLINE
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
      TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-     GemmVectorization, VectorSize>::
+     GemmVectorization, VectorSize, MiniBatchSize>::
     Gemm(input_t A, input_t B, output_t C, element_t alpha, element_t beta,
          typename std::make_signed<typename input_t::index_t>::type batch_size)
     : a_(A),
@@ -69,11 +70,12 @@ Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int GemmVectorization, int VectorSize>
+          int GemmAlgorithm, int GemmVectorization, int VectorSize,
+          int MiniBatchSize>
 SYCL_BLAS_INLINE std::string
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
      TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-     GemmVectorization, VectorSize>::get_type_string() noexcept {
+     GemmVectorization, VectorSize, MiniBatchSize>::get_type_string() noexcept {
   std::ostringstream str{};
   str << "ReferenceGemmFactory<" << wg_size << ", "
       << type_string<value_t>::get_value() << ">";
@@ -87,14 +89,17 @@ Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int GemmVectorization, int VectorSize>
-SYCL_BLAS_INLINE typename Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB,
-                               ClSize, tile_type, TransA, TransB, element_t,
-                               is_beta_zero, GemmMemoryType, GemmAlgorithm,
-                               GemmVectorization, VectorSize>::index_t
-Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
-     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-     GemmVectorization, VectorSize>::get_workgroup_cluster() const noexcept {
+          int GemmAlgorithm, int GemmVectorization, int VectorSize,
+          int MiniBatchSize>
+SYCL_BLAS_INLINE
+    typename Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize,
+                  tile_type, TransA, TransB, element_t, is_beta_zero,
+                  GemmMemoryType, GemmAlgorithm, GemmVectorization, VectorSize,
+                  MiniBatchSize>::index_t
+    Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
+         TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
+         GemmVectorization, VectorSize, MiniBatchSize>::get_workgroup_cluster()
+        const noexcept {
   return ((m_ * n_ - 1) / wg_size + 1);
 }
 /*!
@@ -107,80 +112,88 @@ Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int GemmVectorization, int VectorSize>
-SYCL_BLAS_INLINE typename Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB,
-                               ClSize, tile_type, TransA, TransB, element_t,
-                               is_beta_zero, GemmMemoryType, GemmAlgorithm,
-                               GemmVectorization, VectorSize>::index_t
-Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
-     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-     GemmVectorization,
-     VectorSize>::get_num_workgroup_cluster(index_t compute_units) const
+          int GemmAlgorithm, int GemmVectorization, int VectorSize,
+          int MiniBatchSize>
+SYCL_BLAS_INLINE
+    typename Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize,
+                  tile_type, TransA, TransB, element_t, is_beta_zero,
+                  GemmMemoryType, GemmAlgorithm, GemmVectorization, VectorSize,
+                  MiniBatchSize>::index_t
+    Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
+         TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
+         GemmVectorization, VectorSize,
+         MiniBatchSize>::get_num_workgroup_cluster(index_t compute_units) const
     noexcept {
   constexpr index_t num_gemm_per_compute_units = 4;
   return ((num_gemm_per_compute_units * compute_units - 1) /
               Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize,
                    tile_type, TransA, TransB, element_t, is_beta_zero,
-                   GemmMemoryType, GemmAlgorithm, GemmVectorization,
-                   VectorSize>::get_workgroup_cluster() +
+                   GemmMemoryType, GemmAlgorithm, GemmVectorization, VectorSize,
+                   MiniBatchSize>::get_workgroup_cluster() +
           1);
 }
 
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int GemmVectorization, int VectorSize>
+          int GemmAlgorithm, int GemmVectorization, int VectorSize,
+          int MiniBatchSize>
 SYCL_BLAS_INLINE cl::sycl::nd_range<1>
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
      TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-     GemmVectorization, VectorSize>::get_nd_range(index_t compute_units) const
-    noexcept {
+     GemmVectorization, VectorSize,
+     MiniBatchSize>::get_nd_range(index_t compute_units) const noexcept {
   const cl::sycl::range<1> nwg(
       Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
            TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-           GemmAlgorithm, GemmVectorization,
-           VectorSize>::get_workgroup_cluster() *
+           GemmAlgorithm, GemmVectorization, VectorSize,
+           MiniBatchSize>::get_workgroup_cluster() *
       Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
            TransA, TransB, element_t, is_beta_zero, GemmMemoryType,
-           GemmAlgorithm, GemmVectorization,
-           VectorSize>::get_num_workgroup_cluster(compute_units));
+           GemmAlgorithm, GemmVectorization, VectorSize,
+           MiniBatchSize>::get_num_workgroup_cluster(compute_units));
   const cl::sycl::range<1> wgs(wg_size);
   return cl::sycl::nd_range<1>(nwg * wgs, wgs);
 }
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int GemmVectorization, int VectorSize>
-SYCL_BLAS_INLINE typename Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB,
-                               ClSize, tile_type, TransA, TransB, element_t,
-                               is_beta_zero, GemmMemoryType, GemmAlgorithm,
-                               GemmVectorization, VectorSize>::index_t
-Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
-     TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-     GemmVectorization, VectorSize>::get_size() const {
+          int GemmAlgorithm, int GemmVectorization, int VectorSize,
+          int MiniBatchSize>
+SYCL_BLAS_INLINE
+    typename Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize,
+                  tile_type, TransA, TransB, element_t, is_beta_zero,
+                  GemmMemoryType, GemmAlgorithm, GemmVectorization, VectorSize,
+                  MiniBatchSize>::index_t
+    Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
+         TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
+         GemmVectorization, VectorSize, MiniBatchSize>::get_size() const {
   return m_ * n_;
 }
 
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int GemmVectorization, int VectorSize>
+          int GemmAlgorithm, int GemmVectorization, int VectorSize,
+          int MiniBatchSize>
 SYCL_BLAS_INLINE bool
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
      TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-     GemmVectorization, VectorSize>::valid_thread(const cl::sycl::nd_item<1>&
-                                                      ndItem) const {
+     GemmVectorization, VectorSize,
+     MiniBatchSize>::valid_thread(const cl::sycl::nd_item<1>& ndItem) const {
   return true;
 }
 
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int GemmVectorization, int VectorSize>
+          int GemmAlgorithm, int GemmVectorization, int VectorSize,
+          int MiniBatchSize>
 SYCL_BLAS_INLINE void
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
      TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-     GemmVectorization, VectorSize>::eval(cl::sycl::nd_item<1> id) noexcept {
+     GemmVectorization, VectorSize, MiniBatchSize>::eval(cl::sycl::nd_item<1>
+                                                             id) noexcept {
   const index_t wg_batch_id = id.get_group(0) / get_workgroup_cluster();
   // This will disable all workgroups that dont have any batch to work on
   if (wg_batch_id >= batch_size_) {
@@ -241,11 +254,12 @@ Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int GemmVectorization, int VectorSize>
+          int GemmAlgorithm, int GemmVectorization, int VectorSize,
+          int MiniBatchSize>
 SYCL_BLAS_INLINE void
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
      TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-     GemmVectorization, VectorSize>::bind(cl::sycl::handler& h) {
+     GemmVectorization, VectorSize, MiniBatchSize>::bind(cl::sycl::handler& h) {
   a_.bind(h);
   b_.bind(h);
   c_.bind(h);
@@ -254,11 +268,13 @@ Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
 template <typename input_t, typename output_t, bool DoubleBuffer, bool NbcA,
           bool NbcB, int ClSize, typename tile_type, bool TransA, bool TransB,
           typename element_t, bool is_beta_zero, int GemmMemoryType,
-          int GemmAlgorithm, int GemmVectorization, int VectorSize>
+          int GemmAlgorithm, int GemmVectorization, int VectorSize,
+          int MiniBatchSize>
 SYCL_BLAS_INLINE void
 Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type, TransA,
      TransB, element_t, is_beta_zero, GemmMemoryType, GemmAlgorithm,
-     GemmVectorization, VectorSize>::adjust_access_displacement() {
+     GemmVectorization, VectorSize,
+     MiniBatchSize>::adjust_access_displacement() {
   a_.adjust_access_displacement();
   b_.adjust_access_displacement();
   c_.adjust_access_displacement();

--- a/test/unittest/blas3/blas3_gemm_batched_test.cpp
+++ b/test/unittest/blas3/blas3_gemm_batched_test.cpp
@@ -44,7 +44,7 @@ GENERATE_GEMM_TEST(BatchGemm, BetaNonZeroLDMatch);
 
 const auto BetaNonZeroLDMultiplied =
     ::testing::Combine(::testing::Values(0),         // offset
-                       ::testing::Values(5),         // batch
+                       ::testing::Values(8),         // batch
                        ::testing::Values(63, 128),   // m
                        ::testing::Values(63, 128),   // n
                        ::testing::Values(63, 128),   // k


### PR DESCRIPTION
The parameter is only used in the ARM_GPU configuration. It allows each
work item to process a batch of size MiniBatchSize at a time. This
changes the access pattern of the matrices which may work well with the
caching system.

A MiniBatchSize of 1 should compile to the same kernel than before.