### PR TITLE
[DPC++] Look for renamed DPC++ runtime shared library.

### DIFF
--- a/cmake/Modules/FindDPCPP.cmake
+++ b/cmake/Modules/FindDPCPP.cmake
@@ -38,7 +38,7 @@ set(DPCPP_USER_FLAGS "" CACHE STRING
     "Additional user-specified compiler flags for DPC++")
 
 get_filename_component(DPCPP_BIN_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
-find_library(DPCPP_LIB_DIR NAMES sycl PATHS "${DPCPP_BIN_DIR}/../lib")
+find_library(DPCPP_LIB_DIR NAMES sycl sycl6 PATHS "${DPCPP_BIN_DIR}/../lib")
 
 add_library(DPCPP::DPCPP INTERFACE IMPORTED)
 


### PR DESCRIPTION
This PR fixes https://github.com/codeplaysoftware/sycl-blas/issues/337

* The intel DPC++ nightly renames sycl.lib/dll to sycl{MAJOR_VER}.lib/dll.
* This breaks the FindDPCPP.cmake script.
* This commit allows sycl6.dll to be found.
  * Tested on Windows against:
	* SYCL-nightly 2022/10/26 (w/ sycl6.lib, passes).
	* SYCL-nightly 2022/09/11 (w/ sycl.lib, passes).
  * Tested on Linux against 2022/09/11, passes.