### PR TITLE
Perform a wait when quantizing buffer

### DIFF
--- a/include/utils/quantization.hpp
+++ b/include/utils/quantization.hpp
@@ -105,7 +105,8 @@ struct MakeQuantizedBuffer {
     ex.get_policy_handler().copy_to_device(&input_scalar, data_gpu_x_v, 1);
     auto gpu_x_v =
         blas::make_sycl_iterator_buffer<scalar_t>(static_cast<int>(1));
-    blas::_quantize(ex, data_gpu_x_v, gpu_x_v);
+    auto event = blas::_quantize(ex, data_gpu_x_v, gpu_x_v);
+    ex.get_policy_handler().wait(event);
     return gpu_x_v;
   }
 };


### PR DESCRIPTION
When using special data types (like `cl::sycl::half`)
calling `make_quantized_buffer` doesn't set up all required data dependencies.
This causes tests and benchmarks to fail.

This patch introduces a wait within `make_quantized_buffer`,
but only for special data types (not `float` or `double`).