### PR TITLE
Added flags for header only tests and fpga copy kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,11 @@ install(DIRECTORY ${SYCLBLAS_INCLUDE}/
 
 option(BLAS_ENABLE_TESTING "Whether to enable testing" ON)
 option(ENABLE_EXPRESSION_TESTS "Whether to build expression tree fusion tests" OFF)
+# Header-only tests
+option(BLAS_HEADER_ONLY_TESTING "Whether to use sycl-blas testing in header-only mode" OFF)
+if(BLAS_HEADER_ONLY_TESTING)
+  add_definitions(-DBLAS_HEADER_ONLY_TESTING)
+endif()
 
 if(${BLAS_ENABLE_TESTING})
   enable_testing()

--- a/cmake/Modules/ConfigureSYCLBLAS.cmake
+++ b/cmake/Modules/ConfigureSYCLBLAS.cmake
@@ -59,6 +59,13 @@ if(NAIVE_GEMM)
   add_definitions(-DNAIVE_GEMM)
 endif()
 
+# If the user has specified that we should use fpga optimizations/fixes, enable that
+option(SYCL_BLAS_FPGA "Using fpga optimizations/fixes" off)
+if(SYCL_BLAS_FPGA)
+  add_definitions(-DSYCL_BLAS_FPGA)
+endif()
+
+
 # the TARGET variable defines the platform for which the sycl library is built
 SET(TARGET "DEFAULT_CPU" CACHE STRING "Default Platform 'DEFAULT_CPU'")
 SET(BACKEND_DEVICE ${TARGET})

--- a/cmake/Modules/FindSyclBLAS.cmake
+++ b/cmake/Modules/FindSyclBLAS.cmake
@@ -1,0 +1,58 @@
+# Try to find the SyclBLAS library.
+#
+# If the library is found then the `SyclBLAS::SyclBLAS` target will be exported
+# with the required include directories.
+#
+# Sets the following variables:
+#   SyclBLAS_FOUND        - whether the system has SyclBLAS
+#   SyclBLAS_INCLUDE_DIRS - the SyclBLAS include directory
+
+find_path(SyclBLAS_INCLUDE_DIR
+  NAMES sycl_blas.h
+  PATH_SUFFIXES include
+  HINTS ${SyclBLAS_DIR}
+  DOC "The SyclBLAS include directory"
+)
+
+find_path(SyclBLAS_SRC_DIR
+  NAMES sycl_blas.hpp
+  PATH_SUFFIXES src
+  HINTS ${SyclBLAS_DIR}
+  DOC "The SyclBLAS source directory"
+)
+
+find_path(SyclBLAS_VPTR_INCLUDE_DIR
+  NAMES vptr/virtual_ptr.hpp
+  PATH_SUFFIXES external/computecpp-sdk/include
+  HINTS ${SyclBLAS_DIR}
+  DOC "The SyclBLAS virtual pointer include directory"
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SyclBLAS
+  FOUND_VAR SyclBLAS_FOUND
+  REQUIRED_VARS SyclBLAS_INCLUDE_DIR
+                SyclBLAS_SRC_DIR
+                SyclBLAS_VPTR_INCLUDE_DIR
+)
+
+mark_as_advanced(SyclBLAS_FOUND
+                 SyclBLAS_SRC_DIR
+                 SyclBLAS_VPTR_INCLUDE_DIR
+                 SyclBLAS_INCLUDE_DIR
+)
+
+if(SyclBLAS_FOUND)
+  set(SyclBLAS_INCLUDE_DIRS
+    ${SyclBLAS_INCLUDE_DIR}
+    ${SyclBLAS_SRC_DIR}
+    ${SyclBLAS_VPTR_INCLUDE_DIR}
+  )
+endif()
+
+if(SyclBLAS_FOUND AND NOT TARGET SyclBLAS::SyclBLAS)
+  add_library(SyclBLAS::SyclBLAS INTERFACE IMPORTED)
+  set_target_properties(SyclBLAS::SyclBLAS PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${SyclBLAS_INCLUDE_DIRS}"
+  )
+endif()

--- a/src/policy/sycl_policy_handler.hpp
+++ b/src/policy/sycl_policy_handler.hpp
@@ -27,6 +27,22 @@
 
 #include "policy/sycl_policy_handler.h"
 
+#ifdef SYCL_BLAS_FPGA
+template<typename Acc, typename Data_Acc>
+class Kernel_Copy{
+  public:
+    Kernel_Copy(Acc accessor, Data_Acc data_accessor)
+    : accessor(accessor)
+    , data_accessor(data_accessor){}
+    void operator() (cl::sycl::id<1> wiID){
+      accessor[wiID] = data_accessor[wiID];
+    }
+  private:
+    Acc accessor;
+    Data_Acc data_accessor;
+};
+#endif
+
 namespace blas {
 
 template <typename element_t>
@@ -140,6 +156,30 @@ PolicyHandler<codeplay_policy>::copy_to_device(const element_t *src,
   return copy_to_device(src, get_buffer(dst), size);
 }
 
+#ifdef SYCL_BLAS_FPGA
+/*  @brief Copying the data to device using a kernel
+  @tparam element_t is the type of the data
+  @param src is the host pointer we want to copy from.
+  @param dst is the BufferIterator we want to copy to.
+  @param size is the number of elements to be copied
+*/
+template <typename element_t>
+inline typename codeplay_policy::event_t
+PolicyHandler<codeplay_policy>::copy_to_device(
+    const element_t *src, BufferIterator<element_t, codeplay_policy> dst,
+    size_t size) {
+      cl::sycl::range<1> numOfItems{size};
+      cl::sycl::buffer<element_t,1> data_buf(src, numOfItems);
+      auto event = q_.submit([&](sycl::handler& cgh){
+        //Copy host to device
+        auto acc = blas::get_range_accessor<cl::sycl::access::mode::write>(dst, cgh, size);
+        auto data_acc = data_buf.template get_access<cl::sycl::access::mode::read>(cgh);
+        cgh.parallel_for(numOfItems, Kernel_Copy<decltype(acc), decltype(data_acc)>(acc, data_acc));
+      });
+      return {event};
+}
+#else
+
 /*  @brief Copying the data back to device
   @tparam element_t is the type of the data
   @param src is the host pointer we want to copy from.
@@ -158,6 +198,7 @@ PolicyHandler<codeplay_policy>::copy_to_device(
   });
   return {event};
 }
+#endif
 
 /*  @brief Copying the data back to device
     @tparam element_t is the type of the data

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -37,7 +37,11 @@
 
 #include <gtest/gtest.h>
 
+#ifdef BLAS_HEADER_ONLY_TESTING
+#include <sycl_blas.hpp>
+#else
 #include <sycl_blas.h>
+#endif
 
 #include <common/cli_device_selector.hpp>
 #include <common/float_comparison.hpp>

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -27,6 +27,11 @@ set(SYCLBLAS_UNITTEST ${CMAKE_CURRENT_SOURCE_DIR})
 
 include_directories(${SYCLBLAS_TEST} ${BLAS_INCLUDE_DIRS})
 
+if(${BLAS_HEADER_ONLY_TESTING})
+  set(SyclBLAS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+	  find_package(SyclBLAS REQUIRED)
+endif()
+
 # compiling tests
 set(SYCL_UNITTEST_SRCS
   # Blas 1 tests
@@ -73,8 +78,20 @@ foreach(blas_test ${SYCL_UNITTEST_SRCS})
   if(STRESS_TESTING)
     target_compile_definitions(${test_exec} PRIVATE STRESS_TESTING)
   endif()
+
+  if(${BLAS_HEADER_ONLY_TESTING})
+  add_sycl_to_target(
+    TARGET ${test_exec}
+    SOURCES ${blas_test}
+  )
+  target_link_libraries(${test_exec} PRIVATE gtest_main Clara::Clara blas::blas SyclBLAS::SyclBLAS)
+  target_include_directories(${test_exec} PRIVATE ${CBLAS_INCLUDE} ${SYCLBLAS_COMMON_INCLUDE_DIR})
+else()
   target_link_libraries(${test_exec} PRIVATE gtest_main Clara::Clara blas::blas sycl_blas)
   target_include_directories(${test_exec} PRIVATE ${CBLAS_INCLUDE} ${SYCLBLAS_COMMON_INCLUDE_DIR})
+endif()
+
+  
   if(TEST_DEVICE)
     add_test(NAME ${test_exec} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${test_exec} --device ${TEST_DEVICE})
   else()


### PR DESCRIPTION
Cmake files have been modified to include:
* BLAS_HEADER_ONLY_TESTING - allows test to be compiled with sycl-blas in header only mode ( to fix "programmed with different xclbin" error on fpga)
* SYCL_BLAS_FPGA - allows use of a ```copy_to_device()``` function which uses a kernel to copy data to the device (to handle the "xclbin not loaded error" on the fpga)