### PR TITLE
Use sycl::vec default initialization instead of using 0 as argument.

### DIFF
--- a/src/operations/blas3/gemm_interleaved.hpp
+++ b/src/operations/blas3/gemm_interleaved.hpp
@@ -325,7 +325,7 @@ class Gemm<input_t, output_t, /* DoubleBuffer = */ false, /* NbcA = */ false,
     for (int i = 0; i < item_size; ++i) {
       auto in_range = boundary_check(i + index_start, dim_size);
       if (!in_range) {
-        *reg_res = packet_type{0};
+        *reg_res = packet_type{};
         input += stride;
         ++reg_res;
         continue;
@@ -467,7 +467,7 @@ class Gemm<input_t, output_t, /* DoubleBuffer = */ false, /* NbcA = */ false,
 #pragma unroll
     for (int i = 0; i < item_rows * item_cols * (item_batchs / VectorSize);
          ++i) {
-      reg_res[i] = packet_type(0);
+      reg_res[i] = packet_type{};
     }
   }
 

--- a/src/operations/blas3/gemm_load_store.hpp
+++ b/src/operations/blas3/gemm_load_store.hpp
@@ -83,7 +83,7 @@ struct Packetize {
   static SYCL_BLAS_INLINE typename std::enable_if<internal>::type load(
       const bool in_range, SrcPointerType src, DestPointerType dest,
       EdgePredicate edge_in_range) {
-    PacketType packet{0};
+    PacketType packet{};
 
     if (in_range) {
       using address_t = cl::sycl::access::address_space;

--- a/src/operations/blas3/gemm_local.hpp
+++ b/src/operations/blas3/gemm_local.hpp
@@ -472,7 +472,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType,
             typename OutputPointerType>
   SYCL_BLAS_INLINE typename std::enable_if<internal>::type store_packet(
       element_t *reg, OutputPointerType out_ptr) {
-    vector_t out_vec{0};
+    vector_t out_vec{};
 
     out_vec.template load<address_t::private_space>(
         0, cl::sycl::multi_ptr<const element_t, address_t::private_space>(reg));

--- a/src/operations/blas3/gemm_no_local_full_vec.hpp
+++ b/src/operations/blas3/gemm_no_local_full_vec.hpp
@@ -315,7 +315,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
       for (index_t j = 0; j < item_rows / packet_size; ++j) {
         if (do_check<need_check_boundary>(check_boundary(
                 dim_m_c_start + j * wg_rows, dim_n_c_start + i * wg_cols))) {
-          cl::sycl::vec<element_t, packet_size> out_vec{0};
+          cl::sycl::vec<element_t, packet_size> out_vec{};
 
           out_vec.template load<address_t::global_space>(
               0, cl::sycl::multi_ptr<const element_t, address_t::global_space>(
@@ -563,7 +563,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
         bool in_range = do_check<check_row>(is_valid_row(work_per_load - 1)) &&
                         do_check<check_col>(is_valid_col(i));
 
-        cl::sycl::vec<element_t, work_per_load> in_vec{0};
+        cl::sycl::vec<element_t, work_per_load> in_vec{};
         if (in_range) {
           // if in range perform a vectorised load
           in_vec.template load<address_t::global_space>(
@@ -638,7 +638,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
         bool in_range =
             do_check<check_row>(is_valid_row(i * next_element + j)) &&
             do_check<check_col>(is_valid_col(work_per_load - 1));
-        cl::sycl::vec<element_t, work_per_load> in_vec{0};
+        cl::sycl::vec<element_t, work_per_load> in_vec{};
         if (in_range) {
           // if in range perform a vectorised load
           in_vec.template load<address_t::global_space>(
@@ -712,7 +712,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
     bool in_range = do_check<check_row>(is_valid_row(work_per_load - 1)) &&
                     do_check<check_col>(is_valid_col(col_ofs));
 
-    cl::sycl::vec<element_t, work_per_load> in_vec{0};
+    cl::sycl::vec<element_t, work_per_load> in_vec{};
     if (in_range) {
       // If in range perform a vectorised load.
       in_vec.template load<address_t::global_space>(
@@ -774,7 +774,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
     bool in_range = do_check<check_row>(is_valid_row(row_ofs)) &&
                     do_check<check_col>(is_valid_col(work_per_load - 1));
 
-    cl::sycl::vec<element_t, work_per_load> in_vec{0};
+    cl::sycl::vec<element_t, work_per_load> in_vec{};
     if (in_range) {
       // If in range perform a vectorised load.
       in_vec.template load<address_t::global_space>(
@@ -906,7 +906,7 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, tile_type,
       for (int j = 0; j < item_rows / packet_size; j++) {
         if (do_check<check_block>(chk_boundary(dim_m_c_start + j * wg_rows,
                                                dim_n_c_start + i * wg_cols))) {
-          cl::sycl::vec<element_t, packet_size> out_vec{0};
+          cl::sycl::vec<element_t, packet_size> out_vec{};
 
           out_vec.template load<address_t::private_space>(
               0, cl::sycl::multi_ptr<const element_t, address_t::private_space>(


### PR DESCRIPTION
This is required as the spec expects the same data type for the argument as the vector has, otherwise the variadic ctor will be chosen, which has different semantics. So either `static_cast`s would've to be added or we just can rely on the default ctor to zero initialize the contents.