### PR TITLE
Fix building benchmarks without validation

### DIFF
--- a/benchmark/common_utils.hpp
+++ b/benchmark/common_utils.hpp
@@ -19,9 +19,10 @@
 #include "benchmark_cli_args.hpp"
 #include "blas_meta.h"
 
+#include "utils/quantization.hpp"
+
 #ifdef BLAS_VERIFY_BENCHMARK
 #include "utils/float_comparison.hpp"
-#include "utils/quantization.hpp"
 #include "utils/system_reference_blas.hpp"
 #endif
 


### PR DESCRIPTION
The quantization header is used for data types in the benchmarks even
when validation is disabled.

cc @ProGTX 