### PR TITLE
Fix build of syclblas samples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,9 +145,14 @@ option(BLAS_VERIFY_BENCHMARK "Whether to verify the results of benchmarks" ON)
 option(BUILD_CLBLAST_BENCHMARKS "Whether to build CLBLAST benchmarks" OFF)
 option(BUILD_ACL_BENCHMARKS "Whether to build ARM Compute Library benchmarks" OFF)
 option(BUILD_EXPRESSION_BENCHMARKS "Whether to build the expression benchmarks" OFF)
+option(BLAS_BUILD_SAMPLES "Whether to build SYCL-BLAS samples" OFF)
 
 if(${BLAS_ENABLE_BENCHMARK})
   add_subdirectory(benchmark)
+endif()
+
+if (BLAS_BUILD_SAMPLES)
+  add_subdirectory(samples)
 endif()
 
 option(BLAS_ENABLE_AUTO_TUNERS "Whether to enable building GEMM auto tuners" OFF)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,28 +1,29 @@
-set(COMPUTECPP_SDK_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../external/computecpp-sdk/include)
-set(SYCLBLAS_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+set(SyclBLAS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+set(SyclBLAS_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/Modules)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../external/computecpp-sdk/cmake/Modules)
+list(APPEND CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-find_package(OpenCL REQUIRED)
 find_package(ComputeCpp REQUIRED)
 find_package(SyclBLAS REQUIRED)
 include(ConfigureSYCLBLAS)
 
-file(GLOB SRC_LIST
-  ${CMAKE_CURRENT_SOURCE_DIR}/gemv.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/gemm.cpp
+set(SAMPLES_LIST
+  gemv.cpp
+  gemm.cpp
 )
-foreach(src_file ${SRC_LIST})
+
+foreach(src_file ${SAMPLES_LIST})
   get_filename_component(sample_exec ${src_file} NAME_WE)
-  set(TARGET sample_exec ${src_file})
+  set(sample_exec "sample_${sample_exec}")
   add_executable(${sample_exec} ${src_file})
   set_property(TARGET ${sample_exec} PROPERTY CXX_STANDARD 11)
   add_sycl_to_target(
     TARGET ${sample_exec}
     SOURCES ${src_file}
   )
-  target_link_libraries(${sample_exec} PUBLIC SyclBLAS::SyclBLAS )
+  target_link_libraries(${sample_exec} PUBLIC SyclBLAS::SyclBLAS)
   install(TARGETS ${sample_exec} RUNTIME DESTINATION bin)
 endforeach()
 include_directories(${SYCLBLAS_INCLUDE} ${ComputeCpp_INCLUDE_DIRS} ${COMPUTECPP_SDK_INCLUDE})


### PR DESCRIPTION
- Add cmake option BLAS_BUILD_SAMPLES to enable building the samples
- Fix the samples target names to not conflict with internal syclblas targets