### PR TITLE
Fix ACL benchmark compilation failure

### DIFF
--- a/benchmark/acl/CMakeLists.txt
+++ b/benchmark/acl/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 function(generate_acl_benchmark name source definition)
   add_executable(${name} ${source} main.cpp)
-  target_link_libraries(${name} PRIVATE benchmark acl sycl_blas Clara::Clara)
+  target_link_libraries(${name} PRIVATE benchmark acl sycl_blas_common sycl_blas Clara::Clara)
   target_include_directories(${name} PRIVATE ${CBLAS_INCLUDE})
   target_compile_definitions(${name} PRIVATE ${definition})
 

--- a/benchmark/acl/utils.hpp
+++ b/benchmark/acl/utils.hpp
@@ -16,27 +16,23 @@
 #include <arm_compute/runtime/NEON/NEFunctions.h>
 #endif
 
-#include "common_utils.hpp"
+#include <common/common_utils.hpp>
 
 namespace blas_benchmark {
 
-void create_benchmark(blas_benchmark::Args &args, bool* success);
+void create_benchmark(blas_benchmark::Args &args, bool *success);
 
 namespace utils {
 
-template<typename Tensor>
-inline void map_if_needed(Tensor&) {}
+template <typename Tensor>
+inline void map_if_needed(Tensor &) {}
 
-template<typename Tensor>
-inline void unmap_if_needed(Tensor&) {}
+template <typename Tensor>
+inline void unmap_if_needed(Tensor &) {}
 
-inline void map_if_needed(arm_compute::CLTensor& tensor) {
-  tensor.map(true);
-}
+inline void map_if_needed(arm_compute::CLTensor &tensor) { tensor.map(true); }
 
-inline void unmap_if_needed(arm_compute::CLTensor& tensor) {
-  tensor.unmap();
-}
+inline void unmap_if_needed(arm_compute::CLTensor &tensor) { tensor.unmap(); }
 
 template <typename tensor_t>
 void fill_tensor(tensor_t &tensor, std::vector<float> &src) {
@@ -48,13 +44,13 @@ void fill_tensor(tensor_t &tensor, std::vector<float> &src) {
 
   arm_compute::Iterator it(&tensor, window);
 
-  arm_compute::execute_window_loop(window,
-                                   [&](const arm_compute::Coordinates &id) {
-                                     int idx = id[0] * shape[1] + id[1];
-                                     *reinterpret_cast<float *>(it.ptr()) =
-                                         src[idx];
-                                   },
-                                   it);
+  arm_compute::execute_window_loop(
+      window,
+      [&](const arm_compute::Coordinates &id) {
+        int idx = id[0] * shape[1] + id[1];
+        *reinterpret_cast<float *>(it.ptr()) = src[idx];
+      },
+      it);
 
   unmap_if_needed(tensor);
 }
@@ -69,12 +65,13 @@ void extract_tensor(tensor_t &tensor, std::vector<float> &dst) {
 
   arm_compute::Iterator it(&tensor, window);
 
-  arm_compute::execute_window_loop(window,
-                                   [&](const arm_compute::Coordinates &id) {
-                                     int idx = id[0] * shape[1] + id[1];
-                                     dst[idx] = *reinterpret_cast<float *>(it.ptr());
-                                   },
-                                   it);
+  arm_compute::execute_window_loop(
+      window,
+      [&](const arm_compute::Coordinates &id) {
+        int idx = id[0] * shape[1] + id[1];
+        dst[idx] = *reinterpret_cast<float *>(it.ptr());
+      },
+      it);
 
   unmap_if_needed(tensor);
 }


### PR DESCRIPTION
Fix ACL benchmark compilation failing after the refactor of the utilities into a common library. Links this target in CMake and modifies the include slightly.