### PR TITLE
Fix Windows build of sycl-blas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,15 @@ list(APPEND COMPUTECPP_USER_FLAGS
   -no-serial-memop
 )
 
+if (MSVC)
+  # The device compiler needs C++14 to parse the Windows headers
+  set(CMAKE_CXX_STANDARD 14)
+  set(BUILD_SHARED_LIBS FALSE CACHE BOOL
+    "Force SYCL-BLAS to be built as a static library on Windows"
+    FORCE
+  )
+endif()
+
 # By default, tall and skinny Gemm is enabled (for better performance)
 option(GEMM_TALL_SKINNY_SUPPORT "Whether to enable tall and skinny Gemm" ON)
 # By default vectorization in gemm kernels is disabled until fully implemented.
@@ -104,6 +113,14 @@ include(CmakeFunctionHelper)
 
 add_subdirectory(src)
 build_library(sycl_blas)
+
+if (WIN32)
+  # On Windows, all symbols must be resolved at link time for DLLs.
+  # The sycl_blas target is just a collection of other objects so
+  # the linked libraries are not going to be propagated to this target.
+  # This requires manual linking against ComputeCpp.lib on Windows.
+  target_link_libraries(sycl_blas PRIVATE ComputeCpp::ComputeCpp)
+endif()
 
 set_target_properties(sycl_blas PROPERTIES
   VERSION ${PROJECT_VERSION}

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -39,6 +39,12 @@ set(boolean_list "true" "false")
 function(sanitize_file_name output file_name)
   string(REGEX REPLACE "(:|\\*|<| |,|>)" "_" file_name ${file_name})
   string(REGEX REPLACE "(_____|____|___|__)" "_" file_name ${file_name})
+  if (WIN32)
+    # Long paths are problematic on Windows so we hash the filename
+    # to reduce its size
+    string(MD5 file_name ${file_name})
+    set(file_name ${file_name}.cpp)
+  endif()
   set(${output} "${file_name}" PARENT_SCOPE)
 endfunction()
 

--- a/include/policy/sycl_policy_handler.h
+++ b/include/policy/sycl_policy_handler.h
@@ -124,7 +124,7 @@ class PolicyHandler<codeplay_policy> {
 
   template <typename element_t>
   typename policy_t::event_t copy_to_device(const element_t *src,
-                                            element_t *dst, size_t size);
+                                            element_t *dst, size_t size = 0);
   /*  @brief Copying the data back to device
     @tparam element_t is the type of the data
     @param src is the host pointer we want to copy from.
@@ -134,7 +134,8 @@ class PolicyHandler<codeplay_policy> {
 
   template <typename element_t>
   typename policy_t::event_t copy_to_device(
-      const element_t *src, BufferIterator<element_t, policy_t> dst, size_t);
+      const element_t *src, BufferIterator<element_t, policy_t> dst,
+      size_t size = 0);
   /*  @brief Copying the data back to device
       @tparam element_t is the type of the data
       @param src is the device pointer we want to copy from.
@@ -144,11 +145,11 @@ class PolicyHandler<codeplay_policy> {
 
   template <typename element_t>
   typename policy_t::event_t copy_to_host(element_t *src, element_t *dst,
-                                          size_t size);
+                                          size_t size = 0);
 
   template <typename element_t>
   typename policy_t::event_t copy_to_host(
-      BufferIterator<element_t, policy_t> src, element_t *dst, size_t);
+      BufferIterator<element_t, policy_t> src, element_t *dst, size_t size = 0);
 
   inline const policy_t::device_type get_device_type() const {
     return selectedDeviceType_;

--- a/src/operations/blas_operators.hpp
+++ b/src/operations/blas_operators.hpp
@@ -281,11 +281,11 @@ struct IMaxOperator : public Operators {
     if (AbsoluteValue::eval(
             static_cast<typename StripASP<lhs_t>::type>(l).get_value()) <
             AbsoluteValue::eval(
-                static_cast<typename StripASP<rhs_t>::type>(r).get_value()) or
+                static_cast<typename StripASP<rhs_t>::type>(r).get_value()) ||
         (AbsoluteValue::eval(
              static_cast<typename StripASP<lhs_t>::type>(l).get_value()) ==
              AbsoluteValue::eval(
-                 static_cast<typename StripASP<rhs_t>::type>(r).get_value()) and
+                 static_cast<typename StripASP<rhs_t>::type>(r).get_value()) &&
          l.get_index() > r.get_index())) {
       return static_cast<typename StripASP<rhs_t>::type>(r);
     } else {

--- a/src/policy/sycl_policy_handler.cpp
+++ b/src/policy/sycl_policy_handler.cpp
@@ -57,7 +57,7 @@ namespace blas {
   template typename codeplay_policy::event_t                                   \
   PolicyHandler<codeplay_policy>::copy_to_device<element_t>(                   \
       const element_t *src, BufferIterator<element_t, codeplay_policy> dst,    \
-      size_t size = 0);                                                        \
+      size_t size);                                                            \
   template typename codeplay_policy::event_t                                   \
   PolicyHandler<codeplay_policy>::copy_to_host<element_t>(                     \
       element_t * src, element_t * dst, size_t size);                          \
@@ -65,7 +65,7 @@ namespace blas {
   template typename codeplay_policy::event_t                                   \
   PolicyHandler<codeplay_policy>::copy_to_host<element_t>(                     \
       BufferIterator<element_t, codeplay_policy> src, element_t * dst,         \
-      size_t size = 0);                                                        \
+      size_t size);                                                            \
   template ptrdiff_t PolicyHandler<codeplay_policy>::get_offset<element_t>(    \
       const element_t *ptr) const;                                             \
                                                                                \
@@ -113,7 +113,7 @@ INSTANTIATE_TEMPLATE_METHODS(double)
   PolicyHandler<codeplay_policy>::copy_to_device<IndexValueTuple<ind, val>>(  \
       const IndexValueTuple<ind, val> *src,                                   \
       BufferIterator<IndexValueTuple<ind, val>, codeplay_policy> dst,         \
-      size_t size = 0);                                                       \
+      size_t size);                                                           \
   template typename codeplay_policy::event_t                                  \
   PolicyHandler<codeplay_policy>::copy_to_host<IndexValueTuple<ind, val>>(    \
       IndexValueTuple<ind, val> * src, IndexValueTuple<ind, val> * dst,       \
@@ -122,7 +122,7 @@ INSTANTIATE_TEMPLATE_METHODS(double)
   template typename codeplay_policy::event_t                                  \
   PolicyHandler<codeplay_policy>::copy_to_host<IndexValueTuple<ind, val>>(    \
       BufferIterator<IndexValueTuple<ind, val>, codeplay_policy> src,         \
-      IndexValueTuple<ind, val> * dst, size_t size = 0);                      \
+      IndexValueTuple<ind, val> * dst, size_t size);                          \
   template ptrdiff_t                                                          \
   PolicyHandler<codeplay_policy>::get_offset<IndexValueTuple<ind, val>>(      \
       const IndexValueTuple<ind, val> *ptr) const;                            \

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -56,7 +56,7 @@ using namespace blas;
 
 // The executor type used in tests
 using test_executor_t =
-    class blas::Executor<blas::PolicyHandler<blas::codeplay_policy>>;
+    blas::Executor<blas::PolicyHandler<blas::codeplay_policy>>;
 
 /**
  * Construct a SYCL queue using the device specified in the command line, or


### PR DESCRIPTION
- Long filenames are problematic on Windows. This hashes long filenames to avoid build failures on Windows
- SYCL-BLAS is not prepared to generate a DLL because all symbols must be resolved at link time, so force the library to be linked statically on Windows
- Minor C++ fixes to make the code compatible with MSVC
- Update the ComputeCpp-SDK submodule to get some flags required to build sycl code on Windows