### PR TITLE
Fix failing reduction tests on PowerVR

### DIFF
--- a/include/operations/extension/reduction.h
+++ b/include/operations/extension/reduction.h
@@ -98,7 +98,7 @@ struct ReductionParams {
   }
 
   static index_t calculate_reduced_group_count(index_t rows, index_t cols) {
-    constexpr index_t reductions_per_thread = 64;
+    constexpr index_t reductions_per_thread = get_reductions_per_thread();
     constexpr index_t local_range =
         get_local_thread_size_preserve() * get_local_thread_size_reduce();
     const auto num_elems_to_reduce = is_outer_dim() ? cols : rows;
@@ -161,13 +161,14 @@ class Reduction {
   const index_t leading_dim_;
   const index_t ld_mul_;
   /* Work groups per dimension */
+  const index_t reduced_group_count_;
   const index_t group_count_rows_;
   const index_t group_count_cols_;
   const index_t preserve_elements_num_groups_;
   const index_t reduce_elements_num_groups_;
   const index_t num_elems_to_preserve_;
   const index_t num_elems_to_reduce_;
-  Reduction(input_t in, output_t out, index_t reduced_group_count);
+  Reduction(input_t in, output_t out);
   bool valid_thread(cl::sycl::nd_item<1> id) const;
   void bind(cl::sycl::handler& h);
   void adjust_access_displacement();
@@ -193,9 +194,8 @@ class Reduction {
 template <typename operator_t, typename params_t, typename input_t,
           typename output_t>
 inline Reduction<operator_t, params_t, input_t, output_t> make_reduction(
-    input_t in, output_t out, typename params_t::index_t reduced_group_count) {
-  return Reduction<operator_t, params_t, input_t, output_t>(
-      in, out, reduced_group_count);
+    input_t in, output_t out) {
+  return Reduction<operator_t, params_t, input_t, output_t>(in, out);
 }
 
 }  // namespace blas

--- a/src/executors/executor_sycl.hpp
+++ b/src/executors/executor_sycl.hpp
@@ -304,8 +304,7 @@ Executor<PolicyHandler<codeplay_policy>>::execute(
   /* Best case: we can reduce directly in C */
   if (is_beta_zero && ldc == rows) {
     Reduction<blas::AddOperator, params_t, CubeType, output_t> reduction(
-        cube_reduction, gemm_wrapper.c_,
-        params_t::calculate_reduced_group_count(rows * cols, depth));
+        cube_reduction, gemm_wrapper.c_);
     events = concatenate_vectors(events, execute(reduction));
   }
   /* Otherwise we reduce to a temporary buffer */
@@ -317,8 +316,7 @@ Executor<PolicyHandler<codeplay_policy>>::execute(
 
     /* Execute the reduction */
     Reduction<blas::AddOperator, params_t, CubeType, output_t> reduction(
-        cube_reduction, temp,
-        params_t::calculate_reduced_group_count(rows * cols, depth));
+        cube_reduction, temp);
     events = concatenate_vectors(events, execute(reduction));
 
     /* If beta is zero, simply do a 2D copy from the temp buffer to C */

--- a/test/unittest/reduction/reduction_test.cpp
+++ b/test/unittest/reduction/reduction_test.cpp
@@ -47,7 +47,8 @@ const auto combi = ::testing::Combine(
     ::testing::Values(1, 15, 1000, 1337, 8195),  // columns
     ::testing::Values(1, 2, 3),                  // ld_mul
     ::testing::Values(operator_t::Add, operator_t::Max, operator_t::Min,
-                      operator_t::AbsoluteAdd, operator_t::Mean, operator_t::Product),
+                      operator_t::AbsoluteAdd, operator_t::Mean,
+                      operator_t::Product),
     ::testing::Values(reduction_dim_t::inner, reduction_dim_t::outer));
 
 template <typename scalar_t>
@@ -74,7 +75,7 @@ void run_test(const combination_t<scalar_t> combi) {
   if (op == operator_t::Product) {
     // Use smaller input range for Product tests since the product
     // operation saturates float overflow faster than the other operations
-    fill_random_with_range(in_m, -2.f, 1.f);
+    fill_random_with_range(in_m, scalar_t{-2}, scalar_t{1});
   } else {
     fill_random(in_m);
   }


### PR DESCRIPTION
- Fix a bug in two step reduction when using `MeanOperator`: both steps were calculating the mean. The correct behaviour is for the second step to use `AddOperator` instead.
- The `reduced_group_count` variable was computed in two different places with slightly different calculations which resulted in incorrect output.
- Use smaller local range for PowerVR
