### PR TITLE
Use vptr from updated ComputeCpp-SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,16 @@ ARG cxx_compiler
 ARG impl
 ARG target
 
+# Timezone is required
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 RUN apt-get -yq update
 
 # Utilities
 RUN apt-get install -yq --allow-downgrades --allow-remove-essential            \
-    --allow-change-held-packages git wget python-pip apt-utils cmake unzip                \
-    libboost-all-dev software-properties-common python-software-properties libcompute-dev
+    --allow-change-held-packages git wget python3-pip apt-utils cmake unzip    \
+    libboost-all-dev software-properties-common libtinfo5
 
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:focal
 
 # Default values for the build
 ARG git_branch

--- a/include/policy/sycl_policy_handler.h
+++ b/include/policy/sycl_policy_handler.h
@@ -42,9 +42,9 @@ class PolicyHandler<codeplay_policy> {
 
   explicit PolicyHandler(cl::sycl::queue q)
       : q_(q),
-        pointerMapperPtr_(std::shared_ptr<cl::sycl::codeplay::PointerMapper>(
-            new cl::sycl::codeplay::PointerMapper(),
-            [](cl::sycl::codeplay::PointerMapper *p) {
+        pointerMapperPtr_(std::shared_ptr<vptr::PointerMapper>(
+            new vptr::PointerMapper(),
+            [](vptr::PointerMapper *p) {
               p->clear();
               delete p;
             })),
@@ -182,7 +182,7 @@ class PolicyHandler<codeplay_policy> {
 
  private:
   typename policy_t::queue_t q_;
-  std::shared_ptr<cl::sycl::codeplay::PointerMapper> pointerMapperPtr_;
+  std::shared_ptr<vptr::PointerMapper> pointerMapperPtr_;
   const size_t workGroupSize_;
   const policy_t::device_type selectedDeviceType_;
   const bool localMemorySupport_;

--- a/src/policy/sycl_policy_handler.hpp
+++ b/src/policy/sycl_policy_handler.hpp
@@ -32,13 +32,13 @@ namespace blas {
 template <typename element_t>
 inline element_t *PolicyHandler<codeplay_policy>::allocate(
     size_t num_elements) const {
-  return static_cast<element_t *>(cl::sycl::codeplay::SYCLmalloc(
+  return static_cast<element_t *>(vptr::SYCLmalloc(
       num_elements * sizeof(element_t), *pointerMapperPtr_));
 }
 
 template <typename element_t>
 inline void PolicyHandler<codeplay_policy>::deallocate(element_t *p) const {
-  cl::sycl::codeplay::SYCLfree(static_cast<void *>(p), *pointerMapperPtr_);
+  vptr::SYCLfree(static_cast<void *>(p), *pointerMapperPtr_);
 }
 
 /*


### PR DESCRIPTION
Using the current DPC++ nightly leads to errors whilst compiling the SYCL-BLAS due to the `cl::sycl::codeplay` namespace that was used in the ComputeCpp-SDK virtual pointer implementation. The ComputeCpp-SDK has been updated to use a more appropriate `vptr` namespace instead. This PR updates SYCL-BLAS to use the updated DPC++-nightly-compatible ComputeCpp-SDK.