### PR TITLE
Don't generate POWER_VR configs when IMGDNN is used.

### DIFF
--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -538,7 +538,7 @@ elseif(${TARGET} STREQUAL "ARM_GPU")
       "${data}" 64 "false" "false" "false"
       64 2 2 4 4 1 1 1 1 4 4 "no_local" "standard" "full" 2 "interleaved")
   endforeach()
-elseif(${TARGET} STREQUAL "POWER_VR")
+elseif(${TARGET} STREQUAL "POWER_VR" AND NOT IMGDNN_DIR)
   set(supported_types
     "float"
     "half"


### PR DESCRIPTION
Adds a check before generating configs for the `POWER_VR` target that checks if IMGDNN is being used. If it is, skip generating those configs as they are unused and unnecessarily increase compile times.