### PR TITLE
Export symbols in Windows shared library

### DIFF
--- a/cmake/Modules/ConfigureSYCLBLAS.cmake
+++ b/cmake/Modules/ConfigureSYCLBLAS.cmake
@@ -67,3 +67,10 @@ message(STATUS "${TARGET} is chosen as a backend platform")
 # the BLAS_MODEL_OPTIMIZATION variable defines which model optimized configs should
 # be enabled for. Currently only affects ARM_GPU configs.
 SET(BLAS_MODEL_OPTIMIZATION "DEFAULT" CACHE STRING "Default Model 'DEFAULT'")
+
+if (WIN32)
+  # On Win32, shared library symbols need to be explicitly exported.
+  if (BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+  endif()
+endif()


### PR DESCRIPTION
Windows does not export symbols in shared libraries by default. This commit results in all the symbols being exported to the Windows .dll by default.

Since this PR is for Windows it is untested by the CI. Instead, it has been tested manually.