### PR TITLE
Improve testing of Reduction

### DIFF
--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -191,7 +191,7 @@ endfunction(generate_blas_binary_objects)
 # blas binary function for generating source code
 function(generate_blas_reduction_objects blas_level func)
 set(LOCATION "${SYCLBLAS_GENERATED_SRC}/${blas_level}/${func}/")
-set(operator_list "AddOperator" "MinOperator" "MaxOperator" "DivisionOperator" "ProductOperator" "AbsoluteAddOperator" "MeanOperator")
+set(operator_list "AddOperator" "MinOperator" "MaxOperator" "ProductOperator" "AbsoluteAddOperator" "MeanOperator")
 string(FIND ${func} "_const" pos)
 if(pos)
   string(REPLACE "_const" "" actualfunc ${func})

--- a/doc/Reduction.md
+++ b/doc/Reduction.md
@@ -12,7 +12,6 @@ operators are:
 - `AddOperator`
 - `AbsoluteAddOperator`
 - `ProductOperator`
-- `DivisionOperator`
 - `MinOperator`
 - `MaxOperator`
 - `MeanOperator`

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -125,19 +125,32 @@ static inline scalar_t random_scalar(scalar_t rangeMin, scalar_t rangeMax) {
 }
 
 /**
- * @fn random_data
+ * @brief Generates a random vector of scalar values, using a uniform
+ * distribution.
+ * @param vec Input vector to fill
+ * @param rangeMin Minimum value for the uniform distribution
+ * @param rangeMax Maximum value for the uniform distribution
+ */
+template <typename scalar_t>
+static inline void fill_random_with_range(std::vector<scalar_t> &vec,
+                                          scalar_t rangeMin,
+                                          scalar_t rangeMax) {
+  for (scalar_t &e : vec) {
+    e = random_scalar(rangeMin, rangeMax);
+  }
+}
+
+/**
  * @brief Generates a random vector of scalar values, using a uniform
  * distribution.
  */
 template <typename scalar_t>
 static inline void fill_random(std::vector<scalar_t> &vec) {
-  for (scalar_t &e : vec) {
-    e = random_scalar(scalar_t{-2}, scalar_t{5});
-  }
+  fill_random_with_range(vec, scalar_t{-2}, scalar_t{5});
 }
 
 /**
- * @breif Fills a lower or upper triangular matrix suitable for TRSM testing
+ * @brief Fills a lower or upper triangular matrix suitable for TRSM testing
  * @param A The matrix to fill. Size must be at least m * lda
  * @param m The number of rows of matrix @p A
  * @param n The number of columns of matrix @p A


### PR DESCRIPTION
- Enable testing of Product Reduction. The tests were failing since the input
range was a bit too large. For large input matrices (e.g. 513x8195) it was
outputting too large/small values to fit in a float. As a workaround, the input
range was made smaller for large matrices. 

- Remove testing of Division Reduction. The reduction algorithm assumes that the
binary operator used is commutative, which Division is not. Therefore, the
Division operator cannot be supported and was removed.