### PR TITLE
[Issue 332] Don't define BLAS_ENABLE_CONST_INPUT in source if OFF

### DIFF
--- a/src/policy/CMakeLists.txt
+++ b/src/policy/CMakeLists.txt
@@ -22,7 +22,11 @@
 # *  @filename CMakeLists.txt
 # *
 # **************************************************************************/
-add_definitions(-DBLAS_ENABLE_CONST_INPUT=${BLAS_ENABLE_CONST_INPUT})
+
+if(BLAS_ENABLE_CONST_INPUT)
+    add_definitions(-DBLAS_ENABLE_CONST_INPUT=${BLAS_ENABLE_CONST_INPUT})
+endif()
+
 add_library(sycl_policy OBJECT ${SYCLBLAS_SRC}/policy/sycl_policy_handler.cpp)
 set_target_compile_def(sycl_policy)
 target_include_directories(sycl_policy PRIVATE ${SYCLBLAS_SRC} ${SYCLBLAS_INCLUDE}


### PR DESCRIPTION
As described in https://github.com/codeplaysoftware/sycl-blas/issues/332, `sycl_policy_handler.cpp` only checks for the existance of `BLAS_ENABLE_CONST_INPUT`, not its value. 

This patch
* Only defines `BLAS_ENABLE_CONST_INPUT` if it is ON in `sycl_policy_handler.cpp`.
* Otherwise the code contained by the `#ifdef` is not compiled.