### PR TITLE
Remove duplicate configs in auto_tuner python script

### DIFF
--- a/tools/auto_tuner/gen/generate_combinations.py
+++ b/tools/auto_tuner/gen/generate_combinations.py
@@ -291,7 +291,8 @@ def get_gemm_configs_from_json(json_file):
         gemm_configs += [
             NaiveGemm(cache_size=cls) for cls in r["cache_line_size"]
         ]
-    return gemm_configs
+    #Remove duplicates from the configs by converting to dictionary then back to list
+    return list(dict.fromkeys(gemm_configs))
 
 
 def write_output_definition_file(config_list, config_source, output_file):


### PR DESCRIPTION
This PR removes duplicate configurations generated from the target device .json files in the auto tuner. This was causing issues with cross compilation with linaro toolchains as CMake seems to generate invalid build commands for duplicate configs, although host compilers seem able to handle it.

This could be handled by very careful construction of the json parameters to avoid duplicates but it seems sensible to catch this in the generator script when we can do this in a very simple way.