### PR TITLE
Fix clblast compilation on Windows

### DIFF
--- a/benchmark/clblast/clwrap.cpp
+++ b/benchmark/clblast/clwrap.cpp
@@ -26,6 +26,7 @@
 #include "clwrap.h"
 
 #include <algorithm>
+#include <memory>
 
 char *getCLErrorString(cl_int err) {
   switch (err) {

--- a/benchmark/clblast/clwrap.cpp
+++ b/benchmark/clblast/clwrap.cpp
@@ -209,8 +209,8 @@ OpenCLDeviceSelector::OpenCLDeviceSelector(std::string vendor,
                                            std::string type) {
   // Get the number of platforms, and a list of IDs
   cl_uint num_platforms = get_platform_count();
-  cl_platform_id platforms[num_platforms];
-  cl_int status = clGetPlatformIDs(num_platforms, platforms, NULL);
+  std::unique_ptr<cl_platform_id[]> platforms(new cl_platform_id[num_platforms]);
+  cl_int status = clGetPlatformIDs(num_platforms, platforms.get(), NULL);
   if (status != CL_SUCCESS) {
     do_error("failure in clGetPlatformIDs");
   }
@@ -223,9 +223,9 @@ OpenCLDeviceSelector::OpenCLDeviceSelector(std::string vendor,
 
     // Get devices, etc.
     cl_uint num_devices = get_device_count(platform);
-    cl_device_id devices[num_devices];
+    std::unique_ptr<cl_device_id[]> devices(new cl_device_id[num_devices]);
     cl_int status = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, num_devices,
-                                   devices, NULL);
+                                   devices.get(), NULL);
     if (status != CL_SUCCESS) {
       do_error("failure in clGetDeviceIDs");
     }

--- a/benchmark/clblast/utils.hpp
+++ b/benchmark/clblast/utils.hpp
@@ -20,8 +20,8 @@ static inline void print_device_information(cl_device_id device) {
   if (!device_name_length) {
     return;
   }
-  char device_name[device_name_length];
-  clGetDeviceInfo(device, CL_DEVICE_NAME, sizeof(device_name), device_name,
+  std::string device_name(device_name_length, '\0');
+  clGetDeviceInfo(device, CL_DEVICE_NAME, sizeof(device_name), &device_name[0],
                   nullptr);
   cl_device_type device_type;
   clGetDeviceInfo(device, CL_DEVICE_TYPE, sizeof(cl_device_type), &device_type,


### PR DESCRIPTION
Dynamic arrays are a non-standard C++ extension. This patch replaces two ocurrences of such arrays with standard C++11