### PR TITLE
Add support for mean reduction

### DIFF
--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -191,7 +191,7 @@ endfunction(generate_blas_binary_objects)
 # blas binary function for generating source code
 function(generate_blas_reduction_objects blas_level func)
 set(LOCATION "${SYCLBLAS_GENERATED_SRC}/${blas_level}/${func}/")
-set(operator_list "AddOperator" "MinOperator" "MaxOperator" "DivisionOperator" "ProductOperator" "AbsoluteAddOperator")
+set(operator_list "AddOperator" "MinOperator" "MaxOperator" "DivisionOperator" "ProductOperator" "AbsoluteAddOperator" "MeanOperator")
 string(FIND ${func} "_const" pos)
 if(pos)
   string(REPLACE "_const" "" actualfunc ${func})

--- a/doc/Reduction.md
+++ b/doc/Reduction.md
@@ -15,6 +15,7 @@ operators are:
 - `DivisionOperator`
 - `MinOperator`
 - `MaxOperator`
+- `MeanOperator`
 
 Currently in `SYCL-BLAS` only partial reduction is supported. Unlike full
 reduction, it reduces the columns or rows of a matrix to a single row or column

--- a/include/operations/blas_operators.h
+++ b/include/operations/blas_operators.h
@@ -51,6 +51,7 @@ struct DivisionOperator;
 struct MaxOperator;
 struct MinOperator;
 struct AbsoluteAddOperator;
+struct MeanOperator;
 
 }  // namespace blas
 

--- a/src/operations/blas_operators.hpp
+++ b/src/operations/blas_operators.hpp
@@ -219,6 +219,12 @@ struct AddOperator : public Operators {
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
     return constant<typename rhs_t::value_t, const_val::zero>::value();
   }
+
+  template <typename element_t, typename index_t>
+  static SYCL_BLAS_INLINE typename StripASP<element_t>::type get_final_value(
+      const element_t &l, const index_t &) {
+    return l;
+  }
 };
 
 struct ProductOperator : public Operators {
@@ -231,6 +237,12 @@ struct ProductOperator : public Operators {
   template <typename rhs_t>
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
     return constant<typename rhs_t::value_t, const_val::one>::value();
+  }
+
+  template <typename element_t, typename index_t>
+  static SYCL_BLAS_INLINE typename StripASP<element_t>::type get_final_value(
+      const element_t &l, const index_t &) {
+    return l;
   }
 };
 
@@ -245,6 +257,31 @@ struct DivisionOperator : public Operators {
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
     return constant<typename rhs_t::value_t, const_val::one>::value();
   }
+
+  template <typename element_t, typename index_t>
+  static SYCL_BLAS_INLINE typename StripASP<element_t>::type get_final_value(
+      const element_t &l, const index_t &) {
+    return l;
+  }
+};
+
+struct MeanOperator : public Operators {
+  template <typename element_t>
+  static SYCL_BLAS_INLINE typename StripASP<element_t>::type eval(
+      const element_t &accumulator, const element_t &val) {
+    return accumulator + val;
+  }
+
+  template <typename rhs_t>
+  constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
+    return constant<typename rhs_t::value_t, const_val::zero>::value();
+  }
+
+  template <typename element_t, typename index_t>
+  static SYCL_BLAS_INLINE typename StripASP<element_t>::type get_final_value(
+      const element_t &l, const index_t &r) {
+    return (l / static_cast<element_t>(r));
+  }
 };
 
 struct MaxOperator : public Operators {
@@ -257,6 +294,12 @@ struct MaxOperator : public Operators {
   template <typename rhs_t>
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
     return constant<typename rhs_t::value_t, const_val::min>::value();
+  }
+
+  template <typename element_t, typename index_t>
+  static SYCL_BLAS_INLINE typename StripASP<element_t>::type get_final_value(
+      const element_t &l, const index_t &) {
+    return l;
   }
 };
 
@@ -271,6 +314,12 @@ struct MinOperator : public Operators {
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
     return constant<typename rhs_t::value_t, const_val::max>::value();
   }
+
+  template <typename element_t, typename index_t>
+  static SYCL_BLAS_INLINE typename StripASP<element_t>::type get_final_value(
+      const element_t &l, const index_t &) {
+    return l;
+  }
 };
 
 struct AbsoluteAddOperator : public Operators {
@@ -283,6 +332,12 @@ struct AbsoluteAddOperator : public Operators {
   template <typename rhs_t>
   constexpr static SYCL_BLAS_INLINE typename rhs_t::value_t init() {
     return constant<typename rhs_t::value_t, const_val::zero>::value();
+  }
+
+  template <typename element_t, typename index_t>
+  static SYCL_BLAS_INLINE typename StripASP<element_t>::type get_final_value(
+      const element_t &l, const index_t &) {
+    return l;
   }
 };
 

--- a/src/operations/extension/reduction.hpp
+++ b/src/operations/extension/reduction.hpp
@@ -207,6 +207,7 @@ SYCL_BLAS_INLINE void Reduction<operator_t, params_t, input_t, output_t>::eval(
   // Reduce elements from global memory
   reduce(global_reduce_id, global_preserve_id, accumulator);
 
+  accumulator = operator_t::get_final_value(accumulator, num_elems_to_reduce_);
   const index_t scratch_idx =
       preserve_local_id +
       reduce_local_id * (params_t::get_local_thread_size_preserve() +


### PR DESCRIPTION
This PR adds `MeanOperator` which can be passed to the reduction kernel to perform mean reduction.