### PR TITLE
Fix compilation of reduction_rows.cpp

### DIFF
--- a/benchmark/syclblas/expression/reduction_rows.cpp
+++ b/benchmark/syclblas/expression/reduction_rows.cpp
@@ -93,7 +93,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t rows,
     launch_reduction<AddOperator, scalar_t>(ex, mat_gpu, vec_temp_gpu, rows,
                                             cols);
     auto event =
-        utils::quantized_copy_to_host<scalar_t>(ex, vec_temp_gpu, vec_temp);
+        utils::quantized_copy_to_host<scalar_t>(ex, vec_temp_buffer, vec_temp);
     ex.get_policy_handler().wait(event);
   }
 

--- a/src/interface/blas3_interface.hpp
+++ b/src/interface/blas3_interface.hpp
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename blas3_interface.hpp
+ *
+ **************************************************************************/
+
+#ifndef SYCL_BLAS_BLAS3_INTERFACE_HPP
+#define SYCL_BLAS_BLAS3_INTERFACE_HPP
+
+#include "interface/gemm_interface.hpp"
+#include "interface/gemm_launcher.hpp"
+#include "interface/trsm_interface.hpp"
+
+#endif // SYCL_BLAS_BLAS2_INTERFACE_HPP

--- a/src/interface/blas3_interface.hpp
+++ b/src/interface/blas3_interface.hpp
@@ -30,4 +30,4 @@
 #include "interface/gemm_launcher.hpp"
 #include "interface/trsm_interface.hpp"
 
-#endif // SYCL_BLAS_BLAS2_INTERFACE_HPP
+#endif // SYCL_BLAS_BLAS3_INTERFACE_HPP


### PR DESCRIPTION
This benchmark is only enable if BUILD_EXPRESSION_BENCHMARKS=ON.

This fixes a compilation issue.