### PR TITLE
Batch GEMM with alpha==0 and batch>1

### DIFF
--- a/src/interface/blas3_interface.hpp
+++ b/src/interface/blas3_interface.hpp
@@ -88,11 +88,13 @@ typename executor_t::policy_t::event_t _gemm_backend(
     // When alpha = 0, GEMM is equivalent to C = beta * C.
     if (_ldc == _M) {
       // When LDC is M, we can scale the full matrix at once.
-      return ::blas::_scal(ex, _N * _M, _beta, _C, index_t{1});
+      const auto matrix_size = _N * _M * batch_size;
+      return ::blas::_scal(ex, matrix_size, _beta, _C, index_t{1});
     } else {
       // When LDC is not M, we must scale each column of C separately.
       typename executor_t::policy_t::event_t events;
-      for (index_t i = 0; i < _N; ++i) {
+      const auto num_columns = batch_size * _N;
+      for (index_t i = 0; i < num_columns; ++i) {
         auto ev = ::blas::_scal(ex, _M, _beta, _C + i * _ldc, index_t{1});
         append_vector(events, ev);
       }

--- a/test/unittest/blas3/blas3_gemm_batched_test.cpp
+++ b/test/unittest/blas3/blas3_gemm_batched_test.cpp
@@ -34,8 +34,8 @@ const auto BetaNonZeroLDMatch =
                        ::testing::Values(63, 128),   // k
                        ::testing::Values('n', 't'),  // transa
                        ::testing::Values('n', 't'),  // transb
-                       ::testing::Values(1.0),       // alpha
-                       ::testing::Values(1.0),       // beta
+                       ::testing::Values(3.0),       // alpha
+                       ::testing::Values(7.0),       // beta
                        ::testing::Values(1),         // lda_mul
                        ::testing::Values(1),         // ldb_mul
                        ::testing::Values(1)          // ldc_mul
@@ -50,11 +50,42 @@ const auto BetaNonZeroLDMultiplied =
                        ::testing::Values(63, 128),   // k
                        ::testing::Values('n', 't'),  // transa
                        ::testing::Values('n', 't'),  // transb
-                       ::testing::Values(1.0),       // alpha
-                       ::testing::Values(1.0),       // beta
+                       ::testing::Values(3.0),       // alpha
+                       ::testing::Values(7.0),       // beta
                        ::testing::Values(2),         // lda_mul
                        ::testing::Values(3),         // ldb_mul
                        ::testing::Values(4)          // ldc_mul
                        );
 GENERATE_GEMM_TEST(BatchGemm, BetaNonZeroLDMultiplied);
 
+const auto BetaNonZeroLDMatchAlpha0 =
+    ::testing::Combine(::testing::Values(0),         // offset
+                       ::testing::Values(5),         // batch
+                       ::testing::Values(63, 128),   // m
+                       ::testing::Values(63, 128),   // n
+                       ::testing::Values(63, 128),   // k
+                       ::testing::Values('n', 't'),  // transa
+                       ::testing::Values('n', 't'),  // transb
+                       ::testing::Values(0.0),       // alpha
+                       ::testing::Values(7.0),       // beta
+                       ::testing::Values(1),         // lda_mul
+                       ::testing::Values(1),         // ldb_mul
+                       ::testing::Values(1)          // ldc_mul
+                       );
+GENERATE_GEMM_TEST(BatchGemm, BetaNonZeroLDMatchAlpha0);
+
+const auto BetaNonZeroLDMultipliedAlpha0 =
+    ::testing::Combine(::testing::Values(0),         // offset
+                       ::testing::Values(5),         // batch
+                       ::testing::Values(63, 128),   // m
+                       ::testing::Values(63, 128),   // n
+                       ::testing::Values(63, 128),   // k
+                       ::testing::Values('n', 't'),  // transa
+                       ::testing::Values('n', 't'),  // transb
+                       ::testing::Values(0.0),       // alpha
+                       ::testing::Values(7.0),       // beta
+                       ::testing::Values(2),         // lda_mul
+                       ::testing::Values(3),         // ldb_mul
+                       ::testing::Values(4)          // ldc_mul
+                       );
+GENERATE_GEMM_TEST(BatchGemm, BetaNonZeroLDMultipliedAlpha0);


### PR DESCRIPTION
When `alpha == 0`, GEMM can just scale the matrix.
However, this currently doesn't take the `batch_size` into account,
leading to wrong results.

This PR fixes this issue and adds tests for the new cases.
It also updates existing tests by changing `alpha` and `beta`
to something other than `1` -
the issue this PR is fixing doesn't present itself when `beta == 1`.