### PR TITLE
Test synchronous api for relevant operations

### DIFF
--- a/src/interface/blas1_interface.hpp
+++ b/src/interface/blas1_interface.hpp
@@ -593,7 +593,9 @@ typename ValueType<container_0_t>::type _dot(sb_handle_t &sb_handle, index_t _N,
   auto res = std::vector<element_t>(1);
   auto gpu_res = make_sycl_iterator_buffer<element_t>(static_cast<index_t>(1));
   blas::internal::_dot(sb_handle, _N, _vx, _incx, _vy, _incy, gpu_res);
-  blas::helper::copy_to_host(sb_handle.get_queue(), gpu_res, res.data(), 1);
+  auto event =
+      blas::helper::copy_to_host(sb_handle.get_queue(), gpu_res, res.data(), 1);
+  sb_handle.wait(event);
   return res[0];
 }
 
@@ -649,7 +651,9 @@ index_t _iamax(sb_handle_t &sb_handle, index_t _N, container_t _vx,
   auto gpu_res =
       make_sycl_iterator_buffer<IndValTuple>(static_cast<index_t>(1));
   blas::internal::_iamax(sb_handle, _N, _vx, _incx, gpu_res);
-  blas::helper::copy_to_host(sb_handle.get_queue(), gpu_res, rsT.data(), 1);
+  auto event =
+      blas::helper::copy_to_host(sb_handle.get_queue(), gpu_res, rsT.data(), 1);
+  sb_handle.wait(event);
   return rsT[0].get_index();
 }
 
@@ -668,7 +672,9 @@ index_t _iamin(sb_handle_t &sb_handle, index_t _N, container_t _vx,
   auto gpu_res =
       make_sycl_iterator_buffer<IndValTuple>(static_cast<index_t>(1));
   blas::internal::_iamin(sb_handle, _N, _vx, _incx, gpu_res);
-  blas::helper::copy_to_host(sb_handle.get_queue(), gpu_res, rsT.data(), 1);
+  auto event =
+      blas::helper::copy_to_host(sb_handle.get_queue(), gpu_res, rsT.data(), 1);
+  sb_handle.wait(event);
   return rsT[0].get_index();
 }
 
@@ -688,7 +694,9 @@ typename ValueType<container_t>::type _asum(sb_handle_t &sb_handle, index_t _N,
   auto res = std::vector<element_t>(1, element_t(0));
   auto gpu_res = make_sycl_iterator_buffer<element_t>(static_cast<index_t>(1));
   blas::internal::_asum(sb_handle, _N, _vx, _incx, gpu_res);
-  blas::helper::copy_to_host(sb_handle.get_queue(), gpu_res, res.data(), 1);
+  auto event =
+      blas::helper::copy_to_host(sb_handle.get_queue(), gpu_res, res.data(), 1);
+  sb_handle.wait(event);
   return res[0];
 }
 
@@ -708,7 +716,9 @@ typename ValueType<container_t>::type _nrm2(sb_handle_t &sb_handle, index_t _N,
   auto res = std::vector<element_t>(1, element_t(0));
   auto gpu_res = make_sycl_iterator_buffer<element_t>(static_cast<index_t>(1));
   blas::internal::_nrm2(sb_handle, _N, _vx, _incx, gpu_res);
-  blas::helper::copy_to_host(sb_handle.get_queue(), gpu_res, res.data(), 1);
+  auto event =
+      blas::helper::copy_to_host(sb_handle.get_queue(), gpu_res, res.data(), 1);
+  sb_handle.wait(event);
   return res[0];
 }
 

--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -254,18 +254,17 @@ struct dump_arg_helper<cl::sycl::half> {
 };
 
 /**
- * Return type of the tested api (either asynchronous (event) or
- * synchronous(result))
+ * Type of the tested api
  */
-enum class api_type : int { event = 0, result = 1 };
+enum class api_type : int { async = 0, sync = 1 };
 
 template <>
 struct dump_arg_helper<api_type> {
   inline void operator()(std::ostream &ss, const api_type &type) {
-    if (type == api_type::event) {
-      ss << "event";
+    if (type == api_type::async) {
+      ss << "async";
     } else {
-      ss << "result";
+      ss << "sync";
     }
   }
 };

--- a/test/unittest/blas1/blas1_iamax_test.cpp
+++ b/test/unittest/blas1/blas1_iamax_test.cpp
@@ -6,10 +6,11 @@ template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
   using tuple_t = IndexValueTuple<int, scalar_t>;
 
+  api_type api;
   index_t size;
   index_t incX;
   generation_mode_t mode;
-  std::tie(size, incX, mode) = combi;
+  std::tie(api, size, incX, mode) = combi;
 
   // Input vector
   std::vector<scalar_t> x_v(size * incX);
@@ -31,24 +32,20 @@ void run_test(const combination_t<scalar_t> combi) {
   blas::SB_Handle sb_handle(q);
 
   // Iterators
-  auto gpu_x_v = blas::make_sycl_iterator_buffer<scalar_t>(int(size * incX));
-  blas::helper::copy_to_device(sb_handle.get_queue(), x_v.data(), gpu_x_v,
-                               size * incX);
-  auto gpu_out_s = blas::make_sycl_iterator_buffer<tuple_t>(int(1));
-  blas::helper::copy_to_device(sb_handle.get_queue(), &out_s, gpu_out_s, 1);
+  auto gpu_x_v = blas::make_sycl_iterator_buffer<scalar_t>(x_v, size * incX);
 
-  _iamax(sb_handle, size, gpu_x_v, incX, gpu_out_s);
-  auto event =
-      blas::helper::copy_to_host(sb_handle.get_queue(), gpu_out_s, &out_s, 1);
-  sb_handle.wait(event);
-
-  using data_tuple_t = IndexValueTuple<int, scalar_t>;
-  data_tuple_t out_data_s{out_s.ind, static_cast<scalar_t>(out_s.val)};
+  if (api == api_type::async) {
+    auto gpu_out_s = blas::make_sycl_iterator_buffer<tuple_t>(&out_s, 1);
+    _iamax(sb_handle, size, gpu_x_v, incX, gpu_out_s);
+    auto event =
+        blas::helper::copy_to_host(sb_handle.get_queue(), gpu_out_s, &out_s, 1);
+    sb_handle.wait(event);
+  } else {
+    out_s.ind = _iamax(sb_handle, size, gpu_x_v, incX);
+  }
 
   // Validate the result
-  ASSERT_EQ(out_cpu_s, out_data_s.ind);
-  ASSERT_EQ(x_v[out_data_s.ind * incX], out_data_s.val);
-  ASSERT_EQ(x_v[out_cpu_s * incX], out_data_s.val);
+  ASSERT_EQ(out_cpu_s, out_s.ind);
 }
 
 BLAS_REGISTER_TEST_ALL(Iamax, combination_t, combi, generate_name);

--- a/test/unittest/blas1/blas1_iamin_test.cpp
+++ b/test/unittest/blas1/blas1_iamin_test.cpp
@@ -31,10 +31,11 @@ template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
   using tuple_t = IndexValueTuple<int, scalar_t>;
 
+  api_type api;
   index_t size;
   index_t incX;
   generation_mode_t mode;
-  std::tie(size, incX, mode) = combi;
+  std::tie(api, size, incX, mode) = combi;
 
   const scalar_t max = std::numeric_limits<scalar_t>::max();
 
@@ -65,21 +66,19 @@ void run_test(const combination_t<scalar_t> combi) {
 
   // Iterators
   auto gpu_x_v = blas::make_sycl_iterator_buffer<scalar_t>(x_v, size * incX);
-  auto gpu_out_s = blas::make_sycl_iterator_buffer<tuple_t>(int(1));
-  blas::helper::copy_to_device(sb_handle.get_queue(), &out_s, gpu_out_s, 1);
 
-  _iamin(sb_handle, size, gpu_x_v, incX, gpu_out_s);
-  auto event =
-      blas::helper::copy_to_host(sb_handle.get_queue(), gpu_out_s, &out_s, 1);
-  sb_handle.wait(event);
-
-  using data_tuple_t = IndexValueTuple<int, scalar_t>;
-  data_tuple_t out_data_s{out_s.ind, static_cast<scalar_t>(out_s.val)};
+  if (api == api_type::async) {
+    auto gpu_out_s = blas::make_sycl_iterator_buffer<tuple_t>(&out_s, 1);
+    _iamin(sb_handle, size, gpu_x_v, incX, gpu_out_s);
+    auto event = blas::helper::copy_to_host(sb_handle.get_queue(), gpu_out_s,
+                                            &out_s, 1);
+    sb_handle.wait(event);
+  } else {
+    out_s.ind = _iamin(sb_handle, size, gpu_x_v, incX);
+  }
 
   // Validate the result
-  ASSERT_EQ(out_cpu_s, out_data_s.ind);
-  ASSERT_EQ(x_v[out_data_s.ind * incX], out_data_s.val);
-  ASSERT_EQ(x_v[out_cpu_s * incX], out_data_s.val);
+  ASSERT_EQ(out_cpu_s, out_s.ind);
 }
 
 BLAS_REGISTER_TEST_ALL(Iamin, combination_t, combi, generate_name);

--- a/test/unittest/blas1/blas1_iaminmax_common.hpp
+++ b/test/unittest/blas1/blas1_iaminmax_common.hpp
@@ -36,7 +36,7 @@ enum class generation_mode_t : char {
 };
 
 template <typename scalar_t>
-using combination_t = std::tuple<int, int, generation_mode_t>;
+using combination_t = std::tuple<api_type, int, int, generation_mode_t>;
 
 template <typename scalar_t>
 void populate_data(generation_mode_t mode, scalar_t limit,
@@ -64,16 +64,18 @@ void populate_data(generation_mode_t mode, scalar_t limit,
 #ifdef STRESS_TESTING
 template <typename scalar_t>
 const auto combi = ::testing::Combine(
-    ::testing::Values(11, 65, 10000, 1002400),  // size
-    ::testing::Values(1, 5),                    // incX
+    ::testing::Values(api_type::async, api_type::sync),  // Api
+    ::testing::Values(11, 65, 10000, 1002400),           // size
+    ::testing::Values(1, 5),                             // incX
     ::testing::Values(generation_mode_t::Random, generation_mode_t::Limit,
                       generation_mode_t::Incrementing,
                       generation_mode_t::Decrementing));
 #else
 template <typename scalar_t>
 const auto combi = ::testing::Combine(
-    ::testing::Values(11, 65, 1000000),  // size
-    ::testing::Values(5),                // incX
+    ::testing::Values(api_type::async, api_type::sync),  // Api
+    ::testing::Values(11, 65, 1000000),                  // size
+    ::testing::Values(5),                                // incX
     ::testing::Values(generation_mode_t::Random, generation_mode_t::Limit,
                       generation_mode_t::Incrementing,
                       generation_mode_t::Decrementing));
@@ -88,9 +90,10 @@ inline void dump_arg<generation_mode_t>(std::ostream &ss,
 template <class T>
 static std::string generate_name(
     const ::testing::TestParamInfo<combination_t<T>> &info) {
+  api_type api;
   int size, incX;
   generation_mode_t mode;
-  BLAS_GENERATE_NAME(info.param, size, incX, mode);
+  BLAS_GENERATE_NAME(info.param, api, size, incX, mode);
 }
 
 #endif

--- a/test/unittest/blas1/blas1_nrm2_test.cpp
+++ b/test/unittest/blas1/blas1_nrm2_test.cpp
@@ -26,20 +26,21 @@
 #include "blas_test.hpp"
 
 template <typename scalar_t>
-using combination_t = std::tuple<int, int>;
+using combination_t = std::tuple<api_type, int, int>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
+  api_type api;
   index_t size;
   index_t incX;
-  std::tie(size, incX) = combi;
+  std::tie(api, size, incX) = combi;
 
   // Input vectors
   std::vector<scalar_t> x_v(size * incX);
   fill_random(x_v);
 
-  // Output vector
-  std::vector<scalar_t> out_s(1, 10.0);
+  // Output scalar
+  scalar_t out_s = 10.0;
 
   // Reference implementation
   auto out_cpu_s = reference_blas::nrm2(size, x_v.data(), incX);
@@ -50,28 +51,35 @@ void run_test(const combination_t<scalar_t> combi) {
 
   // Iterators
   auto gpu_x_v = blas::make_sycl_iterator_buffer<scalar_t>(x_v, size * incX);
-  auto gpu_out_s = blas::make_sycl_iterator_buffer<scalar_t>(out_s, 1);
 
-  _nrm2(sb_handle, size, gpu_x_v, incX, gpu_out_s);
-  auto event = blas::helper::copy_to_host(sb_handle.get_queue(), gpu_out_s,
-                                          out_s.data(), 1);
-  sb_handle.wait(event);
+  if (api == api_type::async) {
+    auto gpu_out_s = blas::make_sycl_iterator_buffer<scalar_t>(&out_s, 1);
+    _nrm2(sb_handle, size, gpu_x_v, incX, gpu_out_s);
+    auto event =
+        blas::helper::copy_to_host(sb_handle.get_queue(), gpu_out_s, &out_s, 1);
+    sb_handle.wait(event);
+  } else {
+    out_s = _nrm2(sb_handle, size, gpu_x_v, incX);
+  }
 
   // Validate the result
-  const bool isAlmostEqual = utils::almost_equal(out_s[0], out_cpu_s);
+  const bool isAlmostEqual = utils::almost_equal(out_s, out_cpu_s);
   ASSERT_TRUE(isAlmostEqual);
 }
 
 template <typename scalar_t>
-const auto combi = ::testing::Combine(::testing::Values(11, 1002),  // size
+const auto combi = ::testing::Combine(::testing::Values(api_type::async,
+                                                        api_type::sync),  // Api
+                                      ::testing::Values(11, 1002),  // size
                                       ::testing::Values(1, 4)       // incX
 );
 
 template <class T>
 static std::string generate_name(
     const ::testing::TestParamInfo<combination_t<T>>& info) {
+  api_type api;
   int size, incX;
-  BLAS_GENERATE_NAME(info.param, size, incX);
+  BLAS_GENERATE_NAME(info.param, api, size, incX);
 }
 
 BLAS_REGISTER_TEST_ALL(Nrm2, combination_t, combi, generate_name);

--- a/test/unittest/blas1/blas1_rotg_test.cpp
+++ b/test/unittest/blas1/blas1_rotg_test.cpp
@@ -49,7 +49,7 @@ void run_test(const combination_t<scalar_t> combi) {
   scalar_t s;
   scalar_t a = a_input;
   scalar_t b = b_input;
-  if (api == api_type::event) {
+  if (api == api_type::async) {
     auto device_a = blas::make_sycl_iterator_buffer<scalar_t>(&a_input, 1);
     auto device_b = blas::make_sycl_iterator_buffer<scalar_t>(&b_input, 1);
     auto device_c = blas::make_sycl_iterator_buffer<scalar_t>(1);
@@ -77,15 +77,15 @@ void run_test(const combination_t<scalar_t> combi) {
     return;
   }
 
-  const bool isAlmostEqual =
-      utils::almost_equal(a, a_ref) && utils::almost_equal(b, b_ref) &&
-      utils::almost_equal(c, c_ref) && utils::almost_equal(s, s_ref);
-  ASSERT_TRUE(isAlmostEqual);
+  ASSERT_TRUE(utils::almost_equal(a, a_ref));
+  ASSERT_TRUE(utils::almost_equal(b, b_ref));
+  ASSERT_TRUE(utils::almost_equal(c, c_ref));
+  ASSERT_TRUE(utils::almost_equal(s, s_ref));
 }
 
 template <typename scalar_t>
 const auto combi = ::testing::Combine(
-    ::testing::Values(api_type::event, api_type::result),  // Api
+    ::testing::Values(api_type::async, api_type::sync),  // Api
     ::testing::Values<scalar_t>(0, 2.5, -7.3,
                                 std::numeric_limits<scalar_t>::max()),  // a
     ::testing::Values<scalar_t>(0, 0.5, -4.3,


### PR DESCRIPTION
* Add missing waits for synchronous operations.
* Change iamax and iamin tests to only verify the index value as the synchronous version and OneMKL only return the index.