### PR TITLE
[Quantize] Use get_count to schedule quantization

### DIFF
--- a/src/quantize/quantize.hpp
+++ b/src/quantize/quantize.hpp
@@ -82,7 +82,7 @@ struct Quantize {
           const auto kernel = QuantizeKernel<input_t, output_t>{
               quantized_input_acc_t<input_t>{input, cgh},
               quantized_output_acc_t<output_t>{output, cgh}};
-          cgh.parallel_for(cl::sycl::range<1>{input.get_size()}, kernel);
+          cgh.parallel_for(cl::sycl::range<1>{input.get_count()}, kernel);
         })};
   }
 };


### PR DESCRIPTION
When launching the quantization kernel,
the wrong number of work-items was specified to `parallel_for`,
leading to out of bounds memory access.
This didn't affect `float` and `double` types
because they don't need a quantization kernel.

The fix is to only schedule as many work-items
as there are data elements (using `get_count`).