### PR TITLE
Call quantized_copy_to_host in benchmarks

### DIFF
--- a/benchmark/syclblas/blas1/asum.cpp
+++ b/benchmark/syclblas/blas1/asum.cpp
@@ -59,7 +59,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   data_t vr_temp = 0;
   {
     auto vr_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, vr_temp);
-    auto event = _asum(ex, size, inx, 1, vr_temp_gpu);
+    _asum(ex, size, inx, 1, vr_temp_gpu);
+    auto event =
+        utils::quantized_copy_to_host<scalar_t>(ex, vr_temp_gpu, vr_temp);
     ex.get_policy_handler().wait(event);
   }
 

--- a/benchmark/syclblas/blas1/axpy.cpp
+++ b/benchmark/syclblas/blas1/axpy.cpp
@@ -62,7 +62,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   std::vector<data_t> y_temp = v2;
   {
     auto y_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, y_temp);
-    auto event = _axpy(ex, size, alpha, inx, 1, y_temp_gpu, 1);
+    _axpy(ex, size, alpha, inx, 1, y_temp_gpu, 1);
+    auto event =
+        utils::quantized_copy_to_host<scalar_t>(ex, y_temp_gpu, y_temp);
     ex.get_policy_handler().wait(event);
   }
 

--- a/benchmark/syclblas/blas1/dot.cpp
+++ b/benchmark/syclblas/blas1/dot.cpp
@@ -60,7 +60,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   data_t vr_temp = 0;
   {
     auto vr_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, vr_temp);
-    auto event = _dot(ex, size, inx, 1, iny, 1, vr_temp_gpu);
+    _dot(ex, size, inx, 1, iny, 1, vr_temp_gpu);
+    auto event =
+        utils::quantized_copy_to_host<scalar_t>(ex, vr_temp_gpu, vr_temp);
     ex.get_policy_handler().wait(event);
   }
 

--- a/benchmark/syclblas/blas1/iamax.cpp
+++ b/benchmark/syclblas/blas1/iamax.cpp
@@ -45,21 +45,20 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   ExecutorType& ex = *executorPtr;
 
   using data_t = utils::data_storage_t<scalar_t>;
+  using tuple_scalar_t = blas::IndexValueTuple<index_t, scalar_t>;
 
   // Create data
   std::vector<data_t> v1 = blas_benchmark::utils::random_data<data_t>(size);
-  blas::IndexValueTuple<index_t, scalar_t> out(-1, 0);
+  tuple_scalar_t out{-1, 0};
 
   auto inx = utils::make_quantized_buffer<scalar_t>(ex, v1);
-  auto outI =
-      blas::make_sycl_iterator_buffer<blas::IndexValueTuple<index_t, scalar_t>>(
-          &out, 1);
+  auto outI = blas::make_sycl_iterator_buffer<tuple_scalar_t>(&out, 1);
 
 #ifdef BLAS_VERIFY_BENCHMARK
   // Run a first time with a verification of the results
   index_t idx_ref =
       static_cast<index_t>(reference_blas::iamax(size, v1.data(), 1));
-  blas::IndexValueTuple<index_t, scalar_t> idx_temp(-1, 0);
+  tuple_scalar_t idx_temp{-1, 0};
   {
     auto idx_temp_gpu =
         blas::make_sycl_iterator_buffer<blas::IndexValueTuple<int, scalar_t>>(

--- a/benchmark/syclblas/blas1/iamin.cpp
+++ b/benchmark/syclblas/blas1/iamin.cpp
@@ -45,21 +45,20 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   ExecutorType& ex = *executorPtr;
 
   using data_t = utils::data_storage_t<scalar_t>;
+  using tuple_scalar_t = blas::IndexValueTuple<index_t, scalar_t>;
 
   // Create data
   std::vector<data_t> v1 = blas_benchmark::utils::random_data<data_t>(size);
-  blas::IndexValueTuple<index_t, scalar_t> out(0, 0);
+  tuple_scalar_t out{0, 0};
 
   auto inx = utils::make_quantized_buffer<scalar_t>(ex, v1);
-  auto outI =
-      blas::make_sycl_iterator_buffer<blas::IndexValueTuple<index_t, scalar_t>>(
-          &out, 1);
+  auto outI = blas::make_sycl_iterator_buffer<tuple_scalar_t>(&out, 1);
 
 #ifdef BLAS_VERIFY_BENCHMARK
   // Run a first time with a verification of the results
   index_t idx_ref =
       static_cast<index_t>(reference_blas::iamin(size, v1.data(), 1));
-  blas::IndexValueTuple<index_t, scalar_t> idx_temp(-1, -1);
+  tuple_scalar_t idx_temp{-1, -1};
   {
     auto idx_temp_gpu =
         blas::make_sycl_iterator_buffer<blas::IndexValueTuple<int, scalar_t>>(

--- a/benchmark/syclblas/blas1/nrm2.cpp
+++ b/benchmark/syclblas/blas1/nrm2.cpp
@@ -58,7 +58,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   data_t vr_temp = 0;
   {
     auto vr_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, vr_temp);
-    auto event = _nrm2(ex, size, inx, 1, vr_temp_gpu);
+    _nrm2(ex, size, inx, 1, vr_temp_gpu);
+    auto event =
+        utils::quantized_copy_to_host<scalar_t>(ex, vr_temp_gpu, vr_temp);
     ex.get_policy_handler().wait(event);
   }
 

--- a/benchmark/syclblas/blas1/scal.cpp
+++ b/benchmark/syclblas/blas1/scal.cpp
@@ -59,7 +59,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   std::vector<data_t> v1_temp = v1;
   {
     auto v1_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, v1_temp);
-    auto event = _scal(ex, size, alpha, v1_temp_gpu, 1);
+    _scal(ex, size, alpha, v1_temp_gpu, 1);
+    auto event =
+        utils::quantized_copy_to_host<scalar_t>(ex, v1_temp_gpu, v1_temp);
     ex.get_policy_handler().wait(event);
   }
 

--- a/benchmark/syclblas/blas2/gemv.cpp
+++ b/benchmark/syclblas/blas2/gemv.cpp
@@ -94,8 +94,10 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int ti, index_t m,
   std::vector<data_t> v_y_temp = v_y;
   {
     auto v_y_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, v_y_temp);
-    auto event = _gemv(ex, *t_str, m, n, alpha, m_a_gpu, m, v_x_gpu, incX, beta,
-                       v_y_temp_gpu, incY);
+    _gemv(ex, *t_str, m, n, alpha, m_a_gpu, m, v_x_gpu, incX, beta,
+          v_y_temp_gpu, incY);
+    auto event =
+        utils::quantized_copy_to_host<scalar_t>(ex, v_y_temp_gpu, v_y_temp);
     ex.get_policy_handler().wait();
   }
 

--- a/benchmark/syclblas/blas3/gemm.cpp
+++ b/benchmark/syclblas/blas3/gemm.cpp
@@ -71,8 +71,10 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
   std::vector<data_t> c_temp = c;
   {
     auto c_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, c_temp);
-    auto event = _gemm(ex, *t_a, *t_b, m, n, k, alpha, a_gpu, lda, b_gpu, ldb,
-                       beta, c_temp_gpu, ldc);
+    _gemm(ex, *t_a, *t_b, m, n, k, alpha, a_gpu, lda, b_gpu, ldb, beta,
+          c_temp_gpu, ldc);
+    auto event =
+        utils::quantized_copy_to_host<scalar_t>(ex, c_temp_gpu, c_temp);
     ex.get_policy_handler().wait(event);
   }
 

--- a/benchmark/syclblas/blas3/gemm_batched.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched.cpp
@@ -160,9 +160,10 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int t1, int t2,
   std::vector<data_t> c_temp = c;
   {
     auto c_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, c_temp);
+    _gemm_batched(ex, *t_a, *t_b, m, n, k, alpha, a_gpu, lda, b_gpu, ldb, beta,
+                  c_temp_gpu, ldc, batch_size, batch_type);
     auto event =
-        _gemm_batched(ex, *t_a, *t_b, m, n, k, alpha, a_gpu, lda, b_gpu, ldb,
-                      beta, c_temp_gpu, ldc, batch_size, batch_type);
+        utils::quantized_copy_to_host<scalar_t>(ex, c_temp_gpu, c_temp);
     ex.get_policy_handler().wait(event);
   }
   if (batch_type == blas::gemm_batch_type_t::interleaved) {

--- a/benchmark/syclblas/expression/reduction_rows.cpp
+++ b/benchmark/syclblas/expression/reduction_rows.cpp
@@ -90,8 +90,10 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t rows,
   {
     auto vec_temp_buffer = utils::make_quantized_buffer<scalar_t>(ex, vec_temp);
     auto vec_temp_gpu = make_vector_view(ex, vec_temp_buffer, 1, rows);
-    auto event = launch_reduction<AddOperator, scalar_t>(
-        ex, mat_gpu, vec_temp_gpu, rows, cols);
+    launch_reduction<AddOperator, scalar_t>(ex, mat_gpu, vec_temp_gpu, rows,
+                                            cols);
+    auto event =
+        utils::quantized_copy_to_host<scalar_t>(ex, vec_temp_gpu, vec_temp);
     ex.get_policy_handler().wait(event);
   }
 

--- a/include/utils/quantization.hpp
+++ b/include/utils/quantization.hpp
@@ -250,6 +250,9 @@ struct QuantizedCopyToHost<double>
 /**
  * @brief Constructs a buffer containing data that was quantized
  *        from the provided input vector
+ *
+ * The vector will not be written back on buffer destruction.
+ *
  * @return Buffer containing quantized data
  * @note scalar_t cannot be deduced, it has to be provided
  */
@@ -263,6 +266,9 @@ auto make_quantized_buffer(executor_t& ex,
 /**
  * @brief Constructs a buffer containing data that was quantized
  *        from the provided input scalar
+ *
+ * The scalar will not be written back on buffer destruction.
+ *
  * @return Buffer containing quantized data
  * @note scalar_t cannot be deduced, it has to be provided
  */


### PR DESCRIPTION
The patch that quantized all tests and benchmarks (https://github.com/codeplaysoftware/sycl-blas/pull/252)
ignored the fact that `make_quantized_buffer`
cannot copy back to the original data.
This would only be possible with non-quantized types,
whereas for others it creates another buffer of a different type.

This patch addresses this by adding the missing copy-back to benchmarks.
It also adds a Doxygen note about data not being copied back.