### PR TITLE
Initial quantization

### DIFF
--- a/include/policy/default_policy_handler.h
+++ b/include/policy/default_policy_handler.h
@@ -25,6 +25,9 @@
 
 #ifndef SYCL_BLAS_DEFAULT_POLICY_H
 #define SYCL_BLAS_DEFAULT_POLICY_H
+
+#include "container/blas_iterator.h"
+
 namespace blas {
 
 template <typename blas_policy_t>

--- a/include/quantize/quantize.h
+++ b/include/quantize/quantize.h
@@ -1,0 +1,76 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename quantize.h
+ *
+ **************************************************************************/
+
+#ifndef SYCL_BLAS_QUANTIZE_H
+#define SYCL_BLAS_QUANTIZE_H
+
+#include "executors/executor.h"
+
+namespace blas {
+namespace internal {
+
+/**
+ * @brief Quantizes a buffer of one type to a buffer of another
+ * @tparam input_t Input data type
+ * @tparam output_t Output data type
+ * @tparam executor_t Type of the executor
+ * @param ex Executor where the operation will run
+ * @param[in] input Buffer holding the input data
+ * @param[out] output Buffer where ouput will be stored
+ * @return Event associated with the operation
+ * @note Internal function
+ */
+template <typename input_t, typename output_t, typename executor_t>
+typename executor_t::policy_t::event_t _quantize(
+    executor_t& ex, cl::sycl::buffer<input_t> input,
+    cl::sycl::buffer<output_t> output);
+
+}  // namespace internal
+
+/**
+ * @brief Quantizes a buffer of one type to a buffer of another
+ * @tparam executor_t Type of the executor
+ * @tparam container_input_t Container type of the input buffer
+ * @tparam container_output_t Container type of the output buffer
+ * @param ex Executor where the operation will run
+ * @param[in] input Container holding the input data
+ * @param[out] output Container where ouput will be stored
+ * @return Event associated with the operation
+ */
+template <typename executor_t, typename container_input_t,
+          typename container_output_t>
+typename executor_t::policy_t::event_t _quantize(executor_t& ex,
+                                                 container_input_t input,
+                                                 container_output_t output) {
+  auto input_buf = ex.get_policy_handler().get_buffer(input).get_buffer();
+  auto output_buf = ex.get_policy_handler().get_buffer(output).get_buffer();
+  using input_t = typename container_input_t::scalar_t;
+  using output_t = typename container_output_t::scalar_t;
+  return internal::_quantize<input_t, output_t>(ex, input_buf, output_buf);
+}
+
+}  // namespace blas
+
+#endif  // SYCL_BLAS_QUANTIZE_H

--- a/include/sycl_blas.h
+++ b/include/sycl_blas.h
@@ -59,4 +59,6 @@
 
 #include "policy/policy_handler.h"
 
+#include "quantize/quantize.h"
+
 #include "views/view.h"

--- a/include/utils/quantization.hpp
+++ b/include/utils/quantization.hpp
@@ -1,0 +1,309 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename quantization.hpp
+ *
+ **************************************************************************/
+
+#ifndef UTILS_QUANTIZATION_HPP
+#define UTILS_QUANTIZATION_HPP
+
+#include <sycl_blas.h>
+
+#include <CL/sycl.hpp>
+
+#include <type_traits>
+#include <vector>
+
+namespace utils {
+namespace internal {
+
+/**
+ * @brief How data types should be stored before quantization.
+ *        Most data quantizes to and from float.
+ * @tparam scalar_t Data type
+ */
+template <typename scalar_t>
+struct DataStorage {
+  using type = float;
+};
+
+/**
+ * @brief double can be stored as itself because it's supported natively
+ */
+template <>
+struct DataStorage<double> {
+  using type = double;
+};
+
+}  // namespace internal
+
+/**
+ * @brief How data types should be stored before quantization
+ * @tparam scalar_t Data type
+ */
+template <typename scalar_t>
+using data_storage_t = typename internal::DataStorage<scalar_t>::type;
+
+////////////////////////////////////////////////////////////////////////////////
+// Testing: make_quantized_buffer
+
+namespace internal {
+
+template <typename scalar_t>
+using quantized_buffer_t =
+    decltype(blas::make_sycl_iterator_buffer<scalar_t>(int{}));
+
+/**
+ * @brief Helper for constructing a quantized buffer
+ *
+ * 1. Constructs a buffer to hold the input data, which is float or double
+ * 2. Copies input data to the buffer
+ * 3. Constructs a buffer to hold data of scalar_t
+ * 4. Performs quantization from input data to scalar_t
+ */
+template <typename scalar_t>
+struct MakeQuantizedBuffer {
+  using data_t = data_storage_t<scalar_t>;
+
+  using return_t = quantized_buffer_t<scalar_t>;
+
+  template <typename executor_t>
+  static return_t run(executor_t& ex, std::vector<data_t>& input_vec) {
+    auto data_gpu_x_v = blas::make_sycl_iterator_buffer<data_t>(
+        static_cast<int>(input_vec.size()));
+    ex.get_policy_handler().copy_to_device(input_vec.data(), data_gpu_x_v,
+                                           input_vec.size());
+    auto gpu_x_v = blas::make_sycl_iterator_buffer<scalar_t>(
+        static_cast<int>(input_vec.size()));
+    blas::_quantize(ex, data_gpu_x_v, gpu_x_v);
+    return gpu_x_v;
+  }
+
+  template <typename executor_t>
+  static return_t run(executor_t& ex, data_t& input_scalar) {
+    auto data_gpu_x_v =
+        blas::make_sycl_iterator_buffer<data_t>(static_cast<int>(1));
+    ex.get_policy_handler().copy_to_device(&input_scalar, data_gpu_x_v, 1);
+    auto gpu_x_v =
+        blas::make_sycl_iterator_buffer<scalar_t>(static_cast<int>(1));
+    blas::_quantize(ex, data_gpu_x_v, gpu_x_v);
+    return gpu_x_v;
+  }
+};
+
+/**
+ * @brief Helper for constructing a quantized buffer
+ *        where no quantization actually takes place,
+ *        as is the case with float and double.
+ *
+ * 1. Constructs a buffer to hold data of scalar_t
+ * 2. Copies input data to the buffer
+ */
+template <typename scalar_t>
+struct MakeQuantizedBufferNoConversion {
+  using data_t = scalar_t;
+
+  using return_t = quantized_buffer_t<scalar_t>;
+
+  template <typename executor_t>
+  static return_t run(executor_t& ex, std::vector<data_t>& input_vec) {
+    auto gpu_x_v = blas::make_sycl_iterator_buffer<scalar_t>(
+        static_cast<int>(input_vec.size()));
+    ex.get_policy_handler().copy_to_device(input_vec.data(), gpu_x_v,
+                                           input_vec.size());
+    return gpu_x_v;
+  }
+
+  template <typename executor_t>
+  static return_t run(executor_t& ex, data_t& input_scalar) {
+    auto gpu_x_v =
+        blas::make_sycl_iterator_buffer<scalar_t>(static_cast<int>(1));
+    ex.get_policy_handler().copy_to_device(&input_scalar, gpu_x_v, 1);
+    return gpu_x_v;
+  }
+};
+
+/**
+ * @brief Buffer of float doesn't need a quantization step
+ */
+template <>
+struct MakeQuantizedBuffer<float>
+    : public MakeQuantizedBufferNoConversion<float> {};
+
+/**
+ * @brief Buffer of double doesn't need a quantization step
+ */
+template <>
+struct MakeQuantizedBuffer<double>
+    : public MakeQuantizedBufferNoConversion<double> {};
+
+////////////////////////////////////////////////////////////////////////////////
+// Testing: quantized_copy_to_host
+
+/**
+ * @brief Helper for copying data from device to host
+ *        while also quantizing the data
+ *
+ * 1. Constructs a buffer to hold the output data, which is float or double
+ * 2. Performs quantization from scalar_t to output data
+ * 3. Copies output data to host
+ */
+template <typename scalar_t>
+struct QuantizedCopyToHost {
+  using data_t = data_storage_t<scalar_t>;
+
+  template <typename executor_t>
+  using return_t = typename executor_t::policy_t::event_t;
+
+  template <typename executor_t>
+  static return_t<executor_t> run(executor_t& ex,
+                                  quantized_buffer_t<scalar_t>& device_buffer,
+                                  std::vector<data_t>& output_vec) {
+    auto data_gpu_x_v = blas::make_sycl_iterator_buffer<data_t>(
+        static_cast<int>(output_vec.size()));
+    blas::_quantize(ex, device_buffer, data_gpu_x_v);
+    return ex.get_policy_handler().copy_to_host(data_gpu_x_v, output_vec.data(),
+                                                output_vec.size());
+  }
+
+  template <typename executor_t>
+  static return_t<executor_t> run(executor_t& ex,
+                                  quantized_buffer_t<scalar_t>& device_buffer,
+                                  data_t& output_scalar) {
+    auto data_gpu_x_v =
+        blas::make_sycl_iterator_buffer<data_t>(static_cast<int>(1));
+    blas::_quantize(ex, device_buffer, data_gpu_x_v);
+    return ex.get_policy_handler().copy_to_host(data_gpu_x_v, &output_scalar,
+                                                1);
+  }
+};
+
+/**
+ * @brief Helper for copying data from device to host
+ *        where no quantization actually takes place,
+ *        as is the case with float and double.
+ *
+ * 1. Copies from device buffer to output data on host
+ */
+template <typename scalar_t>
+struct QuantizedCopyToHostNoConversion {
+  using data_t = scalar_t;
+
+  template <typename executor_t>
+  using return_t = typename executor_t::policy_t::event_t;
+
+  template <typename executor_t>
+  static return_t<executor_t> run(executor_t& ex,
+                                  quantized_buffer_t<scalar_t>& device_buffer,
+                                  std::vector<data_t>& output_vec) {
+    return ex.get_policy_handler().copy_to_host(
+        device_buffer, output_vec.data(), output_vec.size());
+  }
+
+  template <typename executor_t>
+  static return_t<executor_t> run(executor_t& ex,
+                                  quantized_buffer_t<scalar_t>& device_buffer,
+                                  data_t& output_scalar) {
+    return ex.get_policy_handler().copy_to_host(device_buffer, &output_scalar,
+                                                1);
+  }
+};
+
+/**
+ * @brief Buffer of float doesn't need a quantization step
+ */
+template <>
+struct QuantizedCopyToHost<float>
+    : public QuantizedCopyToHostNoConversion<float> {};
+
+/**
+ * @brief Buffer of double doesn't need a quantization step
+ */
+template <>
+struct QuantizedCopyToHost<double>
+    : public QuantizedCopyToHostNoConversion<double> {};
+
+}  // namespace internal
+
+////////////////////////////////////////////////////////////////////////////////
+// Exposed interface
+
+/**
+ * @brief Constructs a buffer containing data that was quantized
+ *        from the provided input vector
+ * @return Buffer containing quantized data
+ * @note scalar_t cannot be deduced, it has to be provided
+ */
+template <typename scalar_t, typename executor_t>
+auto make_quantized_buffer(executor_t& ex,
+                           std::vector<data_storage_t<scalar_t>>& input_vec)
+    -> decltype(internal::MakeQuantizedBuffer<scalar_t>::run(ex, input_vec)) {
+  return internal::MakeQuantizedBuffer<scalar_t>::run(ex, input_vec);
+}
+
+/**
+ * @brief Constructs a buffer containing data that was quantized
+ *        from the provided input scalar
+ * @return Buffer containing quantized data
+ * @note scalar_t cannot be deduced, it has to be provided
+ */
+template <typename scalar_t, typename executor_t>
+auto make_quantized_buffer(executor_t& ex,
+                           data_storage_t<scalar_t>& input_scalar)
+    -> decltype(internal::MakeQuantizedBuffer<scalar_t>::run(ex,
+                                                             input_scalar)) {
+  return internal::MakeQuantizedBuffer<scalar_t>::run(ex, input_scalar);
+}
+
+/**
+ * @brief Performs a copy from a buffer of scalar_t to output vector
+ *        while also quantizing the data
+ * @return Event associated with the operation
+ * @note scalar_t cannot be deduced, it has to be provided
+ */
+template <typename scalar_t, typename executor_t>
+auto quantized_copy_to_host(
+    executor_t& ex, internal::quantized_buffer_t<scalar_t>& device_buffer,
+    std::vector<data_storage_t<scalar_t>>& output_vec) ->
+    typename executor_t::policy_t::event_t {
+  return internal::QuantizedCopyToHost<scalar_t>::run(ex, device_buffer,
+                                                      output_vec);
+}
+
+/**
+ * @brief Performs a copy from a buffer of scalar_t to output scalar
+ *        while also quantizing the data
+ * @return Event associated with the operation
+ * @note scalar_t cannot be deduced, it has to be provided
+ */
+template <typename scalar_t, typename executor_t>
+auto quantized_copy_to_host(
+    executor_t& ex, internal::quantized_buffer_t<scalar_t>& device_buffer,
+    data_storage_t<scalar_t>& output_scalar) ->
+    typename executor_t::policy_t::event_t {
+  return internal::QuantizedCopyToHost<scalar_t>::run(ex, device_buffer,
+                                                      output_scalar);
+}
+
+}  // namespace utils
+
+#endif  // UTILS_QUANTIZATION_HPP

--- a/python_generator/py_gen_quantize.py
+++ b/python_generator/py_gen_quantize.py
@@ -1,0 +1,71 @@
+#/***************************************************************************
+# *
+# *  @license
+# *  Copyright (C) Codeplay Software Limited
+# *  Licensed under the Apache License, Version 2.0 (the "License");
+# *  you may not use this file except in compliance with the License.
+# *  You may obtain a copy of the License at
+# *
+# *      http://www.apache.org/licenses/LICENSE-2.0
+# *
+# *  For your convenience, a copy of the License has been included in this
+# *  repository.
+# *
+# *  Unless required by applicable law or agreed to in writing, software
+# *  distributed under the License is distributed on an "AS IS" BASIS,
+# *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# *  See the License for the specific language governing permissions and
+# *  limitations under the License.
+# *
+# *  SYCL-BLAS: BLAS implementation using SYCL
+# *
+# *  @filename py_gen_quantize.py
+# *
+# **************************************************************************/
+# py_gen import
+import errno
+import os
+import sys
+
+
+def generate(argv):
+    generator_path = argv[1]
+    sys.path.insert(0, generator_path)
+    from py_gen import generate_file, Iterable, Itermode, IterGroup
+    from string import Template
+
+    input_template = argv[2]
+    blas_template_impl = sys.argv[3]
+    executor = argv[4]
+    data = argv[5]
+    file_name = argv[6]
+    source = 'generated_src/quantize/'
+
+    try:
+        os.makedirs(source)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+    f = open(blas_template_impl, "r")
+    template = Template(f.read())
+    f.close()
+    iterables = [
+        Iterable(key='EXECUTOR',
+                 vals=[executor],
+                 itermode=Itermode.combinations,
+                 iter_modifier=1),
+        Iterable(key='DATA_TYPE',
+                 vals=[data],
+                 itermode=Itermode.combinations,
+                 iter_modifier=1),
+    ]
+    iter_groups = [IterGroup('@ip1@', template, iterables, combine_iters=True)]
+    generate_file(input_template,
+                  source + file_name,
+                  iter_groups,
+                  format_generated=False,
+                  format_script="")
+
+
+if __name__ == '__main__':
+    generate(sys.argv)

--- a/src/quantize/CMakeLists.txt
+++ b/src/quantize/CMakeLists.txt
@@ -22,6 +22,5 @@
 # *  @filename CMakeLists.txt
 # *
 # **************************************************************************/
-add_subdirectory(policy)
-add_subdirectory(interface)
-add_subdirectory(quantize)
+
+generate_quantize()

--- a/src/quantize/quantize.cpp.in
+++ b/src/quantize/quantize.cpp.in
@@ -1,0 +1,70 @@
+/***************************************************************************
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename quantize.cpp.in
+ *
+ **************************************************************************/
+
+#include "quantize/quantize.h"
+#include "quantize/quantize.hpp"
+
+#include "executors/executor_sycl.hpp"
+#include "policy/sycl_policy_handler.h"
+
+namespace blas {
+namespace internal {
+
+using executor_t = Executor<${EXECUTOR}>;
+using scalar_t = ${DATA_TYPE};
+
+using event_t = typename executor_t::policy_t::event_t;
+
+/**
+ * @brief Base case quantization where it just copies one buffer to another
+ */
+template <>
+event_t _quantize<scalar_t, scalar_t, executor_t>(
+    executor_t& ex, cl::sycl::buffer<scalar_t> input,
+    cl::sycl::buffer<scalar_t> output) {
+  return Quantize<scalar_t, scalar_t>::run(ex, input, output);
+}
+
+/**
+ * @brief Specialization for quantizing float to scalar_t
+ */
+template <>
+event_t _quantize<float, scalar_t, executor_t>(
+    executor_t& ex, cl::sycl::buffer<float> input,
+    cl::sycl::buffer<scalar_t> output) {
+  return Quantize<float, scalar_t>::run(ex, input, output);
+}
+
+/**
+ * @brief Specialization for quantizing scalar_t to float
+ */
+template <>
+event_t _quantize<scalar_t, float, executor_t>(executor_t& ex,
+                                               cl::sycl::buffer<scalar_t> input,
+                                               cl::sycl::buffer<float> output) {
+  return Quantize<scalar_t, float>::run(ex, input, output);
+}
+
+}  // namespace internal
+}  // namespace blas

--- a/src/quantize/quantize.hpp
+++ b/src/quantize/quantize.hpp
@@ -1,0 +1,114 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename quantize.hpp
+ *
+ **************************************************************************/
+
+#ifndef SYCL_BLAS_QUANTIZE_HPP
+#define SYCL_BLAS_QUANTIZE_HPP
+
+#include "executors/executor.h"
+#include "policy/sycl_policy_handler.h"
+
+namespace blas {
+namespace internal {
+
+/**
+ * @brief Type of the accessor to use as input when performing quantization
+ * @tparam input_t Input data type
+ */
+template <typename input_t>
+using quantized_input_acc_t =
+    cl::sycl::accessor<input_t, 1, cl::sycl::access::mode::read,
+                       cl::sycl::access::target::global_buffer>;
+
+/**
+ * @brief Type of the accessor to use as output when performing quantization
+ * @tparam output_t Output data type
+ */
+template <typename output_t>
+using quantized_output_acc_t =
+    cl::sycl::accessor<output_t, 1, cl::sycl::access::mode::write,
+                       cl::sycl::access::target::global_buffer>;
+
+/**
+ * @brief Kernel that performs quantization.
+ *        The generic form just performs a static_cast of each element.
+ * @tparam input_t Input data type
+ * @tparam output_t Output data type
+ */
+template <typename input_t, typename output_t>
+struct QuantizeKernel {
+  quantized_input_acc_t<input_t> input_;
+  quantized_output_acc_t<output_t> output_;
+
+  void operator()(cl::sycl::id<1> index) const {
+    output_[index] = static_cast<output_t>(input_[index]);
+  }
+};
+
+/**
+ * @brief Struct that dispatches a kernel to perform quantization
+ * @tparam input_t Input data type
+ * @tparam output_t Output data type
+ */
+template <typename input_t, typename output_t>
+struct Quantize {
+  template <typename executor_t>
+  static typename executor_t::policy_t::event_t run(
+      executor_t& ex, cl::sycl::buffer<input_t>& input,
+      cl::sycl::buffer<output_t>& output) {
+    return {
+        ex.get_policy_handler().get_queue().submit([&](cl::sycl::handler& cgh) {
+          const auto kernel = QuantizeKernel<input_t, output_t>{
+              quantized_input_acc_t<input_t>{input, cgh},
+              quantized_output_acc_t<output_t>{output, cgh}};
+          cgh.parallel_for(cl::sycl::range<1>{input.get_size()}, kernel);
+        })};
+  }
+};
+
+/**
+ * @brief Specialization for quantizing to same type.
+ *        In this case no algorithm is required,
+ *        the data is just copied from one buffer to another.
+ * @tparam scalar_t Input and output data type
+ */
+template <typename scalar_t>
+struct Quantize<scalar_t, scalar_t> {
+  template <typename executor_t>
+  static typename executor_t::policy_t::event_t run(
+      executor_t& ex, cl::sycl::buffer<scalar_t>& input,
+      cl::sycl::buffer<scalar_t>& output) {
+    return {
+        ex.get_policy_handler().get_queue().submit([&](cl::sycl::handler& cgh) {
+          auto input_acc = quantized_input_acc_t<scalar_t>{input, cgh};
+          auto output_acc = quantized_output_acc_t<scalar_t>{output, cgh};
+          cgh.copy(input_acc, output_acc);
+        })};
+  }
+};
+
+}  // namespace internal
+}  // namespace blas
+
+#endif  // SYCL_BLAS_QUANTIZE_HPP

--- a/src/quantize/quantize_base.cpp.in
+++ b/src/quantize/quantize_base.cpp.in
@@ -1,0 +1,86 @@
+/***************************************************************************
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename quantize_base.cpp.in
+ *
+ **************************************************************************/
+
+#include "quantize/quantize.h"
+#include "quantize/quantize.hpp"
+
+#include "executors/executor_sycl.hpp"
+#include "policy/sycl_policy_handler.h"
+
+namespace blas {
+namespace internal {
+
+using executor_t = Executor<${EXECUTOR}>;
+// DATA_TYPE is ignored, so scalar_t is not defined
+
+using event_t = typename executor_t::policy_t::event_t;
+
+/**
+ * @brief Base case quantization where it just copies
+ *        one buffer of float to another
+ */
+template <>
+event_t _quantize<float, float, executor_t>(executor_t& ex,
+                                            cl::sycl::buffer<float> input,
+                                            cl::sycl::buffer<float> output) {
+  return Quantize<float, float>::run(ex, input, output);
+}
+
+#ifdef BLAS_DATA_TYPE_DOUBLE
+
+/**
+ * @brief Base case quantization where it just copies
+ *        one buffer of double to another
+ */
+template <>
+event_t _quantize<double, double, executor_t>(executor_t& ex,
+                                              cl::sycl::buffer<double> input,
+                                              cl::sycl::buffer<double> output) {
+  return Quantize<double, double>::run(ex, input, output);
+}
+
+/**
+ * @brief Specialization for quantizing float to double
+ */
+template <>
+event_t _quantize<float, double, executor_t>(executor_t& ex,
+                                             cl::sycl::buffer<float> input,
+                                             cl::sycl::buffer<double> output) {
+  return Quantize<float, double>::run(ex, input, output);
+}
+
+/**
+ * @brief Specialization for quantizing double to float
+ */
+template <>
+event_t _quantize<double, float, executor_t>(executor_t& ex,
+                                             cl::sycl::buffer<double> input,
+                                             cl::sycl::buffer<float> output) {
+  return Quantize<double, float>::run(ex, input, output);
+}
+
+#endif  // BLAS_DATA_TYPE_DOUBLE
+
+}  // namespace internal
+}  // namespace blas

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -43,6 +43,7 @@
 #include "utils/cli_device_selector.hpp"
 #include "utils/float_comparison.hpp"
 #include "utils/print_queue_information.hpp"
+#include "utils/quantization.hpp"
 #include "utils/system_reference_blas.hpp"
 
 struct Args {

--- a/test/unittest/blas1/blas1_asum_test.cpp
+++ b/test/unittest/blas1/blas1_asum_test.cpp
@@ -34,32 +34,32 @@ void run_test(const combination_t<scalar_t> combi) {
   int incX;
   std::tie(size, incX) = combi;
 
+  using data_t = utils::data_storage_t<scalar_t>;
+
   // Input vector
-  std::vector<scalar_t> x_v(size * incX);
+  std::vector<data_t> x_v(size * incX);
   fill_random(x_v);
 
   // Output scalar
-  std::vector<scalar_t> out_s(1, scalar_t(0));
+  data_t out_s = 0;
 
   // Reference implementation
-  scalar_t out_cpu_s = reference_blas::asum(size, x_v.data(), incX);
+  data_t out_cpu_s = reference_blas::asum(size, x_v.data(), incX);
 
   // SYCL implementation
   auto q = make_queue();
   test_executor_t ex(q);
 
   // Iterators
-  auto gpu_x_v = blas::make_sycl_iterator_buffer<scalar_t>(int(size * incX));
-  ex.get_policy_handler().copy_to_device(x_v.data(), gpu_x_v, size * incX);
-  auto gpu_out_s = blas::make_sycl_iterator_buffer<scalar_t>(int(1));
-  ex.get_policy_handler().copy_to_device(out_s.data(), gpu_out_s, 1);
+  auto gpu_x_v = utils::make_quantized_buffer<scalar_t>(ex, x_v);
+  auto gpu_out_s = utils::make_quantized_buffer<scalar_t>(ex, out_s);
 
   _asum(ex, size, gpu_x_v, incX, gpu_out_s);
-  auto event = ex.get_policy_handler().copy_to_host(gpu_out_s, out_s.data(), 1);
+  auto event = utils::quantized_copy_to_host<scalar_t>(ex, gpu_out_s, out_s);
   ex.get_policy_handler().wait(event);
 
   // Validate the result
-  ASSERT_TRUE(utils::almost_equal(out_s[0], out_cpu_s));
+  ASSERT_TRUE(utils::almost_equal(out_s, out_cpu_s));
 
   ex.get_policy_handler().get_queue().wait();
 }


### PR DESCRIPTION
In order to support different data types,
there has to be a way to convert data from `T*` to `float*`,
and vice-versa.
At minimum this is required to call reference BLAS,
which can only accept data as `float*` or `double*`.

This patch introduces that functionality
by providing a new public function `blas::_quantize`.
The function takes a policy handler,
a container of the input type,
and a container of the output type.
The containers are passed as SYCL buffers
to the `blas::internal::_quantize` function.

At the moment the only "quantization" provided
is a `static_cast` on each element,
which should work in most cases.
It is possible to specialize the quantization
by specializing `blas::internal::QuantizeKernel`
or even `blas::internal::Quantize`.

Important C++ files:
* `include/quantize.h` exposes the function publicly
* `src/quantize/quantize.hpp` provides internal functionality
* `src/quantize/quantize.cpp.in` provides a file template
  where templates for internal functionality are instantiated
  as needed by the data types.
  `float` and `double` don't need this file.
* `src/quantize/quantize_base.cpp.in` instantiates templates
  for `float` and `double`

Right now only the `asum` test was modified
to store the data as only `float*` and `double*`
and perform quantization for the tested type.
For this, special helper functions were provided.