### PR TITLE
Adds Resnet50 ARM Configs, minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Some of the supported options are:
 | `BLAS_ENABLE_STATIC_LIBRARY` | `ON`/`OFF` | Build as a static library (`OFF` by default) |
 | `ENABLE_EXPRESSION_TESTS` | `ON`/`OFF` | Build additional tests that use the header-only framework (e.g to test expression trees); `OFF` by default |
 | `BLAS_VERIFY_BENCHMARK` | `ON`/`OFF` | Verify the results of the benchmarks instead of only measuring the performance. See the documentation of the benchmarks for more details. `ON` by default |
-| `MODEL` | name | Pass a model name here to use optimized GEMM configurations for specific convolution models/sizes. Currently this only affects the `ARM_GPU` platform. The supported models are: `RESNET_50`, `VGG_16` |
+| `BLAS_MODEL_OPTIMIZATION` | name | Pass a model name here to use optimized GEMM configurations for specific convolution models/sizes. Currently this only affects the `ARM_GPU` platform. The supported models are: `RESNET_50`, `VGG_16` |
 
 
 ### Cross-Compile

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Some of the supported options are:
 | `BLAS_ENABLE_STATIC_LIBRARY` | `ON`/`OFF` | Build as a static library (`OFF` by default) |
 | `ENABLE_EXPRESSION_TESTS` | `ON`/`OFF` | Build additional tests that use the header-only framework (e.g to test expression trees); `OFF` by default |
 | `BLAS_VERIFY_BENCHMARK` | `ON`/`OFF` | Verify the results of the benchmarks instead of only measuring the performance. See the documentation of the benchmarks for more details. `ON` by default |
+| `MODEL` | name | Pass a model name here to use optimized GEMM configurations for specific convolution models/sizes. Currently this only affects the `ARM_GPU` platform. The supported models are: `RESNET_50`, `VGG_16` |
 
 
 ### Cross-Compile

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -68,7 +68,12 @@ function(set_target_compile_def in_target)
     message(STATUS "Gemm vectorization support enabled for target ${in_target}")
     target_compile_definitions(${in_target} PUBLIC GEMM_VECTORIZATION_SUPPORT=1)
   endif()
-
+  #Set optimized model configs
+  if(${MODEL} STREQUAL "RESNET_50")
+    target_compile_definitions(${in_target} PUBLIC MODEL_RESNET_50=1)
+  elseif(${MODEL} STREQUAL "VGG_16")
+    target_compile_definitions(${in_target} PUBLIC MODEL_VGG_16=1)
+  endif()
 endfunction()
 
 
@@ -424,6 +429,41 @@ elseif(${TARGET} STREQUAL "ARM_GPU")
     "float"
   )
   foreach(data ${supported_types})
+  if(${MODEL} STREQUAL "RESNET_50")
+  add_gemm_configuration(
+    "${data}" 64 "false" "false" "false"
+    64 4 4 8 8 1 1 1 1 "no_local" "standard" "full" 4 "strided")
+  add_gemm_configuration(
+    "${data}" 32 "false" "false" "false"
+    64 8 4 4 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+  add_gemm_configuration(
+    "${data}" 32 "false" "false" "false"
+    64 4 8 8 4 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+  add_gemm_configuration(
+    "${data}" 64 "false" "false" "false"
+    64 4 4 8 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+    add_gemm_configuration(
+    "${data}" 32 "false" "false" "false"
+    64 8 4 4 8 1 1 1 1 "no_local" "standard" "partial" 1 "strided")
+    add_gemm_configuration(
+    "${data}" 32 "false" "false" "false"
+    64 8 4 4 8 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
+    add_gemm_configuration(
+    "${data}" 16 "false" "false" "false"
+    64 4 4 4 4 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+    add_gemm_configuration(
+    "${data}" 16 "false" "false" "false"
+    64 4 4 4 4 1 1 1 1 "no_local" "standard" "partial" 1 "strided")
+  add_gemm_configuration(
+    "${data}" 64 "false" "false" "false"
+    64 4 4 8 8 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
+  add_gemm_configuration(
+    "${data}" 128 "false" "false" "false"
+    64 4 8 16 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+  add_gemm_configuration(
+    "${data}" 16 "false" "false" "false"
+    64 4 4 4 4 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
+  elseif(${MODEL} STREQUAL "VGG_16")
     add_gemm_configuration(
       "${data}" 64 "false" "false" "false"
       64 4 4 8 8 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
@@ -433,10 +473,21 @@ elseif(${TARGET} STREQUAL "ARM_GPU")
     add_gemm_configuration(
       "${data}" 64 "false" "false" "false"
       64 4 4 4 4 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
+      else()
+      add_gemm_configuration(
+        "${data}" 64 "false" "false" "false"
+        64 4 4 8 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+        add_gemm_configuration(
+          "${data}" 128 "false" "false" "false"
+          64 4 8 16 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+          add_gemm_configuration(
+            "${data}" 32 "false" "false" "false"
+            64 8 4 4 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+    endif()
     add_gemm_configuration(
       "${data}" 64 "false" "false" "false"
-      64 2 2 4 4 1 1 4 4 "no_local" "standard" "full" 4 "interleaved")
-  endforeach()
+      64 2 2 4 4 1 1 4 4 "no_local" "standard" "full" 2 "interleaved")
+endforeach()
 elseif(${TARGET} STREQUAL "POWER_VR")
   set(supported_types
     "float"

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -69,9 +69,9 @@ function(set_target_compile_def in_target)
     target_compile_definitions(${in_target} PUBLIC GEMM_VECTORIZATION_SUPPORT=1)
   endif()
   #Set optimized model configs
-  if(${MODEL} STREQUAL "RESNET_50")
+  if(${BLAS_MODEL_OPTIMIZATION} STREQUAL "RESNET_50")
     target_compile_definitions(${in_target} PUBLIC MODEL_RESNET_50=1)
-  elseif(${MODEL} STREQUAL "VGG_16")
+  elseif(${BLAS_MODEL_OPTIMIZATION} STREQUAL "VGG_16")
     target_compile_definitions(${in_target} PUBLIC MODEL_VGG_16=1)
   endif()
 endfunction()
@@ -429,65 +429,65 @@ elseif(${TARGET} STREQUAL "ARM_GPU")
     "float"
   )
   foreach(data ${supported_types})
-  if(${MODEL} STREQUAL "RESNET_50")
-  add_gemm_configuration(
-    "${data}" 64 "false" "false" "false"
-    64 4 4 8 8 1 1 1 1 "no_local" "standard" "full" 4 "strided")
-  add_gemm_configuration(
-    "${data}" 32 "false" "false" "false"
-    64 8 4 4 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
-  add_gemm_configuration(
-    "${data}" 32 "false" "false" "false"
-    64 4 8 8 4 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
-  add_gemm_configuration(
-    "${data}" 64 "false" "false" "false"
-    64 4 4 8 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
-    add_gemm_configuration(
-    "${data}" 32 "false" "false" "false"
-    64 8 4 4 8 1 1 1 1 "no_local" "standard" "partial" 1 "strided")
-    add_gemm_configuration(
-    "${data}" 32 "false" "false" "false"
-    64 8 4 4 8 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
-    add_gemm_configuration(
-    "${data}" 16 "false" "false" "false"
-    64 4 4 4 4 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
-    add_gemm_configuration(
-    "${data}" 16 "false" "false" "false"
-    64 4 4 4 4 1 1 1 1 "no_local" "standard" "partial" 1 "strided")
-  add_gemm_configuration(
-    "${data}" 64 "false" "false" "false"
-    64 4 4 8 8 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
-  add_gemm_configuration(
-    "${data}" 128 "false" "false" "false"
-    64 4 8 16 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
-  add_gemm_configuration(
-    "${data}" 16 "false" "false" "false"
-    64 4 4 4 4 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
-  elseif(${MODEL} STREQUAL "VGG_16")
-    add_gemm_configuration(
-      "${data}" 64 "false" "false" "false"
-      64 4 4 8 8 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
-    add_gemm_configuration(
-      "${data}" 128 "false" "false" "false"
-      64 4 8 16 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
-    add_gemm_configuration(
-      "${data}" 64 "false" "false" "false"
-      64 4 4 4 4 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
-      else()
+    if(${BLAS_MODEL_OPTIMIZATION} STREQUAL "RESNET_50")
+      add_gemm_configuration(
+        "${data}" 64 "false" "false" "false"
+        64 4 4 8 8 1 1 1 1 "no_local" "standard" "full" 4 "strided")
+      add_gemm_configuration(
+        "${data}" 32 "false" "false" "false"
+        64 8 4 4 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+      add_gemm_configuration(
+        "${data}" 32 "false" "false" "false"
+        64 4 8 8 4 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
       add_gemm_configuration(
         "${data}" 64 "false" "false" "false"
         64 4 4 8 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
-        add_gemm_configuration(
-          "${data}" 128 "false" "false" "false"
-          64 4 8 16 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
-          add_gemm_configuration(
-            "${data}" 32 "false" "false" "false"
-            64 8 4 4 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+      add_gemm_configuration(
+        "${data}" 32 "false" "false" "false"
+        64 8 4 4 8 1 1 1 1 "no_local" "standard" "partial" 1 "strided")
+      add_gemm_configuration(
+        "${data}" 32 "false" "false" "false"
+        64 8 4 4 8 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
+      add_gemm_configuration(
+        "${data}" 16 "false" "false" "false"
+        64 4 4 4 4 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+      add_gemm_configuration(
+        "${data}" 16 "false" "false" "false"
+        64 4 4 4 4 1 1 1 1 "no_local" "standard" "partial" 1 "strided")
+      add_gemm_configuration(
+        "${data}" 64 "false" "false" "false"
+        64 4 4 8 8 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
+      add_gemm_configuration(
+        "${data}" 128 "false" "false" "false"
+        64 4 8 16 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+      add_gemm_configuration(
+        "${data}" 16 "false" "false" "false"
+        64 4 4 4 4 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
+    elseif(${BLAS_MODEL_OPTIMIZATION} STREQUAL "VGG_16")
+      add_gemm_configuration(
+        "${data}" 64 "false" "false" "false"
+        64 4 4 8 8 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
+      add_gemm_configuration(
+        "${data}" 128 "false" "false" "false"
+        64 4 8 16 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+      add_gemm_configuration(
+        "${data}" 64 "false" "false" "false"
+        64 4 4 4 4 1 1 1 1 "no_local" "standard" "partial" 2 "strided")
+    else()
+      add_gemm_configuration(
+        "${data}" 64 "false" "false" "false"
+        64 4 4 8 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+      add_gemm_configuration(
+        "${data}" 128 "false" "false" "false"
+        64 4 8 16 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
+      add_gemm_configuration(
+        "${data}" 32 "false" "false" "false"
+        64 8 4 4 8 1 1 1 1 "no_local" "standard" "partial" 4 "strided")
     endif()
     add_gemm_configuration(
       "${data}" 64 "false" "false" "false"
       64 2 2 4 4 1 1 4 4 "no_local" "standard" "full" 2 "interleaved")
-endforeach()
+  endforeach()
 elseif(${TARGET} STREQUAL "POWER_VR")
   set(supported_types
     "float"

--- a/cmake/Modules/ConfigureSYCLBLAS.cmake
+++ b/cmake/Modules/ConfigureSYCLBLAS.cmake
@@ -59,3 +59,7 @@ endif()
 SET(TARGET "DEFAULT_CPU" CACHE STRING "Default Platform 'DEFAULT_CPU'")
 SET(BACKEND_DEVICE ${TARGET})
 message(STATUS "${TARGET} is chosen as a backend platform")
+
+# the MODEL variable defines for which model optimized configs should
+# be enabled for. Currently only affects ARM_GPU configs.
+SET(MODEL "DEFAULT" CACHE STRING "Default Model 'DEFAULT'")

--- a/cmake/Modules/ConfigureSYCLBLAS.cmake
+++ b/cmake/Modules/ConfigureSYCLBLAS.cmake
@@ -60,6 +60,6 @@ SET(TARGET "DEFAULT_CPU" CACHE STRING "Default Platform 'DEFAULT_CPU'")
 SET(BACKEND_DEVICE ${TARGET})
 message(STATUS "${TARGET} is chosen as a backend platform")
 
-# the MODEL variable defines for which model optimized configs should
+# the BLAS_MODEL_OPTIMIZATION variable defines for which model optimized configs should
 # be enabled for. Currently only affects ARM_GPU configs.
-SET(MODEL "DEFAULT" CACHE STRING "Default Model 'DEFAULT'")
+SET(BLAS_MODEL_OPTIMIZATION "DEFAULT" CACHE STRING "Default Model 'DEFAULT'")

--- a/src/interface/blas3/backend/arm_gpu.hpp
+++ b/src/interface/blas3/backend/arm_gpu.hpp
@@ -42,7 +42,7 @@ typename executor_t::policy_t::event_t _gemm(
         64, false, false, false, 64, Tile<2, 2, 4, 4, 1, 1, 4, 4>, _t_a, _t_b,
         static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
-        static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
+        static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 2,
         static_cast<int>(
             gemm_batch_type_t::interleaved)>::template _select_gemm(ex, _M, _N,
                                                                     _K, _alpha,
@@ -52,6 +52,297 @@ typename executor_t::policy_t::event_t _gemm(
                                                                     _ldc,
                                                                     batch_size);
   } else {
+#if defined MODEL_RESNET_50
+    if (batch_size == 36 && _M == 128 && _K == 128 && _N == 784) {
+      if (!_t_b) {
+        return blas::Gemm_Launcher<
+            64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b,
+            static_cast<int>(gemm_memory_t::no_local),
+            static_cast<int>(gemm_algorithm_t::standard),
+            static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 2,
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                    _K, _alpha,
+                                                                    _a, _lda,
+                                                                    _b, _ldb,
+                                                                    _beta, _c,
+                                                                    _ldc,
+                                                                    batch_size);
+      } else {
+        return blas::Gemm_Launcher<
+            32, false, false, false, 64, Tile<4, 8, 8, 4>, _t_a, _t_b,
+            static_cast<int>(gemm_memory_t::no_local),
+            static_cast<int>(gemm_algorithm_t::standard),
+            static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                    _K, _alpha,
+                                                                    _a, _lda,
+                                                                    _b, _ldb,
+                                                                    _beta, _c,
+                                                                    _ldc,
+                                                                    batch_size);
+      }
+    } else if (batch_size == 36 && _M == 128 && _K == 128 && _N == 49) {
+      if (!_t_b) {
+        return blas::Gemm_Launcher<
+            32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b,
+            static_cast<int>(gemm_memory_t::no_local),
+            static_cast<int>(gemm_algorithm_t::standard),
+            static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                    _K, _alpha,
+                                                                    _a, _lda,
+                                                                    _b, _ldb,
+                                                                    _beta, _c,
+                                                                    _ldc,
+                                                                    batch_size);
+      } else {
+        return blas::Gemm_Launcher<
+            32, false, false, false, 64, Tile<4, 8, 8, 4>, _t_a, _t_b,
+            static_cast<int>(gemm_memory_t::no_local),
+            static_cast<int>(gemm_algorithm_t::standard),
+            static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                    _K, _alpha,
+                                                                    _a, _lda,
+                                                                    _b, _ldb,
+                                                                    _beta, _c,
+                                                                    _ldc,
+                                                                    batch_size);
+      }
+    } else if (batch_size == 36 && _M == 64 && _K == 64 && _N == 196) {
+      if (!_t_b) {
+        return blas::Gemm_Launcher<
+            64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b,
+            static_cast<int>(gemm_memory_t::no_local),
+            static_cast<int>(gemm_algorithm_t::standard),
+            static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                    _K, _alpha,
+                                                                    _a, _lda,
+                                                                    _b, _ldb,
+                                                                    _beta, _c,
+                                                                    _ldc,
+                                                                    batch_size);
+      } else {
+        return blas::Gemm_Launcher<
+            32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b,
+            static_cast<int>(gemm_memory_t::no_local),
+            static_cast<int>(gemm_algorithm_t::standard),
+            static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 1,
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                    _K, _alpha,
+                                                                    _a, _lda,
+                                                                    _b, _ldb,
+                                                                    _beta, _c,
+                                                                    _ldc,
+                                                                    batch_size);
+      }
+    } else if (batch_size == 16 && _M == 256 && _K == 256 && _N == 49) {
+      if (!_t_b) {
+        return blas::Gemm_Launcher<
+            16, false, false, false, 64, Tile<4, 4, 4, 4>, _t_a, _t_b,
+            static_cast<int>(gemm_memory_t::no_local),
+            static_cast<int>(gemm_algorithm_t::standard),
+            static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 1,
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                    _K, _alpha,
+                                                                    _a, _lda,
+                                                                    _b, _ldb,
+                                                                    _beta, _c,
+                                                                    _ldc,
+                                                                    batch_size);
+      } else {
+        return blas::Gemm_Launcher<
+            16, false, false, false, 64, Tile<4, 4, 4, 4>, _t_a, _t_b,
+            static_cast<int>(gemm_memory_t::no_local),
+            static_cast<int>(gemm_algorithm_t::standard),
+            static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                    _K, _alpha,
+                                                                    _a, _lda,
+                                                                    _b, _ldb,
+                                                                    _beta, _c,
+                                                                    _ldc,
+                                                                    batch_size);
+      }
+    }
+    /* Tends to perform well for Winograd sizes (i.e. batched) */
+    else if (batch_size > 1 && !_t_a) {
+      return blas::Gemm_Launcher<
+          64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 2,
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                  _K, _alpha,
+                                                                  _a, _lda, _b,
+                                                                  _ldb, _beta,
+                                                                  _c, _ldc,
+                                                                  batch_size);
+    } else if ((_M == 64 && _K == 576 && _N == 12544)) {
+      return blas::Gemm_Launcher<
+          64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                  _K, _alpha,
+                                                                  _a, _lda, _b,
+                                                                  _ldb, _beta,
+                                                                  _c, _ldc,
+                                                                  batch_size);
+    } else if ((_M == 1024 && _K == 512 && _N == 3136) ||
+               (_M == 256 && _K == 2304 && _N == 784)) {
+      return blas::Gemm_Launcher<
+          32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                  _K, _alpha,
+                                                                  _a, _lda, _b,
+                                                                  _ldb, _beta,
+                                                                  _c, _ldc,
+                                                                  batch_size);
+    } else if ((_M == 2048 && _K == 1024 && _N == 784) ||
+               (_M == 512 && _K == 1024 && _N == 784) ||
+               (_M == 2048 && _K == 512 && _N == 784)) {
+      return blas::Gemm_Launcher<
+          32, false, false, false, 64, Tile<4, 8, 8, 4>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                  _K, _alpha,
+                                                                  _a, _lda, _b,
+                                                                  _ldb, _beta,
+                                                                  _c, _ldc,
+                                                                  batch_size);
+    } else if ((_M == 512 && _K == 2048 && _N == 784)) {
+      return blas::Gemm_Launcher<
+          64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                  _K, _alpha,
+                                                                  _a, _lda, _b,
+                                                                  _ldb, _beta,
+                                                                  _c, _ldc,
+                                                                  batch_size);
+    } else if ((_M == 64 && _K == 576 && _N == 784) ||
+               (_M == 2048 && _K == 512 && _N == 49)) {
+      return blas::Gemm_Launcher<
+          16, false, false, false, 64, Tile<4, 4, 4, 4>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                  _K, _alpha,
+                                                                  _a, _lda, _b,
+                                                                  _ldb, _beta,
+                                                                  _c, _ldc,
+                                                                  batch_size);
+    } else if ((_M == 512 && _K == 256 && _N == 784) ||
+               (_M == 512 && _K == 128 && _N == 196) ||
+               (_M == 512 && _K == 2048 && _N == 49)) {
+      return blas::Gemm_Launcher<
+          32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 1,
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                  _K, _alpha,
+                                                                  _a, _lda, _b,
+                                                                  _ldb, _beta,
+                                                                  _c, _ldc,
+                                                                  batch_size);
+    } else if ((_M == 256 && _K == 512 && _N == 196) ||
+               (_M == 512 && _K == 4608 && _N == 49)) {
+      return blas::Gemm_Launcher<
+          64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 2,
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                  _K, _alpha,
+                                                                  _a, _lda, _b,
+                                                                  _ldb, _beta,
+                                                                  _c, _ldc,
+                                                                  batch_size);
+    } else if ((_M == 1024 && _K == 256 && _N == 49) ||
+               (_M == 2048 && _K == 1024 && _N == 49)) {
+      return blas::Gemm_Launcher<
+          32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 2,
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                  _K, _alpha,
+                                                                  _a, _lda, _b,
+                                                                  _ldb, _beta,
+                                                                  _c, _ldc,
+                                                                  batch_size);
+    } else if ((_M == 512 && _K == 4608 && _N == 49)) {
+      return blas::Gemm_Launcher<
+          16, false, false, false, 64, Tile<4, 4, 4, 4>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 2,
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                  _K, _alpha,
+                                                                  _a, _lda, _b,
+                                                                  _ldb, _beta,
+                                                                  _c, _ldc,
+                                                                  batch_size);
+    } else if (!_t_a) {
+      /* Does well on most im2col or 1x1 convolutions, or is within 10% of
+       * best kernel. */
+      return blas::Gemm_Launcher<
+          32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                  _K, _alpha,
+                                                                  _a, _lda, _b,
+                                                                  _ldb, _beta,
+                                                                  _c, _ldc,
+                                                                  batch_size);
+    } else {
+      return blas::Gemm_Launcher<
+          128, false, false, false, 64, Tile<4, 8, 16, 8>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::template _select_gemm(ex, _M, _N,
+                                                                  _K, _alpha,
+                                                                  _a, _lda, _b,
+                                                                  _ldb, _beta,
+                                                                  _c, _ldc,
+                                                                  batch_size);
+    }
+#elif defined MODEL_VGG_16
     /* Tends to perform well for Winograd sizes (i.e. batched) */
     if (batch_size > 1 && !_t_a) {
       return blas::Gemm_Launcher<
@@ -95,6 +386,33 @@ typename executor_t::policy_t::event_t _gemm(
                                                                   _c, _ldc,
                                                                   batch_size);
     }
+#else
+    if (_M == 512 && _N == 49 && _K == 512) {
+      return blas::Gemm_Launcher<
+          64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero,
+          4>::template _select_gemm(ex, _M, _N, _K, _alpha, _a, _lda, _b, _ldb,
+                                    _beta, _c, _ldc, batch_size);
+    } else if (_t_a) {
+      return blas::Gemm_Launcher<
+          128, false, false, false, 64, Tile<4, 8, 16, 8>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero,
+          4>::template _select_gemm(ex, _M, _N, _K, _alpha, _a, _lda, _b, _ldb,
+                                    _beta, _c, _ldc, batch_size);
+    } else {
+      return blas::Gemm_Launcher<
+          32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b,
+          static_cast<int>(gemm_memory_t::no_local),
+          static_cast<int>(gemm_algorithm_t::standard),
+          static_cast<int>(gemm_vectorization_t::partial), is_beta_zero,
+          4>::template _select_gemm(ex, _M, _N, _K, _alpha, _a, _lda, _b, _ldb,
+                                    _beta, _c, _ldc, batch_size);
+    }
+#endif
   }
 }
 }  // namespace backend

--- a/src/interface/blas3/backend/backend.hpp
+++ b/src/interface/blas3/backend/backend.hpp
@@ -22,15 +22,15 @@
  *  @filename backend.hpp
  *
  **************************************************************************/
-#if RCAR
+#ifdef RCAR
 #include "interface/blas3/backend/rcar.hpp"
-#elif INTEL_GPU
+#elif defined INTEL_GPU
 #include "interface/blas3/backend/intel_gpu.hpp"
-#elif AMD_GPU
+#elif defined AMD_GPU
 #include "interface/blas3/backend/amd_gpu.hpp"
-#elif ARM_GPU
+#elif defined ARM_GPU
 #include "interface/blas3/backend/arm_gpu.hpp"
-#elif POWER_VR
+#elif defined POWER_VR
 #include "interface/blas3/backend/power_vr.hpp"
 #else
 #include "interface/blas3/backend/default_cpu.hpp"


### PR DESCRIPTION
This PR includes optimised configurations for Resnet50 Convolution/GEMM sizes on the ARM GPU backend and includes a few changes to facilitate this without potentially harming performance of other sizes:
* A new CMake variable has been added and documented, ```BLAS_MODEL_OPTIMIZATION``` which allows selecting different sets of configurations for the ARM backend. When not set these will default to configurations from commit ```d2b0b263d372139cb488f0799e384b67298b53cd``` which is the commit currently used by SYCL-DNN. Passing ```VGG_16``` uses the current ARM configurations which were optimised for those sizes and passing ```RESNET_50``` selects the new configurations. Setting this has no effect on other backends currently.
* Fixed an issue with the auto tuner python generator in that it didn't properly respect the rules around vector size of the partial and fully vectorised no local GEMM kernels.

Some formatting was applied to the auto tuner's python generator file creating some noise in the PR but was probably needed.