### PR TITLE
Disable failing expression tests when using DPC++

### DIFF
--- a/test/exprtest/CMakeLists.txt
+++ b/test/exprtest/CMakeLists.txt
@@ -31,10 +31,9 @@ set(SYCL_EXPRTEST_SRCS
 )
 
 # Temporary disabling the following tests for Intel DPC++ as currently Intel compiler crashes while running the following tests
+# https://github.com/intel/llvm/issues/7075
 if(is_computecpp)
-  set(SYCL_EXPRTEST_SRCS
-    ${SYCLBLAS_EXPRTEST}/collapse_nested_tuple.cpp
-  )
+  list(APPEND SYCL_EXPRTEST_SRCS "${SYCLBLAS_EXPRTEST}/collapse_nested_tuple.cpp")
 endif()
 
 foreach(blas_test ${SYCL_EXPRTEST_SRCS})

--- a/test/exprtest/CMakeLists.txt
+++ b/test/exprtest/CMakeLists.txt
@@ -28,8 +28,14 @@ set(SYCLBLAS_EXPRTEST ${CMAKE_CURRENT_SOURCE_DIR})
 set(SYCL_EXPRTEST_SRCS
   ${SYCLBLAS_EXPRTEST}/blas1_scal_asum_test.cpp
   ${SYCLBLAS_EXPRTEST}/blas1_axpy_copy_test.cpp
-  ${SYCLBLAS_EXPRTEST}/collapse_nested_tuple.cpp
 )
+
+# Temporary disabling the following tests for Intel DPC++ as currently Intel compiler crashes while running the following tests
+if(is_computecpp)
+  set(SYCL_EXPRTEST_SRCS
+    ${SYCLBLAS_EXPRTEST}/collapse_nested_tuple.cpp
+  )
+endif()
 
 foreach(blas_test ${SYCL_EXPRTEST_SRCS})
   get_filename_component(test_exec ${blas_test} NAME_WE)


### PR DESCRIPTION
The expression tests are currently crashing when using the DPC++ compiler.
The issue is being tracked [here](https://github.com/intel/llvm/issues/7075). 
Disabling the tests when using DPC++ for now. 