### PR TITLE
Add cmake option to disable extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,8 @@ if(IMGDNN_DIR)
   list(APPEND THIRD_PARTIES_INCLUDE ${IMGDNN_INCLUDE_DIRS})
 endif()
 
+option(BLAS_ENABLE_EXTENSIONS "Whether to enable sycl-blas extensions" ON)
+
 # CmakeFunctionHelper has to be included after any options that it depends on are declared.
 # These include:
 # * TARGET
@@ -112,7 +114,7 @@ endif()
 include(CmakeFunctionHelper)
 
 add_subdirectory(src)
-build_library(sycl_blas)
+build_library(sycl_blas ${BLAS_ENABLE_EXTENSIONS})
 
 if (WIN32)
   # On Windows, all symbols must be resolved at link time for DLLs.

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Some of the supported options are:
 | `BLAS_VERIFY_BENCHMARK` | `ON`/`OFF` | Verify the results of the benchmarks instead of only measuring the performance. See the documentation of the benchmarks for more details. `ON` by default |
 | `BLAS_MODEL_OPTIMIZATION` | name | Pass a model name here to use optimized GEMM configurations for specific convolution models/sizes. Currently this only affects the `ARM_GPU` target. The supported models are: `RESNET_50`, `VGG_16` |
 | `BLAS_ENABLE_CONST_INPUT` | `ON`/`OFF` | Determines whether to enable kernel instantiation with const input buffer (`ON` by default) |
+| `BLAS_ENABLE_EXTENIONS` | `ON`/`OFF` | Determines whether to enable sycl-blas extensions (`ON` by default) |
 
 
 ### Cross-Compile (ComputeCpp Only)

--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -17,9 +17,11 @@ set(sources
   blas3/gemm.cpp
   blas3/gemm_batched.cpp
   blas3/trsm.cpp
-  # Extensions
-  extension/reduction.cpp
 )
+
+if(${BLAS_ENABLE_EXTENSIONS})
+  list(APPEND sources "extension/reduction.cpp")
+endif()
 
 # Add individual benchmarks for each method
 foreach(syclblas_bench ${sources})

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -784,41 +784,48 @@ function(generate_quantize)
 endfunction(generate_quantize)
 
 
-function (build_library LIB_NAME)
-add_library(${LIB_NAME}
-                             $<TARGET_OBJECTS:sycl_policy>
-                             $<TARGET_OBJECTS:quantize>
-                             $<TARGET_OBJECTS:axpy>
-                             $<TARGET_OBJECTS:asum>
-                             $<TARGET_OBJECTS:asum_return>
-                             $<TARGET_OBJECTS:copy>
-                             $<TARGET_OBJECTS:dot>
-                             $<TARGET_OBJECTS:dot_return>
-                             $<TARGET_OBJECTS:iamax>
-                             $<TARGET_OBJECTS:iamax_return>
-                             $<TARGET_OBJECTS:iamin>
-                             $<TARGET_OBJECTS:iamin_return>
-                             $<TARGET_OBJECTS:nrm2>
-                             $<TARGET_OBJECTS:nrm2_return>
-                             $<TARGET_OBJECTS:rot>
-                             $<TARGET_OBJECTS:scal>
-                             $<TARGET_OBJECTS:swap>
-                             $<TARGET_OBJECTS:gemv>
-                             $<TARGET_OBJECTS:ger>
-                             $<TARGET_OBJECTS:symv>
-                             $<TARGET_OBJECTS:syr>
-                             $<TARGET_OBJECTS:syr2>
-                             $<TARGET_OBJECTS:trmv>
-                             $<TARGET_OBJECTS:gemm_launcher>
-                             $<TARGET_OBJECTS:gemm>
-                             $<TARGET_OBJECTS:trsm>
-                             $<TARGET_OBJECTS:reduction>
-                            )
+function (build_library LIB_NAME ENABLE_EXTENSIONS)
+  set(LIB_SRCS  $<TARGET_OBJECTS:sycl_policy>
+                $<TARGET_OBJECTS:quantize>
+                $<TARGET_OBJECTS:axpy>
+                $<TARGET_OBJECTS:asum>
+                $<TARGET_OBJECTS:asum_return>
+                $<TARGET_OBJECTS:copy>
+                $<TARGET_OBJECTS:dot>
+                $<TARGET_OBJECTS:dot_return>
+                $<TARGET_OBJECTS:iamax>
+                $<TARGET_OBJECTS:iamax_return>
+                $<TARGET_OBJECTS:iamin>
+                $<TARGET_OBJECTS:iamin_return>
+                $<TARGET_OBJECTS:nrm2>
+                $<TARGET_OBJECTS:nrm2_return>
+                $<TARGET_OBJECTS:rot>
+                $<TARGET_OBJECTS:scal>
+                $<TARGET_OBJECTS:swap>
+                $<TARGET_OBJECTS:gemv>
+                $<TARGET_OBJECTS:ger>
+                $<TARGET_OBJECTS:symv>
+                $<TARGET_OBJECTS:syr>
+                $<TARGET_OBJECTS:syr2>
+                $<TARGET_OBJECTS:trmv>
+                $<TARGET_OBJECTS:gemm_launcher>
+                $<TARGET_OBJECTS:gemm>
+                $<TARGET_OBJECTS:trsm>)
+
+  if (${ENABLE_EXTENSIONS})
+    list(APPEND LIB_SRCS $<TARGET_OBJECTS:reduction>)
+  endif()
+
+  add_library(${LIB_NAME} ${LIB_SRCS})
+
   if(BLAS_ENABLE_CONST_INPUT)
-    target_sources(${LIB_NAME} PRIVATE 
-                             $<TARGET_OBJECTS:gemv_const>  
-                             $<TARGET_OBJECTS:gemm_const>
-                             $<TARGET_OBJECTS:reduction_const>
-                            )
+    set(CONST_SRCS $<TARGET_OBJECTS:gemv_const>
+                   $<TARGET_OBJECTS:gemm_const>)
+
+    if(${ENABLE_EXTENSIONS})
+      list(APPEND CONST_SRCS $<TARGET_OBJECTS:reduction_const>)
+    endif()
+
+    target_sources(${LIB_NAME} PRIVATE ${CONST_SRCS})
   endif()
 endfunction(build_library)

--- a/doc/Reduction.md
+++ b/doc/Reduction.md
@@ -49,6 +49,11 @@ the input matrix
 18
 ```
 
+## Relevant CMake Variables
+
+The CMake option `BLAS_ENABLE_EXTENSIONS` (`ON` by default) can be used to
+enable/disable compilation of the `Reduction` operation.
+
 ## SYCL-BLAS Reduction kernel
 
 Currently `SYCL-BLAS` supports a partial reduction kernel. Its implementation

--- a/src/interface/CMakeLists.txt
+++ b/src/interface/CMakeLists.txt
@@ -25,6 +25,7 @@
 add_subdirectory(blas1)
 add_subdirectory(blas2)
 add_subdirectory(blas3)
-add_subdirectory(reduction)
 
-
+if(${BLAS_ENABLE_EXTENSIONS})
+    add_subdirectory(reduction)
+endif()

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -42,8 +42,11 @@ set(SYCL_UNITTEST_SRCS
   ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_test.cpp
   ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_batched_test.cpp
   ${SYCLBLAS_UNITTEST}/blas3/blas3_trsm_test.cpp
-  ${SYCLBLAS_UNITTEST}/reduction/reduction_test.cpp
 )
+
+if(${BLAS_ENABLE_EXTENSIONS})
+  list(APPEND SYCL_UNITTEST_SRCS "${SYCLBLAS_UNITTEST}/reduction/reduction_test.cpp")
+endif()
 
 # Temporary disabling the following tests fro Intel DPC++ as currently Intel compiler crashes while running the following tests
 if(is_computecpp)


### PR DESCRIPTION
This PR adds the `BLAS_ENABLE_EXTENSIONS` CMake option which can be used to
disable sycl-blas extensions (currently only reduction). The option is enabled
by default.