### PR TITLE
Add Dependabot to track Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
Adds a Dependabot configuration file to enable dependency tracking for Github Actions workflows. Checks daily for updates to actions used in the workflows.