### PR TITLE
Bump Actions job environments to Ubuntu 18.04

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
 # cancel outdated builds on pull requests.
   skip-check:
     continue-on-error: true
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -34,7 +34,7 @@ jobs:
   Build-and-Test:
     needs: skip-check
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Github removed support for Ubuntu 16 environments in actions yesterday, this PR modifies our actions YAML to use Ubuntu 18.04 for jobs instead.