### PR TITLE
Fix GTest and bump GBench versions

### DIFF
--- a/cmake/templates/GBench.txt.in
+++ b/cmake/templates/GBench.txt.in
@@ -4,14 +4,13 @@ cmake_minimum_required(VERSION 3.4.2)
 # See the guidelines at the URL below for a more detailed explanation
 # https://github.com/google/googletest/blob/master/googletest/README.md
 # We fix a specific commit, so that we don't get unwanted changes from upstream
-#   - 05d8c1c5d09028a39306c368791c0aa545ad19e7
 
 project(googlebench-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googlebench
     GIT_REPOSITORY https://github.com/google/benchmark
-    GIT_TAG 05d8c1c5d09028a39306c368791c0aa545ad19e7
+    GIT_TAG v1.6.1
     SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/googlebench-src"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/googlebench-build"
     CMAKE_ARGS "-DBENCHMARK_ENABLE_TESTING=OFF"

--- a/cmake/templates/GTest.txt.in
+++ b/cmake/templates/GTest.txt.in
@@ -9,7 +9,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG main
+    GIT_TAG release-1.12.1
     SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
Fixing GTest version to a version supporting C++11.