### PR TITLE
Add CMake support for DPCPP AMD build

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,9 @@ cmake -GNinja ../ -DSYCL_COMPILER=dpcpp
 ninja
 ```
 
+If building for `AMD_GPU` devices, it is also required to provide the
+specific architecture through the `DPCPP_SYCL_ARCH` CMake variable.
+
 ### Compile with hipSYCL
 ```bash
 cd build
@@ -379,7 +382,7 @@ Some of the supported options are:
 | `BLAS_VERIFY_BENCHMARK` | `ON`/`OFF` | Verify the results of the benchmarks instead of only measuring the performance. See the documentation of the benchmarks for more details. `ON` by default |
 | `BLAS_MODEL_OPTIMIZATION` | name | Pass a model name here to use optimized GEMM configurations for specific convolution models/sizes. Currently this only affects the `ARM_GPU` target. The supported models are: `RESNET_50`, `VGG_16` |
 | `BLAS_ENABLE_CONST_INPUT` | `ON`/`OFF` | Determines whether to enable kernel instantiation with const input buffer (`ON` by default) |
-| `BLAS_ENABLE_EXTENIONS` | `ON`/`OFF` | Determines whether to enable sycl-blas extensions (`ON` by default) |
+| `BLAS_ENABLE_EXTENSIONS` | `ON`/`OFF` | Determines whether to enable sycl-blas extensions (`ON` by default) |
 
 
 ### Cross-Compile (ComputeCpp Only)

--- a/cmake/Modules/SYCL.cmake
+++ b/cmake/Modules/SYCL.cmake
@@ -90,7 +90,7 @@ elseif(is_dpcpp)
   set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__SYCL_DISABLE_NAMESPACE_INLINE__=ON -O3 -Xclang -cl-mad-enable")
   if(${BACKEND_DEVICE} STREQUAL "DEFAULT_CPU") 
-    set(DPCPP_SYCL_TARGET spir64_x86_64-unknown-unknown-sycldevice)
+    set(DPCPP_SYCL_TARGET spir64_x86_64-unknown-unknown)
   elseif(${BACKEND_DEVICE} STREQUAL "INTEL_GPU")
   # the correct target-triple for intel gpu is: spir64_gen-unknown-unknown-sycldevice
   # however, the current version of DPCPP fails to link with the following error
@@ -103,9 +103,11 @@ elseif(is_dpcpp)
   #clang++: note: diagnostic msg: Error generating preprocessed source(s) - no preprocessable inputs.
   #ninja: build stopped: subcommand failed.
   #TODO : (MEHDI) Create BuG report on intel/llvm 
-    set(DPCPP_SYCL_TARGET spir64-unknown-unknown-sycldevice)
+    set(DPCPP_SYCL_TARGET spir64-unknown-unknown)
   elseif(${BACKEND_DEVICE} STREQUAL "NVIDIA_GPU")
-    set(DPCPP_SYCL_TARGET nvptx64-nvidia-cuda-sycldevice)
+    set(DPCPP_SYCL_TARGET nvptx64-nvidia-cuda)
+  elseif(${BACKEND_DEVICE} STREQUAL "AMD_GPU")
+    set(DPCPP_SYCL_TARGET amdgcn-amd-amdhsa)
   endif()
   find_package(DPCPP REQUIRED)
   get_target_property(SYCL_INCLUDE_DIRS DPCPP::DPCPP INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
* Update `FindDPCPP.cmake` to allow setting a specific architecture,
  this is necessary for AMD targets.
* Wire `AMD_GPU` target for DPCPP.
* Fix DPCPP triples `-sycldevice` is no longer required.