### PR TITLE
[trsm] Assume 1 on diagonal when unit diagonal is set

### DIFF
--- a/src/interface/trsm_interface.hpp
+++ b/src/interface/trsm_interface.hpp
@@ -41,7 +41,8 @@ namespace internal {
  * @param uplo Indicates if A is lower or upper triangular
  * @param trans Indicates the form that the matrix A will take in the
  * multiplication
- * @param diag Indicates if A has a unit or non-unit diagonal
+ * @param diag Indicates if A has a non-unit diagonal or is assumed to be
+ *             unit diagonal.
  * @param M The number of rows of matrix B, must be at least 1
  * @param N The number of columns of B, must be at least 1
  * @param alpha The scalar alpha that is applied to B

--- a/test/unittest/blas3/blas3_trsm_test.cpp
+++ b/test/unittest/blas3/blas3_trsm_test.cpp
@@ -53,10 +53,11 @@ void run_test(const combination_t<scalar_t> combi) {
   std::vector<scalar_t> B(sizeB);
   std::vector<scalar_t> cpu_B(sizeB);
 
-  const scalar_t diagValue =
-      diag == 'u' ? scalar_t{1} : random_scalar(scalar_t{1}, scalar_t{10});
+  // If the matrix is unit-diagonal, the diagonal value should be assumed = 1
+  // by trsm.
+  const scalar_t diagValue = random_scalar(scalar_t{1}, scalar_t{10});
 
-  fill_trsm_matrix(A, k, lda, uplo, diagValue,
+  fill_trsm_matrix(A, k, lda, uplo, diag, diagValue,
                    static_cast<scalar_t>(unusedValue));
   fill_random(B);
 


### PR DESCRIPTION
Fixes: https://github.com/codeplaysoftware/sycl-blas/issues/368

* Takes values on the diagonal to equal 1, even if this isn't actually the case in argument matrix.
* Adjusts tests:
  * To have non-1 values on diagonal, even if unit diagonal.
  * To construct similar matrices in for both upper and lower triangular.
  * To construct trsm arg matrices with for unit diag.

Test locally on Intel iGPU with single precision compiled with DPC++2022-10-06, and using the open-source OneMKL library's test suite compiled with DPC++2022-06-25.