### PR TITLE
Check exception when calling os.makedirs

### DIFF
--- a/python_generator/py_gen_blas_binary.py
+++ b/python_generator/py_gen_blas_binary.py
@@ -24,8 +24,9 @@
 # **************************************************************************/
 
 # py_gen import
-import sys
+import errno
 import os
+import sys
 
 if __name__ == '__main__':
 
@@ -52,8 +53,11 @@ if __name__ == '__main__':
     file_name = sys.argv[12]
     source = 'generated_src/' + blas_level_name + '/' + blas_function_name + '/'
 
-    if not os.path.exists(source):
+    try:
         os.makedirs(source)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
     f = open(blas_template_impl, "r")
     template = Template(f.read())
     f.close()

--- a/python_generator/py_gen_blas_binary_special.py
+++ b/python_generator/py_gen_blas_binary_special.py
@@ -23,8 +23,9 @@
 # *
 # **************************************************************************/
 # py_gen import
-import sys
+import errno
 import os
+import sys
 
 if __name__ == '__main__':
 
@@ -51,8 +52,11 @@ if __name__ == '__main__':
     file_name = sys.argv[12]
     source = 'generated_src/' + blas_level_name + '/' + blas_function_name + '/'
 
-    if not os.path.exists(source):
+    try:
         os.makedirs(source)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
     f = open(blas_template_impl, "r")
     template = Template(f.read())
     f.close()

--- a/python_generator/py_gen_blas_gemm_launcher.py
+++ b/python_generator/py_gen_blas_gemm_launcher.py
@@ -23,8 +23,9 @@
 # *
 # **************************************************************************/
 # py_gen import
-import sys
+import errno
 import os
+import sys
 
 if __name__ == '__main__':
 
@@ -64,8 +65,11 @@ if __name__ == '__main__':
     batch_type = sys.argv[30]
     source = 'generated_src/' + blas_level_name + '/' + blas_function_name + '/'
 
-    if not os.path.exists(source):
+    try:
         os.makedirs(source)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
     f = open(blas_template_impl, "r")
     template = Template(f.read())
     f.close()

--- a/python_generator/py_gen_blas_ternary.py
+++ b/python_generator/py_gen_blas_ternary.py
@@ -23,8 +23,9 @@
 # *
 # **************************************************************************/
 # py_gen import
-import sys
+import errno
 import os
+import sys
 
 if __name__ == '__main__':
 
@@ -52,8 +53,11 @@ if __name__ == '__main__':
     file_name = sys.argv[13]
     source = 'generated_src/' + blas_level_name + '/' + blas_function_name + '/'
 
-    if not os.path.exists(source):
+    try:
         os.makedirs(source)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
     f = open(blas_template_impl, "r")
     template = Template(f.read())
     f.close()

--- a/python_generator/py_gen_blas_unary.py
+++ b/python_generator/py_gen_blas_unary.py
@@ -23,8 +23,9 @@
 # *
 # **************************************************************************/
 # py_gen import
-import sys
+import errno
 import os
+import sys
 
 if __name__ == '__main__':
 
@@ -50,8 +51,11 @@ if __name__ == '__main__':
     file_name = sys.argv[11]
     source = 'generated_src/' + blas_level_name + '/' + blas_function_name + '/'
 
-    if not os.path.exists(source):
+    try:
         os.makedirs(source)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
     f = open(blas_template_impl, "r")
     template = Template(f.read())
     f.close()


### PR DESCRIPTION
Because the generators can be called in parallel
there is a race condition during the build
when os.makedirs tries to create a folder that already exists.
It's safer to try to perform the operation
and ignore the exception if folder already exists.