### PR TITLE
Use SYCL 2020 style selectors.

### DIFF
--- a/cmake/Modules/ConfigureSYCLBLAS.cmake
+++ b/cmake/Modules/ConfigureSYCLBLAS.cmake
@@ -67,10 +67,3 @@ message(STATUS "${TARGET} is chosen as a backend platform")
 # the BLAS_MODEL_OPTIMIZATION variable defines which model optimized configs should
 # be enabled for. Currently only affects ARM_GPU configs.
 SET(BLAS_MODEL_OPTIMIZATION "DEFAULT" CACHE STRING "Default Model 'DEFAULT'")
-
-# SYCL 2020 feature flags
-option(HAS_SYCL2020_SELECTORS "Enable use of SYCL 2020 selector API" Off)
-
-if(HAS_SYCL2020_SELECTORS)
-  add_definitions(-DHAS_SYCL2020_SELECTORS)
-endif()

--- a/cmake/Modules/ConfigureSYCLBLAS.cmake
+++ b/cmake/Modules/ConfigureSYCLBLAS.cmake
@@ -67,3 +67,10 @@ message(STATUS "${TARGET} is chosen as a backend platform")
 # the BLAS_MODEL_OPTIMIZATION variable defines which model optimized configs should
 # be enabled for. Currently only affects ARM_GPU configs.
 SET(BLAS_MODEL_OPTIMIZATION "DEFAULT" CACHE STRING "Default Model 'DEFAULT'")
+
+# SYCL 2020 feature flags
+option(HAS_SYCL2020_SELECTORS "Enable use of SYCL 2020 selector API" Off)
+
+if(HAS_SYCL2020_SELECTORS)
+  add_definitions(-DHAS_SYCL2020_SELECTORS)
+endif()

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -64,16 +64,14 @@ using test_executor_t =
  * using the default device if not specified.
  */
 inline cl::sycl::queue make_queue_impl() {
-  std::unique_ptr<cl::sycl::device_selector> selector;
+  std::function<int(const cl::sycl::device&)> selector;
   if (args.device.empty()) {
-    selector = std::unique_ptr<cl::sycl::device_selector>(
-        new cl::sycl::default_selector());
+    selector = cl::sycl::default_selector();
   } else {
-    selector = std::unique_ptr<cl::sycl::device_selector>(
-        new utils::cli_device_selector(args.device));
+    selector = utils::cli_device_selector(args.device);
   }
 
-  auto q = cl::sycl::queue(*selector, [=](cl::sycl::exception_list eL) {
+  auto q = cl::sycl::queue(selector, [=](cl::sycl::exception_list eL) {
     for (auto &e : eL) {
       try {
         std::rethrow_exception(e);

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -78,7 +78,7 @@ inline cl::sycl::queue make_queue_impl() {
     }
   };
 
-#ifdef HAS_SYCL2020_SELECTORS
+#if SYCL_LANGUAGE_VERSION >= 202002
   std::function<int(const cl::sycl::device&)> selector;
   if (args.device.empty()) {
     selector = cl::sycl::default_selector_v;

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -96,7 +96,7 @@ inline cl::sycl::queue make_queue_impl() {
         new utils::cli_device_selector(args.device));
   }
   auto q = cl::sycl::queue(*selector, async_handler);
-#endif
+#endif  // HAS_SYCL2020_SELECTORS
 
   utils::print_queue_information(q);
   return q;


### PR DESCRIPTION
The main change is that it's no longer assumed that the selectors derive from `sycl::device_selector` but instead they are callables.

Sorry for the spam, just wanted to have the fixes to be considered one-by-one if something would break otherwise :)

Also just for reference, I adapted the CMake configuration files quite rudimentary to build with hipSYCL in this branch, not sure what the status of interest would be to get (a polished version of this) merged: https://github.com/fodinabor/sycl-blas/tree/feature/hipsycl-build