### PR TITLE
Only reference cl::sycl::half if BLAS_DATA_TYPE_HALF is set.

### DIFF
--- a/include/operations/blas_constants.h
+++ b/include/operations/blas_constants.h
@@ -210,6 +210,7 @@ struct constant<std::complex<value_t>, Indicator> {
   }
 };
 
+#ifdef BLAS_DATA_TYPE_HALF
 template <>
 struct constant<cl::sycl::half, const_val::zero>
     : constant<float, const_val::zero> {};
@@ -249,6 +250,7 @@ struct constant<cl::sycl::half, const_val::abs_min>
 template <>
 struct constant<cl::sycl::half, const_val::collapse>
     : constant<float, const_val::collapse> {};
+#endif // BLAS_DATA_TYPE_HALF
 
 template <typename iv_type, const_val IndexIndicator, const_val ValueIndicator>
 struct constant_pair {

--- a/src/operations/blas1_trees.hpp
+++ b/src/operations/blas1_trees.hpp
@@ -75,6 +75,7 @@ struct DetectScalar<double> {
   static element_t get_scalar(element_t &scalar) { return scalar; }
 };
 
+#ifdef BLAS_DATA_TYPE_HALF
 /*! DetectScalar.
  * @brief See Detect Scalar.
  */
@@ -83,6 +84,7 @@ struct DetectScalar<cl::sycl::half> {
   using element_t = cl::sycl::half;
   static element_t get_scalar(element_t &scalar) { return scalar; }
 };
+#endif // BLAS_DATA_TYPE_HALF
 
 /*! DetectScalar.
  * @brief See Detect Scalar.

--- a/src/operations/blas_operators.hpp
+++ b/src/operations/blas_operators.hpp
@@ -29,6 +29,7 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <type_traits>
 #include <vector>
 
 #include <CL/sycl.hpp>
@@ -109,10 +110,15 @@ struct AbsoluteValue {
   template <typename value_t>
   using stripped_t = typename StripASP<value_t>::type;
 
+#ifdef BLAS_DATA_TYPE_HALF
   template <typename value_t>
   using is_floating_point = std::integral_constant<
       bool, std::is_floating_point<stripped_t<value_t>>::value ||
                 std::is_same<stripped_t<value_t>, cl::sycl::half>::value>;
+#else 
+  template <typename value_t>
+  using is_floating_point = std::is_floating_point<value_t>;
+#endif // BLAS_DATA_TYPE_HALF
 
   template <typename value_t>
   static SYCL_BLAS_INLINE value_t eval(


### PR DESCRIPTION
During some experimentation trying to build sycl-blas with hipSYCL, which doesn't support half types, yet, I discovered that the usage of `cl::sycl::half` is not always correctly ifdef'd away.