### PR TITLE
Fix support for 64b index types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ option(BLAS_ENABLE_EXTENSIONS "Whether to enable sycl-blas extensions" ON)
 # * GEMM_TALL_SKINNY_SUPPORT
 # * GEMM_VECTORIZATION_SUPPORT
 # * BLAS_DATA_TYPES
+# * BLAS_INDEX_TYPES
 # * NAIVE_GEMM
 include(CmakeFunctionHelper)
 

--- a/README.md
+++ b/README.md
@@ -383,6 +383,8 @@ Some of the supported options are:
 | `BLAS_MODEL_OPTIMIZATION` | name | Pass a model name here to use optimized GEMM configurations for specific convolution models/sizes. Currently this only affects the `ARM_GPU` target. The supported models are: `RESNET_50`, `VGG_16` |
 | `BLAS_ENABLE_CONST_INPUT` | `ON`/`OFF` | Determines whether to enable kernel instantiation with const input buffer (`ON` by default) |
 | `BLAS_ENABLE_EXTENSIONS` | `ON`/`OFF` | Determines whether to enable sycl-blas extensions (`ON` by default) |
+| `BLAS_DATA_TYPES` | `half;float;double` | Determines the floating-point types to instantiate BLAS operations for. Default is `float` |
+| `BLAS_INDEX_TYPES` | `int32_t;int64_t` | Determines the type(s) to use for `index_t` and `increment_t`. Default is `int` |
 
 
 ### Cross-Compile (ComputeCpp Only)

--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -23,11 +23,15 @@ if(${BLAS_ENABLE_EXTENSIONS})
   list(APPEND sources "extension/reduction.cpp")
 endif()
 
+# Select an index type to run the tests with. Use first given index type.
+list(GET BLAS_INDEX_TYPES 0 BLAS_BENCHMARK_INDEX_TYPE)
+
 # Add individual benchmarks for each method
 foreach(syclblas_bench ${sources})
   get_filename_component(bench_exec ${syclblas_bench} NAME_WE)
   add_executable(bench_${bench_exec} ${syclblas_bench} main.cpp)
   target_link_libraries(bench_${bench_exec} PRIVATE benchmark Clara::Clara sycl_blas)
+  target_compile_definitions(bench_${bench_exec} PRIVATE -DBLAS_BENCHMARK_INDEX_T=${BLAS_BENCHMARK_INDEX_TYPE})
   add_sycl_to_target(
     TARGET bench_${bench_exec}
     SOURCES ${syclblas_bench}

--- a/benchmark/syclblas/blas1/asum.cpp
+++ b/benchmark/syclblas/blas1/asum.cpp
@@ -65,7 +65,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   data_t vr_temp = 0;
   {
     auto vr_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, vr_temp);
-    _asum(ex, size, inx, 1, vr_temp_gpu);
+    _asum(ex, size, inx, static_cast<index_t>(1), vr_temp_gpu);
     auto event =
         utils::quantized_copy_to_host<scalar_t>(ex, vr_temp_gpu, vr_temp);
     ex.get_policy_handler().wait(event);
@@ -81,7 +81,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
 #endif
 
   auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
-    auto event = _asum(ex, size, inx, 1, inr);
+    auto event = _asum(ex, size, inx, static_cast<index_t>(1), inr);
     ex.get_policy_handler().wait(event);
     return event;
   };

--- a/benchmark/syclblas/blas1/axpy.cpp
+++ b/benchmark/syclblas/blas1/axpy.cpp
@@ -62,7 +62,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   std::vector<data_t> y_temp = v2;
   {
     auto y_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, y_temp);
-    _axpy(ex, size, alpha, inx, 1, y_temp_gpu, 1);
+    _axpy(ex, size, alpha, inx, static_cast<index_t>(1), y_temp_gpu, static_cast<index_t>(1));
     auto event =
         utils::quantized_copy_to_host<scalar_t>(ex, y_temp_gpu, y_temp);
     ex.get_policy_handler().wait(event);
@@ -78,7 +78,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
 #endif
 
   auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
-    auto event = _axpy(ex, size, alpha, inx, 1, iny, 1);
+    auto event = _axpy(ex, size, alpha, inx, static_cast<index_t>(1), iny, static_cast<index_t>(1));
     ex.get_policy_handler().wait(event);
     return event;
   };

--- a/benchmark/syclblas/blas1/dot.cpp
+++ b/benchmark/syclblas/blas1/dot.cpp
@@ -64,7 +64,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   data_t vr_temp = 0;
   {
     auto vr_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, vr_temp);
-    _dot(ex, size, inx, 1, iny, 1, vr_temp_gpu);
+    _dot(ex, size, inx, static_cast<index_t>(1), iny, static_cast<index_t>(1), vr_temp_gpu);
     auto event =
         utils::quantized_copy_to_host<scalar_t>(ex, vr_temp_gpu, vr_temp);
     ex.get_policy_handler().wait(event);
@@ -80,7 +80,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
 #endif
 
   auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
-    auto event = _dot(ex, size, inx, 1, iny, 1, inr);
+    auto event = _dot(ex, size, inx, static_cast<index_t>(1), iny, static_cast<index_t>(1), inr);
     ex.get_policy_handler().wait(event);
     return event;
   };

--- a/benchmark/syclblas/blas1/iamax.cpp
+++ b/benchmark/syclblas/blas1/iamax.cpp
@@ -65,9 +65,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   tuple_scalar_t idx_temp{-1, 0};
   {
     auto idx_temp_gpu =
-        blas::make_sycl_iterator_buffer<blas::IndexValueTuple<int, scalar_t>>(
+        blas::make_sycl_iterator_buffer<blas::IndexValueTuple<index_t, scalar_t>>(
             &idx_temp, 1);
-    auto event = _iamax(ex, size, inx, 1, idx_temp_gpu);
+    auto event = _iamax(ex, size, inx, static_cast<index_t>(1), idx_temp_gpu);
     ex.get_policy_handler().wait(event);
   }
 
@@ -82,7 +82,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
 #endif
 
   auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
-    auto event = _iamax(ex, size, inx, 1, outI);
+    auto event = _iamax(ex, size, inx, static_cast<index_t>(1), outI);
     ex.get_policy_handler().wait(event);
     return event;
   };

--- a/benchmark/syclblas/blas1/iamin.cpp
+++ b/benchmark/syclblas/blas1/iamin.cpp
@@ -64,9 +64,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   tuple_scalar_t idx_temp{-1, -1};
   {
     auto idx_temp_gpu =
-        blas::make_sycl_iterator_buffer<blas::IndexValueTuple<int, scalar_t>>(
+        blas::make_sycl_iterator_buffer<blas::IndexValueTuple<index_t, scalar_t>>(
             &idx_temp, 1);
-    auto event = _iamin(ex, size, inx, 1, idx_temp_gpu);
+    auto event = _iamin(ex, size, inx, static_cast<index_t>(1), idx_temp_gpu);
     ex.get_policy_handler().wait(event);
   }
 
@@ -81,7 +81,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
 #endif
 
   auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
-    auto event = _iamin(ex, size, inx, 1, outI);
+    auto event = _iamin(ex, size, inx, static_cast<index_t>(1), outI);
     ex.get_policy_handler().wait(event);
     return event;
   };

--- a/benchmark/syclblas/blas1/nrm2.cpp
+++ b/benchmark/syclblas/blas1/nrm2.cpp
@@ -62,7 +62,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   data_t vr_temp = 0;
   {
     auto vr_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, vr_temp);
-    _nrm2(ex, size, inx, 1, vr_temp_gpu);
+    _nrm2(ex, size, inx, static_cast<index_t>(1), vr_temp_gpu);
     auto event =
         utils::quantized_copy_to_host<scalar_t>(ex, vr_temp_gpu, vr_temp);
     ex.get_policy_handler().wait(event);
@@ -78,7 +78,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
 #endif
 
   auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
-    auto event = _nrm2(ex, size, inx, 1, inr);
+    auto event = _nrm2(ex, size, inx, static_cast<index_t>(1), inr);
     ex.get_policy_handler().wait(event);
     return event;
   };

--- a/benchmark/syclblas/blas1/scal.cpp
+++ b/benchmark/syclblas/blas1/scal.cpp
@@ -59,7 +59,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
   std::vector<data_t> v1_temp = v1;
   {
     auto v1_temp_gpu = utils::make_quantized_buffer<scalar_t>(ex, v1_temp);
-    _scal(ex, size, alpha, v1_temp_gpu, 1);
+    _scal(ex, size, alpha, v1_temp_gpu, static_cast<index_t>(1));
     auto event =
         utils::quantized_copy_to_host<scalar_t>(ex, v1_temp_gpu, v1_temp);
     ex.get_policy_handler().wait(event);
@@ -74,7 +74,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t size,
 #endif
 
   auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
-    auto event = _scal(ex, size, alpha, in, 1);
+    auto event = _scal(ex, size, alpha, in, static_cast<index_t>(1));
     ex.get_policy_handler().wait(event);
     return event;
   };

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -24,8 +24,8 @@
 # **************************************************************************/
 # represent the list of supported handler for executor
 set(executor_list "PolicyHandler<codeplay_policy>")
-#represent the list of supported index/increment type
-set(index_list "int" )
+# represent the list of supported index/increment types
+set(index_list "${BLAS_INDEX_TYPES}" )
 
 # BLAS_DATA_TYPES was provided by the user
 #Each data type in a data list determines the container types.

--- a/cmake/Modules/ConfigureSYCLBLAS.cmake
+++ b/cmake/Modules/ConfigureSYCLBLAS.cmake
@@ -25,6 +25,7 @@
 # **************************************************************************/
 
 set(BLAS_DATA_TYPES "float" CACHE STRING "Data types to test")
+set(BLAS_INDEX_TYPES "int" CACHE STRING "Supported index/increment types")
 
 # Check to see if we've enabled double support in tests
 option(DOUBLE_SUPPORT "Enable double support when testing." off)

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -21,7 +21,12 @@
 #include <common/float_comparison.hpp>
 #include <common/system_reference_blas.hpp>
 
+#ifdef BLAS_BENCHMARK_INDEX_T
+using index_t = BLAS_BENCHMARK_INDEX_T;
+#else
 using index_t = int;
+#endif // BLAS_BENCHMARK_INDEX_T
+
 using blas1_param_t = index_t;
 
 template <typename scalar_t>

--- a/src/interface/trsm_interface.hpp
+++ b/src/interface/trsm_interface.hpp
@@ -253,7 +253,7 @@ typename executor_t::policy_t::event_t _trsm(executor_t& ex, char side,
       const index_t specialBlockSize =
           (M % blockSize == 0) ? blockSize : (M % blockSize);
       const index_t iStart = M - specialBlockSize;
-      for (int i = iStart; i >= 0; i -= blockSize) {
+      for (index_t i = iStart; i >= 0; i -= blockSize) {
         const index_t currentBlockSize =
             (i == iStart) ? specialBlockSize : blockSize;
         auto gemmEvent = internal::_gemm(ex, isTranspose ? 't' : 'n', 'n',
@@ -295,7 +295,7 @@ typename executor_t::policy_t::event_t _trsm(executor_t& ex, char side,
       const index_t specialBlockSize =
           (N % blockSize == 0) ? blockSize : (N % blockSize);
       const index_t iStart = N - specialBlockSize;
-      for (int i = iStart; i >= 0; i -= blockSize) {
+      for (index_t i = iStart; i >= 0; i -= blockSize) {
         const index_t currentBlockSize =
             (i == iStart) ? specialBlockSize : blockSize;
         auto gemmEvent = internal::_gemm(

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -60,6 +60,13 @@ using namespace blas;
 using test_executor_t =
     blas::Executor<blas::PolicyHandler<blas::codeplay_policy>>;
 
+    
+#ifdef BLAS_BENCHMARK_INDEX_T
+using index_t = BLAS_BENCHMARK_INDEX_T;
+#else
+using index_t = int;
+#endif // BLAS_BENCHMARK_INDEX_T
+
 /**
  * Construct a SYCL queue using the device specified in the command line, or
  * using the default device if not specified.
@@ -224,6 +231,29 @@ inline void dump_arg<float>(std::ostream &ss, float f) {
   if (frac_part > 0) {
     ss << "p" << (int)(frac_part * 100);
   }
+}
+
+template <>
+inline void dump_arg<double>(std::ostream &ss, double f) {
+  if (std::isnan(f)) {
+    ss << "nan";
+    return;
+  }
+  if (f < 0) {
+    ss << "m";
+    f = std::fabs(f);
+  }
+  double int_part;
+  double frac_part = modf(f, &int_part);
+  ss << int_part;
+  if (frac_part > 0) {
+    ss << "p" << (int)(frac_part * 100);
+  }
+}
+
+template <>
+inline void dump_arg<cl::sycl::half>(std::ostream &ss, cl::sycl::half f) {
+  dump_arg<float>(ss, static_cast<float>(f));
 }
 
 /**

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -71,12 +71,16 @@ if(GEMM_TALL_SKINNY_SUPPORT)
   list(APPEND SYCL_UNITTEST_SRCS ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_tall_skinny_test.cpp)
 endif()
 
+# Select an index type to run the tests with. Use first given index type.
+list(GET BLAS_INDEX_TYPES 0 BLAS_BENCHMARK_INDEX_TYPE)
+
 foreach(blas_test ${SYCL_UNITTEST_SRCS})
   get_filename_component(test_exec ${blas_test} NAME_WE)
   add_executable(${test_exec} main.cpp ${blas_test})
   if(STRESS_TESTING)
     target_compile_definitions(${test_exec} PRIVATE STRESS_TESTING)
   endif()
+  target_compile_definitions(${test_exec} PRIVATE  -DBLAS_BENCHMARK_INDEX_T=${BLAS_BENCHMARK_INDEX_TYPE})
   target_link_libraries(${test_exec} PRIVATE gtest_main Clara::Clara blas::blas sycl_blas)
   target_include_directories(${test_exec} PRIVATE ${CBLAS_INCLUDE} ${SYCLBLAS_COMMON_INCLUDE_DIR})
   if(TEST_DEVICE)

--- a/test/unittest/blas1/blas1_asum_test.cpp
+++ b/test/unittest/blas1/blas1_asum_test.cpp
@@ -30,8 +30,8 @@ using combination_t = std::tuple<int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int size;
-  int incX;
+  index_t size;
+  index_t incX;
   std::tie(size, incX) = combi;
 
   using data_t = utils::data_storage_t<scalar_t>;

--- a/test/unittest/blas1/blas1_axpy_test.cpp
+++ b/test/unittest/blas1/blas1_axpy_test.cpp
@@ -30,10 +30,10 @@ using combination_t = std::tuple<int, scalar_t, int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int size;
+  index_t size;
   scalar_t alpha;
-  int incX;
-  int incY;
+  index_t incX;
+  index_t incY;
   std::tie(size, alpha, incX, incY) = combi;
 
   using data_t = utils::data_storage_t<scalar_t>;

--- a/test/unittest/blas1/blas1_copy_test.cpp
+++ b/test/unittest/blas1/blas1_copy_test.cpp
@@ -30,9 +30,9 @@ using combination_t = std::tuple<int, int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int size;
-  int incX;
-  int incY;
+  index_t size;
+  index_t incX;
+  index_t incY;
   std::tie(size, incX, incY) = combi;
 
   using data_t = utils::data_storage_t<scalar_t>;

--- a/test/unittest/blas1/blas1_dot_test.cpp
+++ b/test/unittest/blas1/blas1_dot_test.cpp
@@ -30,9 +30,9 @@ using combination_t = std::tuple<int, int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int size;
-  int incX;
-  int incY;
+  index_t size;
+  index_t incX;
+  index_t incY;
   std::tie(size, incX, incY) = combi;
 
   using data_t = utils::data_storage_t<scalar_t>;

--- a/test/unittest/blas1/blas1_iamax_test.cpp
+++ b/test/unittest/blas1/blas1_iamax_test.cpp
@@ -6,8 +6,8 @@ template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
   using tuple_t = IndexValueTuple<int, scalar_t>;
 
-  int size;
-  int incX;
+  index_t size;
+  index_t incX;
   generation_mode_t mode;
   std::tie(size, incX, mode) = combi;
 

--- a/test/unittest/blas1/blas1_iamin_test.cpp
+++ b/test/unittest/blas1/blas1_iamin_test.cpp
@@ -31,8 +31,8 @@ template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
   using tuple_t = IndexValueTuple<int, scalar_t>;
 
-  int size;
-  int incX;
+  index_t size;
+  index_t incX;
   generation_mode_t mode;
   std::tie(size, incX, mode) = combi;
 

--- a/test/unittest/blas1/blas1_nrm2_test.cpp
+++ b/test/unittest/blas1/blas1_nrm2_test.cpp
@@ -30,8 +30,8 @@ using combination_t = std::tuple<int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int size;
-  int incX;
+  index_t size;
+  index_t incX;
   std::tie(size, incX) = combi;
 
   using data_t = utils::data_storage_t<scalar_t>;

--- a/test/unittest/blas1/blas1_rotg_test.cpp
+++ b/test/unittest/blas1/blas1_rotg_test.cpp
@@ -30,9 +30,9 @@ using combination_t = std::tuple<int, int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int size;
-  int incX;
-  int incY;
+  index_t size;
+  index_t incX;
+  index_t incY;
   std::tie(size, incX, incY) = combi;
 
   using data_t = utils::data_storage_t<scalar_t>;

--- a/test/unittest/blas1/blas1_scal_test.cpp
+++ b/test/unittest/blas1/blas1_scal_test.cpp
@@ -30,9 +30,9 @@ using combination_t = std::tuple<int, scalar_t, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int size;
+  index_t size;
   scalar_t alpha;
-  int incX;
+  index_t incX;
   std::tie(size, alpha, incX) = combi;
 
   using data_t = utils::data_storage_t<scalar_t>;

--- a/test/unittest/blas1/blas1_swap_test.cpp
+++ b/test/unittest/blas1/blas1_swap_test.cpp
@@ -30,9 +30,9 @@ using combination_t = std::tuple<int, int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int size;
-  int incX;
-  int incY;
+  index_t size;
+  index_t incX;
+  index_t incY;
   std::tie(size, incX, incY) = combi;
 
   using data_t = utils::data_storage_t<scalar_t>;

--- a/test/unittest/blas2/blas2_gemv_test.cpp
+++ b/test/unittest/blas2/blas2_gemv_test.cpp
@@ -30,14 +30,14 @@ using combination_t = std::tuple<int, int, T, T, bool, int, int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int m;
-  int n;
+  index_t m;
+  index_t n;
   bool trans;
   scalar_t alpha;
   scalar_t beta;
-  int incX;
-  int incY;
-  int lda_mul;
+  index_t incX;
+  index_t incY;
+  index_t lda_mul;
   std::tie(m, n, alpha, beta, trans, incX, incY, lda_mul) = combi;
 
   using data_t = utils::data_storage_t<scalar_t>;

--- a/test/unittest/blas2/blas2_ger_test.cpp
+++ b/test/unittest/blas2/blas2_ger_test.cpp
@@ -30,14 +30,14 @@ using combination_t = std::tuple<int, int, scalar_t, int, int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int m;
-  int n;
-  int lda_mul;
-  int incX;
-  int incY;
+  index_t m;
+  index_t n;
+  index_t lda_mul;
+  index_t incX;
+  index_t incY;
   scalar_t alpha;
   std::tie(m, n, alpha, incX, incY, lda_mul) = combi;
-  int lda = m * lda_mul;
+  index_t lda = m * lda_mul;
 
   using data_t = utils::data_storage_t<scalar_t>;
 

--- a/test/unittest/blas2/blas2_symv_test.cpp
+++ b/test/unittest/blas2/blas2_symv_test.cpp
@@ -30,15 +30,15 @@ using combination_t = std::tuple<char, int, scalar_t, int, int, scalar_t, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int n;
-  int lda_mul;
-  int incX;
-  int incY;
+  index_t n;
+  index_t lda_mul;
+  index_t incX;
+  index_t incY;
   char uplo;
   scalar_t alpha;
   scalar_t beta;
   std::tie(uplo, n, alpha, lda_mul, incX, beta, incY) = combi;
-  int lda = n * lda_mul;
+  index_t lda = n * lda_mul;
 
   using data_t = utils::data_storage_t<scalar_t>;
 

--- a/test/unittest/blas2/blas2_syr2_test.cpp
+++ b/test/unittest/blas2/blas2_syr2_test.cpp
@@ -30,14 +30,14 @@ using combination_t = std::tuple<char, int, scalar_t, int, int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int n;
-  int lda_mul;
-  int incX;
-  int incY;
+  index_t n;
+  index_t lda_mul;
+  index_t incX;
+  index_t incY;
   char uplo;
   scalar_t alpha;
   std::tie(uplo, n, alpha, incX, incY, lda_mul) = combi;
-  int lda = n * lda_mul;
+  index_t lda = n * lda_mul;
 
   using data_t = utils::data_storage_t<scalar_t>;
 

--- a/test/unittest/blas2/blas2_syr_test.cpp
+++ b/test/unittest/blas2/blas2_syr_test.cpp
@@ -30,13 +30,13 @@ using combination_t = std::tuple<char, int, scalar_t, int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int n;
-  int lda_mul;
-  int incX;
+  index_t n;
+  index_t lda_mul;
+  index_t incX;
   char uplo;
   scalar_t alpha;
   std::tie(uplo, n, alpha, incX, lda_mul) = combi;
-  int lda = n * lda_mul;
+  index_t lda = n * lda_mul;
 
   using data_t = utils::data_storage_t<scalar_t>;
 

--- a/test/unittest/blas2/blas2_trmv_test.cpp
+++ b/test/unittest/blas2/blas2_trmv_test.cpp
@@ -35,14 +35,14 @@ using combination_t = std::tuple<char, char, char, int, int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int n;
-  int lda_mul;
-  int incX;
+  index_t n;
+  index_t lda_mul;
+  index_t incX;
   char uplo;
   char trans;
   char diag;
   std::tie(uplo, trans, diag, n, incX, lda_mul) = combi;
-  int lda = n * lda_mul;
+  index_t lda = n * lda_mul;
 
   using data_t = utils::data_storage_t<scalar_t>;
 

--- a/test/unittest/blas3/blas3_gemm_common.hpp
+++ b/test/unittest/blas3/blas3_gemm_common.hpp
@@ -67,18 +67,18 @@ inline std::vector<scalar_t> interleaved_to_strided(
 
 template <typename scalar_t>
 inline void verify_gemm(const gemm_arguments_t<scalar_t> arguments) {
-  int offset;
-  int batch;
-  int m;
-  int n;
-  int k;
+  index_t offset;
+  index_t batch;
+  index_t m;
+  index_t n;
+  index_t k;
   char transa;
   char transb;
   scalar_t alpha;
   scalar_t beta;
-  int lda_mul;
-  int ldb_mul;
-  int ldc_mul;
+  index_t lda_mul;
+  index_t ldb_mul;
+  index_t ldc_mul;
   gemm_batch_type_t batch_type;
   std::tie(offset, batch, m, n, k, transa, transb, alpha, beta, lda_mul,
            ldb_mul, ldc_mul, batch_type) = arguments;
@@ -93,17 +93,17 @@ inline void verify_gemm(const gemm_arguments_t<scalar_t> arguments) {
 
   auto policy_handler = ex.get_policy_handler();
 
-  const int lda = ((transa != 'n') ? k : m) * lda_mul;
-  const int ldb = ((transb != 'n') ? n : k) * ldb_mul;
-  const int ldc = m * ldc_mul;
+  const index_t lda = ((transa != 'n') ? k : m) * lda_mul;
+  const index_t ldb = ((transb != 'n') ? n : k) * ldb_mul;
+  const index_t ldc = m * ldc_mul;
 
-  const int size_a = m * k * lda_mul;
-  const int size_b = k * n * ldb_mul;
-  const int size_c = m * n * ldc_mul;
+  const index_t size_a = m * k * lda_mul;
+  const index_t size_b = k * n * ldb_mul;
+  const index_t size_c = m * n * ldc_mul;
 
-  const int buffer_size_a = batch * size_a + offset;
-  const int buffer_size_b = batch * size_b + offset;
-  const int buffer_size_c = batch * size_c + offset;
+  const index_t buffer_size_a = batch * size_a + offset;
+  const index_t buffer_size_b = batch * size_b + offset;
+  const index_t buffer_size_c = batch * size_c + offset;
 
   std::vector<data_t> a_m(buffer_size_a);
   std::vector<data_t> b_m(buffer_size_b);

--- a/test/unittest/blas3/blas3_trsm_test.cpp
+++ b/test/unittest/blas3/blas3_trsm_test.cpp
@@ -29,8 +29,8 @@ using combination_t = std::tuple<int, int, char, char, char, char, scalar_t,
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
-  int m;
-  int n;
+  index_t m;
+  index_t n;
   char trans;
   char side;
   char diag;
@@ -44,8 +44,8 @@ void run_test(const combination_t<scalar_t> combi) {
 
   using data_t = utils::data_storage_t<scalar_t>;
 
-  const int lda = (side == 'l' ? m : n) * ldaMul;
-  const int ldb = m * ldbMul;
+  const index_t lda = (side == 'l' ? m : n) * ldaMul;
+  const index_t ldb = m * ldbMul;
   const int k = side == 'l' ? m : n;
 
   const int sizeA = k * lda;


### PR DESCRIPTION
SYCL-BLAS requires minor modifications to compile using `int64_t` as an index type.  Additionally, the tests and benchmarks require minor modifications.

* Fixes issues for using `int64_t` as an index type.
* Updates benchmarks and tests to test using chosen index type.
  * Fix test name issue when using `cl::sycl::half` or `double`.
* Introduces `BLAS_INDEX_TYPES` cmake variable
* Documents `BLAS_INDEX_TYPES` and `BLAS_DATA_TYPES` in README.