### PR TITLE
Fix how libraries propagate in SYCL-BLAS lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,23 +87,20 @@ option(GEMM_VECTORIZATION_SUPPORT "Whether to enable vectorization in Gemm kerne
 add_definitions(-DCL_TARGET_OPENCL_VERSION=220)
 
 set(CBLAS_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/external/cblas/include)
-set(COMPUTECPP_SDK_INCLUDE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/computecpp-sdk/include>
-  $<INSTALL_INTERFACE:include>)
+set(COMPUTECPP_SDK_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/external/computecpp-sdk/include)
 set(SYCLBLAS_GENERATED_SRC ${CMAKE_CURRENT_BINARY_DIR}/generated_src)
 set(SYCLBLAS_INCLUDE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 set(SYCLBLAS_COMMON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/common/include)
 set(SYCLBLAS_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(SYCLBLAS_SRC_GENERATOR ${CMAKE_CURRENT_SOURCE_DIR}/python_generator)
-list(APPEND THIRD_PARTIES_INCLUDE ${CBLAS_INCLUDE} ${SYCL_INCLUDE_DIRS} ${COMPUTECPP_SDK_INCLUDE})
+list(APPEND THIRD_PARTIES_INCLUDE ${CBLAS_INCLUDE} ${COMPUTECPP_SDK_INCLUDE})
 
 if(IMGDNN_DIR)
   add_definitions(-DIMGDNN_LIBRARY)
   find_package(IMGDNN REQUIRED)
   list(APPEND THIRD_PARTIES_INCLUDE ${IMGDNN_INCLUDE_DIRS})
 endif()
-
-
 
 # CmakeFunctionHelper has to be included after any options that it depends on are declared.
 # These include:
@@ -123,11 +120,11 @@ if (WIN32)
   # the linked libraries are not going to be propagated to this target.
   # This requires manual linking against SYCL on Windows.
   if(is_computecpp)
-    target_link_libraries(sycl_blas PRIVATE ComputeCpp::ComputeCpp)
+    target_link_libraries(sycl_blas PUBLIC ComputeCpp::ComputeCpp)
   elseif(is_dpcpp)
-    target_link_libraries(sycl_blas PRIVATE DPCPP::DPCPP)
+    target_link_libraries(sycl_blas PUBLIC DPCPP::DPCPP)
   elseif(is_hipsycl)
-    target_link_libraries(sycl_blas PRIVATE hipSYCL::hipSYCL-rt)
+    target_link_libraries(sycl_blas PUBLIC hipSYCL::hipSYCL-rt)
   endif()
 endif()
 if(is_computecpp)
@@ -142,7 +139,10 @@ endif()
 set_target_properties(sycl_blas PROPERTIES
   VERSION ${PROJECT_VERSION}
   INTERFACE_LINK_LIBRARIES ${sycl_impl}
-  INTERFACE_INCLUDE_DIRECTORIES "${SYCLBLAS_INCLUDE};${COMPUTECPP_SDK_INCLUDE};${SYCL_INCLUDE_DIRS}"
+  INTERFACE_INCLUDE_DIRECTORIES "${SYCLBLAS_INCLUDE}"
+)
+target_include_directories(sycl_blas INTERFACE
+  $<BUILD_INTERFACE:${COMPUTECPP_SDK_INCLUDE}>
 )
 
 if(IMGDNN_DIR)


### PR DESCRIPTION
Instead of adding an absolute path to the interface include dirs,
we should use the PUBLIC link, since any SYCL-BLAS target will
transitively depend on ComputeCpp or some other SYCL implementation
as well (SYCL-BLAS uses SYCL constructs in its public headers).

Without this change, packages created by installing the project
will have absolute paths of the machine it was built on, making
the package unrelocatable. With it, a requisite of the SYCL
library is added to the targets. The SDK includes are still
propagated for the export file, but removed for installs, as the
headers are installed alongside the SYCL-BLAS headers so can be
found in the same location.