### PR TITLE
Support for cl::sycl::half

### DIFF
--- a/benchmark/common_utils.hpp
+++ b/benchmark/common_utils.hpp
@@ -679,6 +679,16 @@ static inline void calc_avg_counters(benchmark::State& state) {
 #define BLAS_REGISTER_BENCHMARK_DOUBLE(args, exPtr, success)
 #endif  // BLAS_DATA_TYPE_DOUBLE
 
+#ifdef BLAS_DATA_TYPE_HALF
+/** Registers benchmark for the cl::sycl::half data type
+ * @see BLAS_REGISTER_BENCHMARK
+ */
+#define BLAS_REGISTER_BENCHMARK_HALF(args, exPtr, success) \
+  register_benchmark<cl::sycl::half>(args, exPtr, success)
+#else
+#define BLAS_REGISTER_BENCHMARK_HALF(args, exPtr, success)
+#endif  // BLAS_DATA_TYPE_HALF
+
 /** Registers benchmark for all supported data types.
  *  Expects register_benchmark<scalar_t> to exist.
  * @param args Reference to blas_benchmark::Args
@@ -689,6 +699,7 @@ static inline void calc_avg_counters(benchmark::State& state) {
   do {                                                    \
     BLAS_REGISTER_BENCHMARK_FLOAT(args, exPtr, success);  \
     BLAS_REGISTER_BENCHMARK_DOUBLE(args, exPtr, success); \
+    BLAS_REGISTER_BENCHMARK_HALF(args, exPtr, success);   \
   } while (false)
 
 #endif

--- a/benchmark/syclblas/blas1/asum.cpp
+++ b/benchmark/syclblas/blas1/asum.cpp
@@ -48,6 +48,12 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
 
   // Create data
   std::vector<data_t> v1 = blas_benchmark::utils::random_data<data_t>(size);
+
+  // We need to guarantee that cl::sycl::half can hold the sum
+  // of x_v without overflow by making sum(x_v) to be 1.0
+  std::transform(std::begin(v1), std::end(v1), std::begin(v1),
+                 [=](data_t x) { return x / v1.size(); });
+
   data_t vr;
 
   auto inx = utils::make_quantized_buffer<scalar_t>(ex, v1);

--- a/benchmark/syclblas/blas1/axpy.cpp
+++ b/benchmark/syclblas/blas1/axpy.cpp
@@ -69,7 +69,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   }
 
   std::ostringstream err_stream;
-  if (!utils::compare_vectors(y_temp, y_ref, err_stream, "")) {
+  if (!utils::compare_vectors<data_t, scalar_t>(y_temp, y_ref, err_stream,
+                                                "")) {
     const std::string& err_str = err_stream.str();
     state.SkipWithError(err_str.c_str());
     *success = false;

--- a/benchmark/syclblas/blas1/iamax.cpp
+++ b/benchmark/syclblas/blas1/iamax.cpp
@@ -51,6 +51,10 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   std::vector<data_t> v1 = blas_benchmark::utils::random_data<data_t>(size);
   tuple_scalar_t out{-1, 0};
 
+  // This will clamp the values to what scalar_t can represent
+  std::transform(std::begin(v1), std::end(v1), std::begin(v1),
+                 [](data_t v) { return utils::clamp_to_limits<scalar_t>(v); });
+
   auto inx = utils::make_quantized_buffer<scalar_t>(ex, v1);
   auto outI = blas::make_sycl_iterator_buffer<tuple_scalar_t>(&out, 1);
 

--- a/benchmark/syclblas/blas1/iamin.cpp
+++ b/benchmark/syclblas/blas1/iamin.cpp
@@ -51,6 +51,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   std::vector<data_t> v1 = blas_benchmark::utils::random_data<data_t>(size);
   tuple_scalar_t out{0, 0};
 
+  std::transform(std::begin(v1), std::end(v1), std::begin(v1),
+                 [](data_t v) { return utils::clamp_to_limits<scalar_t>(v); });
+
   auto inx = utils::make_quantized_buffer<scalar_t>(ex, v1);
   auto outI = blas::make_sycl_iterator_buffer<tuple_scalar_t>(&out, 1);
 

--- a/benchmark/syclblas/blas1/nrm2.cpp
+++ b/benchmark/syclblas/blas1/nrm2.cpp
@@ -49,6 +49,10 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   // Create data
   std::vector<data_t> v1 = blas_benchmark::utils::random_data<data_t>(size);
 
+  // We need to guarantee that cl::sycl::half can hold the norm of the vector
+  std::transform(std::begin(v1), std::end(v1), std::begin(v1),
+                 [=](data_t x) { return x / v1.size(); });
+
   auto inx = utils::make_quantized_buffer<scalar_t>(ex, v1);
   auto inr = blas::make_sycl_iterator_buffer<scalar_t>(1);
 
@@ -64,7 +68,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
     ex.get_policy_handler().wait(event);
   }
 
-  if (!utils::almost_equal(vr_temp, vr_ref)) {
+  if (!utils::almost_equal<data_t, scalar_t>(vr_temp, vr_ref)) {
     std::ostringstream err_stream;
     err_stream << "Value mismatch: " << vr_temp << "; expected " << vr_ref;
     const std::string& err_str = err_stream.str();

--- a/benchmark/syclblas/blas2/gemv.cpp
+++ b/benchmark/syclblas/blas2/gemv.cpp
@@ -59,7 +59,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int ti, index_t m,
   {
     double nflops_AtimesX = 2.0 * m_d * n_d;
     double nflops_timesAlpha = ylen;
-    double nflops_addBetaY = (beta != 0) ? 2 * ylen : 0;
+    double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
     state.counters["n_fl_ops"] =
         nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
   }
@@ -67,7 +67,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int ti, index_t m,
     double mem_readA = m_d * n_d;
     double mem_readX = xlen;
     double mem_writeY = ylen;
-    double mem_readY = (beta != 0) ? ylen : 0;
+    double mem_readY = (beta != scalar_t{0}) ? ylen : 0;
     state.counters["bytes_processed"] =
         (mem_readA + mem_readX + mem_writeY + mem_readY) * sizeof(scalar_t);
   }

--- a/benchmark/syclblas/blas2/gemv.cpp
+++ b/benchmark/syclblas/blas2/gemv.cpp
@@ -102,7 +102,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int ti, index_t m,
   }
 
   std::ostringstream err_stream;
-  if (!utils::compare_vectors(v_y_temp, v_y_ref, err_stream, "")) {
+  if (!utils::compare_vectors<data_t, scalar_t>(v_y_temp, v_y_ref, err_stream,
+                                                "")) {
     const std::string& err_str = err_stream.str();
     state.SkipWithError(err_str.c_str());
     *success = false;

--- a/benchmark/syclblas/blas3/gemm.cpp
+++ b/benchmark/syclblas/blas3/gemm.cpp
@@ -123,7 +123,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
     double mem_readA = m_d * k_d;
     double mem_readB = k_d * n_d;
     double mem_writeC = m_d * n_d;
-    double mem_readC = (beta != 0) ? m_d * n_d : 0;
+    double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
     double total_mem =
         (mem_readA + mem_readB + mem_readC + mem_writeC) * sizeof(scalar_t);
     state.counters["bytes_processed"] = total_mem;
@@ -131,7 +131,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
 
     double nflops_AtimesB = (2 * k_d - 1) * m_d * n_d;
     double nflops_timesAlpha = m_d * n_d;
-    double nflops_addBetaC = (beta != 0) ? 2 * m_d * n_d : 0;
+    double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
     double nflops = nflops_AtimesB + nflops_timesAlpha + nflops_addBetaC;
     state.counters["n_fl_ops"] = nflops;
     state.SetItemsProcessed(state.iterations() * nflops);

--- a/benchmark/syclblas/blas3/gemm.cpp
+++ b/benchmark/syclblas/blas3/gemm.cpp
@@ -79,7 +79,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
   }
 
   std::ostringstream err_stream;
-  if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+  if (!utils::compare_vectors<data_t, scalar_t>(c_temp, c_ref, err_stream,
+                                                "")) {
     const std::string& err_str = err_stream.str();
     state.SkipWithError(err_str.c_str());
     *success = false;

--- a/benchmark/syclblas/blas3/gemm_batched.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched.cpp
@@ -102,7 +102,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
   {
     double nflops_AtimesB = (2 * k_d - 1) * m_d * n_d;
     double nflops_timesAlpha = m_d * n_d;
-    double nflops_addBetaC = (beta != 0) ? 2 * m_d * n_d : 0;
+    double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
     state.counters["n_fl_ops"] =
         (nflops_AtimesB + nflops_timesAlpha + nflops_addBetaC) * batch_size_d;
   }
@@ -110,7 +110,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
     double mem_readA = m_d * k_d;
     double mem_readB = k_d * n_d;
     double mem_writeC = m_d * n_d;
-    double mem_readC = (beta != 0) ? m_d * n_d : 0;
+    double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
     state.counters["bytes_processed"] =
         (mem_readA + mem_readB + mem_readC + mem_writeC) * batch_size_d *
         sizeof(scalar_t);

--- a/benchmark/syclblas/blas3/gemm_batched.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched.cpp
@@ -172,7 +172,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
   }
 
   std::ostringstream err_stream;
-  if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+  if (!utils::compare_vectors<data_t, scalar_t>(c_temp, c_ref, err_stream,
+                                                "")) {
     const std::string& err_str = err_stream.str();
     state.SkipWithError(err_str.c_str());
     *success = false;

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -437,6 +437,7 @@ elseif(${TARGET} STREQUAL "RCAR") # need investigation
 elseif(${TARGET} STREQUAL "ARM_GPU")
   set(supported_types
     "float"
+    "cl::sycl::half"
   )
   foreach(data ${supported_types})
     if(${BLAS_MODEL_OPTIMIZATION} STREQUAL "RESNET_50")
@@ -501,6 +502,7 @@ elseif(${TARGET} STREQUAL "ARM_GPU")
 elseif(${TARGET} STREQUAL "POWER_VR")
   set(supported_types
     "float"
+    "cl::sycl::half"
   )
   foreach(data ${supported_types})
     add_gemm_configuration(
@@ -526,9 +528,11 @@ elseif(${TARGET} STREQUAL "AMD_GPU")  # need investigation
   set(supported_types
     "float"
     "double"
+    "cl::sycl::half"
   )
   set(workgroup_float 16)
   set(workgroup_double 8)
+  set(workgroup_cl::sycl::half 32)
   foreach(data ${supported_types})
     set(twr "${workgroup_${data}}")
     set(twc "${workgroup_${data}}")

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -381,6 +381,7 @@ if(${TARGET} STREQUAL "INTEL_GPU")
   set(supported_types
     "float"
     "double"
+    "cl::sycl::half"
   )
   foreach(data ${supported_types})
     add_gemm_configuration(
@@ -393,21 +394,39 @@ if(${TARGET} STREQUAL "INTEL_GPU")
       "${data}" 64 "false" "false" "false"
       64 8 8 8 8 1 1 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
 
-    add_gemm_configuration(
-      "${data}" 16 "true" "false" "false"
-      64 1 1 4 4 1 1 1 1 1 1 "local" "tall_skinny" "none" 4 "strided")
-    add_gemm_configuration(
-      "${data}" 16 "true" "false" "false"
-      64 2 2 4 4 1 1 1 1 1 1 "local" "tall_skinny" "none" 4 "strided")
+    if (${data} STREQUAL "cl::sycl::half")
+      add_gemm_configuration(
+         "${data}" 16 "true" "false" "false"
+         64 1 1 8 8 1 1 1 1 1 1 "local" "tall_skinny" "none" 4 "strided")
+      add_gemm_configuration(
+        "${data}" 16 "true" "false" "false"
+         64 2 2 8 8 1 1 1 1 1 1 "local" "tall_skinny" "none" 4 "strided")
+    else()
+      add_gemm_configuration(
+         "${data}" 16 "true" "false" "false"
+         64 1 1 4 4 1 1 1 1 1 1 "local" "tall_skinny" "none" 4 "strided")
+      add_gemm_configuration(
+        "${data}" 16 "true" "false" "false"
+         64 2 2 4 4 1 1 1 1 1 1 "local" "tall_skinny" "none" 4 "strided")
+    endif()
+
     add_gemm_configuration(
       "${data}" 64 "true" "true" "true"
       64 2 2 8 8 1 1 1 1 1 1 "local" "tall_skinny" "none" 4 "strided")
     add_gemm_configuration(
       "${data}" 64 "true" "true" "true"
-      64 4 4 8 8 1 1  1 1 1 1 "local" "tall_skinny" "none" 4 "strided")
-    add_gemm_configuration(
-      "${data}" 256 "true" "true" "true"
-      64 4 4 16 16 1 1 1 1 1 1 "local" "tall_skinny" "none" 4 "strided")
+      64 4 4 8 8 1 1 1 1 "local" "tall_skinny" "none" 4 "strided")
+
+    if (${data} STREQUAL "double")
+      add_gemm_configuration(
+        "${data}" 256 "true" "true" "true"
+        64 4 4 8 8 1 1 1 1 1 1 "local" "tall_skinny" "none" 4 "strided")
+    else()
+      add_gemm_configuration(
+        "${data}" 256 "true" "true" "true"
+        64 4 4 16 16 1 1 1 1 1 1 "local" "tall_skinny" "none" 4 "strided")
+    endif()
+
     add_gemm_configuration(
       "${data}" 32 "true" "true" "true"
       64 2 1 8 4 1 1 1 1 1 1 "local" "tall_skinny" "none" 4 "strided")

--- a/cmake/Modules/ConfigureSYCLBLAS.cmake
+++ b/cmake/Modules/ConfigureSYCLBLAS.cmake
@@ -44,7 +44,7 @@ if("double" IN_LIST BLAS_DATA_TYPES)
   add_definitions(-DBLAS_DATA_TYPE_DOUBLE)
 endif()
 
-if("cl::sycl::half" IN_LIST BLAS_DATA_TYPES)
+if("half" IN_LIST BLAS_DATA_TYPES)
   add_definitions(-DBLAS_DATA_TYPE_HALF)
 endif()
 

--- a/cmake/Modules/ConfigureSYCLBLAS.cmake
+++ b/cmake/Modules/ConfigureSYCLBLAS.cmake
@@ -44,6 +44,10 @@ if("double" IN_LIST BLAS_DATA_TYPES)
   add_definitions(-DBLAS_DATA_TYPE_DOUBLE)
 endif()
 
+if("cl::sycl::half" IN_LIST BLAS_DATA_TYPES)
+  add_definitions(-DBLAS_DATA_TYPE_HALF)
+endif()
+
 # If the user has specified a specific workgroup size for tests, pass that on to the compiler
 if(WG_SIZE)
   add_definitions(-DWG_SIZE=${WG_SIZE})

--- a/include/operations/blas_constants.h
+++ b/include/operations/blas_constants.h
@@ -26,10 +26,13 @@
 #ifndef SYCL_BLAS_CONSTANTS_H
 #define SYCL_BLAS_CONSTANTS_H
 
+#include "blas_meta.h"
+
+#include <CL/sycl.hpp>
+
 #include <complex>
 #include <limits>
-//#include <utility>
-#include "blas_meta.h"
+
 namespace blas {
 
 template <typename scalar_t, typename index_t>
@@ -206,6 +209,46 @@ struct constant<std::complex<value_t>, Indicator> {
                                  constant<value_t, Indicator>::value());
   }
 };
+
+template <>
+struct constant<cl::sycl::half, const_val::zero>
+    : constant<float, const_val::zero> {};
+
+template <>
+struct constant<cl::sycl::half, const_val::one>
+    : constant<float, const_val::one> {};
+
+template <>
+struct constant<cl::sycl::half, const_val::m_one>
+    : constant<float, const_val::m_one> {};
+
+template <>
+struct constant<cl::sycl::half, const_val::two>
+    : constant<float, const_val::two> {};
+
+template <>
+struct constant<cl::sycl::half, const_val::m_two>
+    : constant<float, const_val::m_two> {};
+
+template <>
+struct constant<cl::sycl::half, const_val::max>
+    : constant<float, const_val::max> {};
+
+template <>
+struct constant<cl::sycl::half, const_val::min>
+    : constant<float, const_val::min> {};
+
+template <>
+struct constant<cl::sycl::half, const_val::abs_max>
+    : constant<float, const_val::abs_max> {};
+
+template <>
+struct constant<cl::sycl::half, const_val::abs_min>
+    : constant<float, const_val::abs_min> {};
+
+template <>
+struct constant<cl::sycl::half, const_val::collapse>
+    : constant<float, const_val::collapse> {};
 
 template <typename iv_type, const_val IndexIndicator, const_val ValueIndicator>
 struct constant_pair {

--- a/include/utils/float_comparison.hpp
+++ b/include/utils/float_comparison.hpp
@@ -36,6 +36,16 @@ inline std::ostream& operator<<(std::ostream& os, const cl::sycl::half& value) {
   os << static_cast<float>(value);
   return os;
 }
+
+namespace std {
+template <>
+class numeric_limits<cl::sycl::half> {
+ public:
+  static constexpr float min() { return -65504.0f; }
+  static constexpr float max() { return 65504.0f; }
+};
+}  // namespace std
+
 #endif  // BLAS_DATA_TYPE_HALF
 
 namespace utils {
@@ -73,6 +83,19 @@ inline cl::sycl::half abs<cl::sycl::half>(cl::sycl::half value) noexcept {
 }
 
 #endif  // BLAS_DATA_TYPE_HALF
+
+template <typename scalar_t>
+scalar_t clamp_to_limits(scalar_t v) {
+  constexpr auto min_value = std::numeric_limits<scalar_t>::min();
+  constexpr auto max_value = std::numeric_limits<scalar_t>::max();
+  if (decltype(min_value)(v) < min_value) {
+    return min_value;
+  } else if (decltype(max_value)(v) > max_value) {
+    return max_value;
+  } else {
+    return v;
+  }
+}
 
 /**
  * Indicates the tolerated margin for relative differences

--- a/src/interface/blas1_interface.hpp
+++ b/src/interface/blas1_interface.hpp
@@ -291,7 +291,7 @@ typename executor_t::policy_t::event_t _rot(
   auto vy = make_vector_view(ex, _vy, _incy, _N);
   auto scalOp1 = make_op<ScalarOp, ProductOperator>(_cos, vx);
   auto scalOp2 = make_op<ScalarOp, ProductOperator>(_sin, vy);
-  auto scalOp3 = make_op<ScalarOp, ProductOperator>(-_sin, vx);
+  auto scalOp3 = make_op<ScalarOp, ProductOperator>(element_t{-_sin}, vx);
   auto scalOp4 = make_op<ScalarOp, ProductOperator>(_cos, vy);
   auto addOp12 = make_op<BinaryOp, AddOperator>(scalOp1, scalOp2);
   auto addOp34 = make_op<BinaryOp, AddOperator>(scalOp3, scalOp4);

--- a/src/interface/blas3/backend/intel_gpu.hpp
+++ b/src/interface/blas3/backend/intel_gpu.hpp
@@ -70,8 +70,11 @@ typename executor_t::policy_t::event_t _gemm(
                                                                   _c, _ldc,
                                                                   batch_size);
     } else if (_M <= 4 || _N <= 4) {
+      // Need to increase the work group size for cl::sycl::half for the
+      // launcher to be instancianted
+      constexpr int wg_size = sizeof(element_t) == 2 ? 8 : 4;
       return blas::Gemm_Launcher<
-          16, true, false, false, 64, Tile<1, 1, 4, 4>, _t_a, _t_b,
+          16, true, false, false, 64, Tile<1, 1, wg_size, wg_size>, _t_a, _t_b,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
@@ -96,8 +99,11 @@ typename executor_t::policy_t::event_t _gemm(
                                                                   _c, _ldc,
                                                                   batch_size);
     } else if (_M <= 8 || _N <= 8) {
+      // Need to increase the work group size for cl::sycl::half for the
+      // launcher to be instancianted
+      constexpr int wg_size = sizeof(element_t) == 2 ? 8 : 4;
       return blas::Gemm_Launcher<
-          16, true, false, false, 64, Tile<2, 2, 4, 4>, _t_a, _t_b,
+          16, true, false, false, 64, Tile<2, 2, wg_size, wg_size>, _t_a, _t_b,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
@@ -135,8 +141,9 @@ typename executor_t::policy_t::event_t _gemm(
                                                                   _c, _ldc,
                                                                   batch_size);
     } else {
+      constexpr int wg_size = sizeof(element_t) == 8 ? 8 : 16;
       return blas::Gemm_Launcher<
-          256, true, true, true, 64, Tile<4, 4, 16, 16>, _t_a, _t_b,
+          256, true, true, true, 64, Tile<4, 4, wg_size, wg_size>, _t_a, _t_b,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
@@ -163,8 +170,11 @@ typename executor_t::policy_t::event_t _gemm(
                                                                   _c, _ldc,
                                                                   batch_size);
     } else {
+      // Need to increase the work group size for double for the
+      // launcher to be instancianted
+      constexpr int wg_size = sizeof(element_t) == 8 ? 8 : 16;
       return blas::Gemm_Launcher<
-          256, true, true, true, 64, Tile<4, 4, 16, 16>, _t_a, _t_b,
+          256, true, true, true, 64, Tile<4, 4, wg_size, wg_size>, _t_a, _t_b,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,

--- a/src/operations/blas1_trees.hpp
+++ b/src/operations/blas1_trees.hpp
@@ -79,6 +79,15 @@ struct DetectScalar<double> {
  * @brief See Detect Scalar.
  */
 template <>
+struct DetectScalar<cl::sycl::half> {
+  using element_t = cl::sycl::half;
+  static element_t get_scalar(element_t &scalar) { return scalar; }
+};
+
+/*! DetectScalar.
+ * @brief See Detect Scalar.
+ */
+template <>
 struct DetectScalar<std::complex<float>> {
   using element_t = std::complex<float>;
   static element_t get_scalar(element_t &scalar) { return scalar; }
@@ -482,7 +491,7 @@ AssignReduction<operator_t, lhs_t, rhs_t>::eval(sharedT scratch,
   index_t frs_thrd = 2 * groupid * localSz + localid;
 
   // Reduction across the grid
-  static constexpr value_t init_val = operator_t::template init<rhs_t>();
+  static const value_t init_val = operator_t::template init<rhs_t>();
   value_t val = init_val;
   for (index_t k = frs_thrd; k < vecS; k += 2 * global_num_thread_) {
     val = operator_t::eval(val, rhs_.eval(k));

--- a/src/operations/blas1_trees.hpp
+++ b/src/operations/blas1_trees.hpp
@@ -491,6 +491,7 @@ AssignReduction<operator_t, lhs_t, rhs_t>::eval(sharedT scratch,
   index_t frs_thrd = 2 * groupid * localSz + localid;
 
   // Reduction across the grid
+  // TODO(Peter): This should be constexpr once half supports it
   static const value_t init_val = operator_t::template init<rhs_t>();
   value_t val = init_val;
   for (index_t k = frs_thrd; k < vecS; k += 2 * global_num_thread_) {

--- a/src/operations/blas2/gemv.hpp
+++ b/src/operations/blas2/gemv.hpp
@@ -581,6 +581,7 @@ GemvRow<interLoop, Lower, Diag, Upper, Unit, lhs_t, matrix_t, vector_t>::eval(
 
   index_t frs_col = idWFC * dimWFC + interLoop * localid;
   index_t lst_col = std::min(dimC, frs_col + dimWFC);
+  // TODO(Peter): This should be constexpr once half supports it
   static const value_t init_val = AddOperator::template init<vector_t>();
   // PROBLEM IF ONLY SOME THREADS OF A WORKGROUP ARE CANCELED
   // TO SOLVE IT, USE GLOBAL VALUES OF frs_col AND lst_col

--- a/src/operations/blas2/gemv.hpp
+++ b/src/operations/blas2/gemv.hpp
@@ -581,7 +581,6 @@ GemvRow<interLoop, Lower, Diag, Upper, Unit, lhs_t, matrix_t, vector_t>::eval(
 
   index_t frs_col = idWFC * dimWFC + interLoop * localid;
   index_t lst_col = std::min(dimC, frs_col + dimWFC);
-  // TODO(Peter): Does it hurt performance if this is not constexpr?
   static const value_t init_val = AddOperator::template init<vector_t>();
   // PROBLEM IF ONLY SOME THREADS OF A WORKGROUP ARE CANCELED
   // TO SOLVE IT, USE GLOBAL VALUES OF frs_col AND lst_col

--- a/src/operations/blas3/gemm_interleaved.hpp
+++ b/src/operations/blas3/gemm_interleaved.hpp
@@ -444,7 +444,8 @@ class Gemm<input_t, output_t, /* DoubleBuffer = */ false, /* NbcA = */ false,
               auto is_in = do_check<need_check_boundary>(
                   boundary_check(mb_start + (b * wg_batchs) + p, batch_size_));
               reinterpret_cast<value_t *>(reg_res)[p] =
-                  is_in ? (output[b * wg_batchs + p] * beta_) : value_t(0);
+                  is_in ? value_t{output[b * wg_batchs + p] * beta_}
+                        : value_t{0};
             }
             ++reg_res;
             continue;

--- a/src/operations/blas3/gemm_load_store.hpp
+++ b/src/operations/blas3/gemm_load_store.hpp
@@ -92,7 +92,7 @@ struct Packetize {
 #pragma unroll
       for (index_t i = 0; i < packet_size; i++) {
         reinterpret_cast<value_t *>(&packet)[i] =
-            edge_in_range(i) ? *(src + i) : 0;
+            edge_in_range(i) ? *(src + i) : value_t{0};
       }
     }
     store<trans, ld>(packet, dest);

--- a/src/operations/extension/reduction_partial_rows.hpp
+++ b/src/operations/extension/reduction_partial_rows.hpp
@@ -44,7 +44,7 @@ class ReductionPartialRows {
   using params_t = ReductionRows_Params<index_t, element_t, ClSize, WgSize>;
 
   /* Neutral value for this reduction operator */
-  static constexpr value_t init_val = operator_t::template init<output_t>();
+  static const value_t init_val;
 
   /* Input and output buffers */
   input_t in_;
@@ -200,6 +200,12 @@ class ReductionPartialRows {
     }
   }
 };
+
+template <typename operator_t, typename input_t, typename output_t, int ClSize,
+          int WgSize, typename element_t>
+const element_t ReductionPartialRows<operator_t, input_t, output_t, ClSize,
+                                     WgSize, element_t>::init_val =
+    operator_t::template init<output_t>();
 
 }  // namespace blas
 

--- a/src/operations/extension/reduction_partial_rows.hpp
+++ b/src/operations/extension/reduction_partial_rows.hpp
@@ -43,7 +43,8 @@ class ReductionPartialRows {
    * See the header file for the definition of this structure */
   using params_t = ReductionRows_Params<index_t, element_t, ClSize, WgSize>;
 
-  /* Neutral value for this reduction operator */
+  /// Neutral value for this reduction operator
+  /// TODO(Peter): This should be constexpr once half supports it
   static const value_t init_val;
 
   /* Input and output buffers */

--- a/src/policy/sycl_policy_handler.cpp
+++ b/src/policy/sycl_policy_handler.cpp
@@ -83,6 +83,10 @@ INSTANTIATE_TEMPLATE_METHODS(float)
 INSTANTIATE_TEMPLATE_METHODS(double)
 #endif  // BLAS_DATA_TYPE_DOUBLE
 
+#ifdef BLAS_DATA_TYPE_HALF
+INSTANTIATE_TEMPLATE_METHODS(cl::sycl::half)
+#endif  // BLAS_DATA_TYPE_HALF
+
 #define INSTANTIATE_TEMPLATE_METHODS_SPECIAL(ind, val)                        \
   template IndexValueTuple<ind, val>                                          \
       *PolicyHandler<codeplay_policy>::allocate<IndexValueTuple<ind, val>>(   \
@@ -145,6 +149,12 @@ INSTANTIATE_TEMPLATE_METHODS_SPECIAL(int, double)
 INSTANTIATE_TEMPLATE_METHODS_SPECIAL(long, double)
 INSTANTIATE_TEMPLATE_METHODS_SPECIAL(long long, double)
 #endif  // BLAS_DATA_TYPE_DOUBLE
+
+#ifdef BLAS_DATA_TYPE_HALF
+INSTANTIATE_TEMPLATE_METHODS_SPECIAL(int, cl::sycl::half)
+INSTANTIATE_TEMPLATE_METHODS_SPECIAL(long, cl::sycl::half)
+INSTANTIATE_TEMPLATE_METHODS_SPECIAL(long long, cl::sycl::half)
+#endif  // BLAS_DATA_TYPE_HALF
 
 }  // namespace blas
 #endif

--- a/test/blas_test_macros.hpp
+++ b/test/blas_test_macros.hpp
@@ -67,6 +67,23 @@
                                   combination_t, combination)
 #endif  // BLAS_DATA_TYPE_DOUBLE
 
+#ifdef BLAS_DATA_TYPE_HALF
+/** Registers test for the cl::sycl::half type
+ * @see BLAS_REGISTER_TEST_CUSTOM_NAME
+ */
+#define BLAS_REGISTER_TEST_HALF(test_suite, class_name, test_function,     \
+                                combination_t, combination)                \
+  class class_name##Half                                                   \
+      : public ::testing::TestWithParam<combination_t<cl::sycl::half>> {}; \
+  TEST_P(class_name##Half, test) {                                         \
+    test_function<cl::sycl::half>(GetParam());                             \
+  };                                                                       \
+  INSTANTIATE_TEST_SUITE_P(test_suite, class_name##Half, combination);
+#else
+#define BLAS_REGISTER_TEST_HALF(test_suite, class_name, test_function, \
+                                combination_t, combination)
+#endif  // BLAS_DATA_TYPE_HALF
+
 /** Registers test for all supported data types
  * @param test_suite Name of the test suite
  * @param class_name Base name of the test class
@@ -80,7 +97,9 @@
   BLAS_REGISTER_TEST_FLOAT(test_suite, class_name, test_function,             \
                            combination_t, combination);                       \
   BLAS_REGISTER_TEST_DOUBLE(test_suite, class_name, test_function,            \
-                            combination_t, combination);
+                            combination_t, combination);                      \
+  BLAS_REGISTER_TEST_HALF(test_suite, class_name, test_function,              \
+                          combination_t, combination);
 
 /** Registers test for all supported data types
  * @see BLAS_REGISTER_TEST_CUSTOM_NAME

--- a/test/unittest/blas1/blas1_axpy_test.cpp
+++ b/test/unittest/blas1/blas1_axpy_test.cpp
@@ -63,7 +63,9 @@ void run_test(const combination_t<scalar_t> combi) {
   ex.get_policy_handler().wait(event);
 
   // Validate the result
-  ASSERT_TRUE(utils::compare_vectors(y_v, y_cpu_v));
+  const bool isAlmostEqual =
+      utils::compare_vectors<data_t, scalar_t>(y_v, y_cpu_v);
+  ASSERT_TRUE(isAlmostEqual);
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas1/blas1_copy_test.cpp
+++ b/test/unittest/blas1/blas1_copy_test.cpp
@@ -61,6 +61,7 @@ void run_test(const combination_t<scalar_t> combi) {
   ex.get_policy_handler().wait(event);
 
   // Validate the result
+  // For copy, the float tolerances are ok
   ASSERT_TRUE(utils::compare_vectors(y_v, y_cpu_v));
 }
 

--- a/test/unittest/blas1/blas1_dot_test.cpp
+++ b/test/unittest/blas1/blas1_dot_test.cpp
@@ -64,7 +64,9 @@ void run_test(const combination_t<scalar_t> combi) {
   ex.get_policy_handler().wait(event);
 
   // Validate the result
-  ASSERT_TRUE(utils::almost_equal(out_s[0], out_cpu_s));
+  const bool isAlmostEqual =
+      utils::almost_equal<data_t, scalar_t>(out_s[0], out_cpu_s);
+  ASSERT_TRUE(isAlmostEqual);
 
   ex.get_policy_handler().get_queue().wait();
 }

--- a/test/unittest/blas1/blas1_iamax_test.cpp
+++ b/test/unittest/blas1/blas1_iamax_test.cpp
@@ -19,7 +19,7 @@ void run_test(const combination_t<scalar_t> combi) {
 
   // This will remove infs from the vector
   std::transform(std::begin(x_v), std::end(x_v), std::begin(x_v),
-                 [](data_t v) { return clamp<scalar_t>(v); });
+                 [](data_t v) { return utils::clamp_to_limits<scalar_t>(v); });
 
   // Output scalar
   tuple_t out_s{0, 0.0};

--- a/test/unittest/blas1/blas1_iamax_test.cpp
+++ b/test/unittest/blas1/blas1_iamax_test.cpp
@@ -17,6 +17,10 @@ void run_test(const combination_t<scalar_t> combi) {
   std::vector<data_t> x_v(size * incX);
   populate_data<data_t>(mode, 0.0, x_v);
 
+  // This will remove infs from the vector
+  std::transform(std::begin(x_v), std::end(x_v), std::begin(x_v),
+                 [](data_t v) { return clamp<scalar_t>(v); });
+
   // Output scalar
   tuple_t out_s{0, 0.0};
 

--- a/test/unittest/blas1/blas1_iamin_test.cpp
+++ b/test/unittest/blas1/blas1_iamin_test.cpp
@@ -45,7 +45,7 @@ void run_test(const combination_t<scalar_t> combi) {
   populate_data<data_t>(mode, max, x_v);
   for (int i = 0; i < size * incX; i++) {
     // There is a bug in Openblas where 0s are not handled correctly
-    if (x_v[i] == 0.0) {
+    if (x_v[i] == scalar_t{0.0}) {
       x_v[i] = 1.0;
     }
   }

--- a/test/unittest/blas1/blas1_iamin_test.cpp
+++ b/test/unittest/blas1/blas1_iamin_test.cpp
@@ -50,6 +50,10 @@ void run_test(const combination_t<scalar_t> combi) {
     }
   }
 
+  // Removes infs from the vector
+  std::transform(std::begin(x_v), std::end(x_v), std::begin(x_v),
+                 [](data_t v) { return clamp<scalar_t>(v); });
+
   // Output scalar
   tuple_t out_s{0, max};
 

--- a/test/unittest/blas1/blas1_iamin_test.cpp
+++ b/test/unittest/blas1/blas1_iamin_test.cpp
@@ -52,7 +52,7 @@ void run_test(const combination_t<scalar_t> combi) {
 
   // Removes infs from the vector
   std::transform(std::begin(x_v), std::end(x_v), std::begin(x_v),
-                 [](data_t v) { return clamp<scalar_t>(v); });
+                 [](data_t v) { return utils::clamp_to_limits<scalar_t>(v); });
 
   // Output scalar
   tuple_t out_s{0, max};

--- a/test/unittest/blas1/blas1_iaminmax_common.hpp
+++ b/test/unittest/blas1/blas1_iaminmax_common.hpp
@@ -38,6 +38,28 @@ enum class generation_mode_t : char {
 template <typename scalar_t>
 using combination_t = std::tuple<int, int, generation_mode_t>;
 
+namespace std {
+template <>
+class numeric_limits<cl::sycl::half> {
+ public:
+  static constexpr float min() { return -65504.0f; }
+  static constexpr float max() { return 65504.0f; }
+};
+}  // namespace std
+
+template<typename scalar_t>
+scalar_t clamp(scalar_t v) {
+  constexpr auto min_value = std::numeric_limits<scalar_t>::min();
+  constexpr auto max_value = std::numeric_limits<scalar_t>::max();
+  if (decltype(min_value)(v) < min_value) {
+    return min_value;
+  } else if (decltype(max_value)(v) > max_value) {
+    return max_value;
+  } else {
+    return v;
+  }
+}
+
 template <typename scalar_t>
 void populate_data(generation_mode_t mode, scalar_t limit,
                    std::vector<scalar_t> &vec) {

--- a/test/unittest/blas1/blas1_iaminmax_common.hpp
+++ b/test/unittest/blas1/blas1_iaminmax_common.hpp
@@ -38,28 +38,6 @@ enum class generation_mode_t : char {
 template <typename scalar_t>
 using combination_t = std::tuple<int, int, generation_mode_t>;
 
-namespace std {
-template <>
-class numeric_limits<cl::sycl::half> {
- public:
-  static constexpr float min() { return -65504.0f; }
-  static constexpr float max() { return 65504.0f; }
-};
-}  // namespace std
-
-template<typename scalar_t>
-scalar_t clamp(scalar_t v) {
-  constexpr auto min_value = std::numeric_limits<scalar_t>::min();
-  constexpr auto max_value = std::numeric_limits<scalar_t>::max();
-  if (decltype(min_value)(v) < min_value) {
-    return min_value;
-  } else if (decltype(max_value)(v) > max_value) {
-    return max_value;
-  } else {
-    return v;
-  }
-}
-
 template <typename scalar_t>
 void populate_data(generation_mode_t mode, scalar_t limit,
                    std::vector<scalar_t> &vec) {

--- a/test/unittest/blas1/blas1_nrm2_test.cpp
+++ b/test/unittest/blas1/blas1_nrm2_test.cpp
@@ -59,7 +59,9 @@ void run_test(const combination_t<scalar_t> combi) {
   ex.get_policy_handler().wait(event);
 
   // Validate the result
-  ASSERT_TRUE(utils::almost_equal(out_s[0], out_cpu_s));
+  const bool isAlmostEqual =
+      utils::almost_equal<data_t, scalar_t>(out_s[0], out_cpu_s);
+  ASSERT_TRUE(isAlmostEqual);
 }
 
 const auto combi = ::testing::Combine(::testing::Values(11, 1002),  // size

--- a/test/unittest/blas1/blas1_rotg_test.cpp
+++ b/test/unittest/blas1/blas1_rotg_test.cpp
@@ -81,7 +81,9 @@ void run_test(const combination_t<scalar_t> combi) {
   ex.get_policy_handler().wait(event);
 
   // Validate the result
-  ASSERT_TRUE(utils::almost_equal(out_s[0], out_cpu_s));
+  const bool isAlmostEqual =
+      utils::almost_equal<data_t, scalar_t>(out_s[0], out_cpu_s);
+  ASSERT_TRUE(isAlmostEqual);
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas1/blas1_scal_test.cpp
+++ b/test/unittest/blas1/blas1_scal_test.cpp
@@ -56,7 +56,10 @@ void run_test(const combination_t<scalar_t> combi) {
   ex.get_policy_handler().wait(event);
 
   // Validate the result
-  ASSERT_TRUE(utils::compare_vectors(x_v, x_cpu_v));
+  const bool isAlmostEqual =
+      utils::compare_vectors<data_t, scalar_t>(x_v, x_cpu_v);
+  ASSERT_TRUE(isAlmostEqual);
+
   ex.get_policy_handler().get_queue().wait();
 }
 

--- a/test/unittest/blas1/blas1_swap_test.cpp
+++ b/test/unittest/blas1/blas1_swap_test.cpp
@@ -64,6 +64,7 @@ void run_test(const combination_t<scalar_t> combi) {
   ex.get_policy_handler().wait(event);
 
   // Validate the result
+  // Since this is just a swap operation, float tolerances are fine
   ASSERT_TRUE(utils::compare_vectors(y_v, y_cpu_v));
   ASSERT_TRUE(utils::compare_vectors(x_v, x_cpu_v));
 }

--- a/test/unittest/blas2/blas2_gemv_test.cpp
+++ b/test/unittest/blas2/blas2_gemv_test.cpp
@@ -78,7 +78,9 @@ void run_test(const combination_t<scalar_t> combi) {
       utils::quantized_copy_to_host<scalar_t>(ex, v_y_gpu, y_v_gpu_result);
   ex.get_policy_handler().wait(event);
 
-  ASSERT_TRUE(utils::compare_vectors(y_v_gpu_result, y_v_cpu));
+  const bool isAlmostEqual =
+      utils::compare_vectors<data_t, scalar_t>(y_v_gpu_result, y_v_cpu);
+  ASSERT_TRUE(isAlmostEqual);
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas2/blas2_ger_test.cpp
+++ b/test/unittest/blas2/blas2_ger_test.cpp
@@ -69,7 +69,9 @@ void run_test(const combination_t<scalar_t> combi) {
       utils::quantized_copy_to_host<scalar_t>(ex, m_c_gpu, c_m_gpu_result);
   ex.get_policy_handler().wait(event);
 
-  ASSERT_TRUE(utils::compare_vectors(c_m_gpu_result, c_m_cpu));
+  const bool isAlmostEqual =
+      utils::compare_vectors<data_t, scalar_t>(c_m_gpu_result, c_m_cpu);
+  ASSERT_TRUE(isAlmostEqual);
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas2/blas2_symv_test.cpp
+++ b/test/unittest/blas2/blas2_symv_test.cpp
@@ -71,7 +71,9 @@ void run_test(const combination_t<scalar_t> combi) {
   auto event = utils::quantized_copy_to_host<scalar_t>(ex, y_v_gpu, y_v);
   ex.get_policy_handler().wait(event);
 
-  ASSERT_TRUE(utils::compare_vectors(y_v, y_cpu_v));
+  const bool isAlmostEqual =
+      utils::compare_vectors<data_t, scalar_t>(y_v, y_cpu_v);
+  ASSERT_TRUE(isAlmostEqual);
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas2/blas2_syr2_test.cpp
+++ b/test/unittest/blas2/blas2_syr2_test.cpp
@@ -67,7 +67,9 @@ void run_test(const combination_t<scalar_t> combi) {
   auto event = utils::quantized_copy_to_host<scalar_t>(ex, a_m_gpu, a_m);
   ex.get_policy_handler().wait(event);
 
-  ASSERT_TRUE(utils::compare_vectors(a_m, a_cpu_m));
+  const bool isAlmostEqual =
+      utils::compare_vectors<data_t, scalar_t>(a_m, a_cpu_m);
+  ASSERT_TRUE(isAlmostEqual);
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas2/blas2_syr_test.cpp
+++ b/test/unittest/blas2/blas2_syr_test.cpp
@@ -63,7 +63,9 @@ void run_test(const combination_t<scalar_t> combi) {
   auto event = utils::quantized_copy_to_host<scalar_t>(ex, a_m_gpu, a_m);
   ex.get_policy_handler().wait(event);
 
-  ASSERT_TRUE(utils::compare_vectors(a_m, a_cpu_m));
+  const bool isAlmostEqual =
+      utils::compare_vectors<data_t, scalar_t>(a_m, a_cpu_m);
+  ASSERT_TRUE(isAlmostEqual);
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas2/blas2_trmv_test.cpp
+++ b/test/unittest/blas2/blas2_trmv_test.cpp
@@ -77,7 +77,9 @@ void run_test(const combination_t<scalar_t> combi) {
   auto event = utils::quantized_copy_to_host<scalar_t>(ex, x_v_gpu, x_v);
   ex.get_policy_handler().wait(event);
 
-  ASSERT_TRUE(utils::compare_vectors(x_v, x_cpu_v));
+  const bool isAlmostEqual =
+      utils::compare_vectors<data_t, scalar_t>(x_v, x_cpu_v);
+  ASSERT_TRUE(isAlmostEqual);
 }
 
 #ifdef STRESS_TESTING

--- a/test/unittest/blas3/blas3_gemm_common.hpp
+++ b/test/unittest/blas3/blas3_gemm_common.hpp
@@ -152,8 +152,12 @@ inline void verify_gemm(const gemm_arguments_t<scalar_t> arguments) {
     c_m_gpu = interleaved_to_strided(c_m_gpu, offset, ldc, n, batch);
   }
 
-  ASSERT_TRUE(utils::compare_vectors(c_m_gpu, c_m_cpu));
   ex.get_policy_handler().wait();
+
+  const bool isAlmostEqual =
+      utils::compare_vectors<data_t, scalar_t>(c_m_gpu, c_m_cpu);
+  ASSERT_TRUE(isAlmostEqual);
+
 }
 
 /** Registers GEMM test for all supported data types


### PR DESCRIPTION
1. Added specializations for `cl::sycl::half`
    * `AbsoluteValue`, `DetectScalar`, `PolicyHandler`
2. Defined new macros
    * `BLAS_DATA_TYPE_HALF`, `BLAS_REGISTER_TEST_HALF`,
      `BLAS_REGISTER_BENCHMARK_HALF`
3. Some changes required because `cl::sycl::half` is not a regular type
    * Defined `operator<<`
    * Treat half as floating point
    * Specializations for `blas::constant`
    * Removed constexpr from `init``
    * Specialized some builtins
4. Some static casts or explicit construction required
    * Align types in ternary operator
    * Construct constants as `value_t` or `scalar_t`
5. Enabled `cl::sycl::half` GEMM configurations
    * AMD GPU, ARM GPU, Power VR