### PR TITLE
Add SBMV baseline implementation

### DIFF
--- a/benchmark/clBench/clblast/CMakeLists.txt
+++ b/benchmark/clBench/clblast/CMakeLists.txt
@@ -16,6 +16,7 @@ set(sources
   # Level 2 blas
   blas2/gbmv.cpp
   blas2/gemv.cpp
+  blas2/sbmv.cpp
   # Level 3 blas
   blas3/gemm.cpp
   blas3/gemm_batched.cpp

--- a/benchmark/clBench/clblast/blas2/gbmv.cpp
+++ b/benchmark/clBench/clblast/blas2/gbmv.cpp
@@ -1,7 +1,7 @@
 /**************************************************************************
  *
  *  @license
- *  Copyright (C) 2022 Codeplay Software Limited
+ *  Copyright (C) Codeplay Software Limited
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at

--- a/benchmark/clBench/clblast/blas2/sbmv.cpp
+++ b/benchmark/clBench/clblast/blas2/sbmv.cpp
@@ -1,7 +1,7 @@
 /**************************************************************************
  *
  *  @license
- *  Copyright (C) 2022 Codeplay Software Limited
+ *  Copyright (C) 2023 Codeplay Software Limited
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -19,52 +19,43 @@
  *
  *  SYCL-BLAS: BLAS implementation using SYCL
  *
- *  @filename gbmv.cpp
+ *  @filename sbmv.cpp
  *
  **************************************************************************/
 
 #include "../utils.hpp"
 
 template <typename scalar_t>
-std::string get_name(std::string t, int m, int n, int kl, int ku) {
+std::string get_name(std::string uplo, int n, int k) {
   std::ostringstream str{};
-  str << "BM_Gbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n << "/" << kl << "/" << ku;
+  str << "BM_Sbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n << "/" << k;
   return str.str();
 }
 
 template <typename scalar_t>
-void run(benchmark::State& state, ExecutorType* executorPtr, int ti, index_t m,
-         index_t n, index_t kl, index_t ku, scalar_t alpha, scalar_t beta,
-         bool* success) {
+void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
+         index_t n, index_t k, scalar_t alpha, scalar_t beta, bool* success) {
   // Standard test setup.
-  std::string ts = blas_benchmark::utils::from_transpose_enum(
-      static_cast<blas_benchmark::utils::Transposition>(ti));
-  const char* t_str = ts.c_str();
+  const char* uplo_str = uplo.c_str();
 
-  index_t xlen = t_str[0] == 'n' ? n : m;
-  index_t ylen = t_str[0] == 'n' ? m : n;
+  index_t xlen = n;
+  index_t ylen = n;
 
-  index_t lda = (kl + ku + 1);
+  index_t lda = (k + 1);
   index_t incX = 1;
   index_t incY = 1;
 
-  // The counters are double. We convert m and n to double to avoid
+  // The counters are double. We convert n to double to avoid
   // integer overflows for n_fl_ops and bytes_processed
-  double m_d = static_cast<double>(m);
   double n_d = static_cast<double>(n);
-  double kl_d = static_cast<double>(kl);
-  double ku_d = static_cast<double>(ku);
+  double k_d = static_cast<double>(k);
 
-  state.counters["m"] = m_d;
   state.counters["n"] = n_d;
-  state.counters["kl"] = kl_d;
-  state.counters["ku"] = ku_d;
+  state.counters["k"] = k_d;
 
   // Compute the number of A non-zero elements.
-  const double A_validVal =
-      (t_str[0] == 'n' ? n_d : m_d) * (kl_d + ku_d + 1.0) -
-      0.5 * (kl_d * (kl_d + 1.0)) - 0.5 * (ku_d * (ku_d + 1.0));
+  const double A_validVal = (n_d * (2.0 * k_d + 1.0)) - (k_d * (k_d + 1.0));
 
   {
     double nflops_AtimesX = 2.0 * A_validVal;
@@ -92,9 +83,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int ti, index_t m,
   std::vector<scalar_t> v_y =
       blas_benchmark::utils::random_data<scalar_t>(ylen);
 
-  // Specify the transposition.
-  clblast::Transpose a_tr =
-      blas_benchmark::utils::translate_transposition(t_str);
+  // Specify the triangle.
+  clblast::Triangle a_tr = blas_benchmark::utils::translate_triangle(uplo_str);
 
   // Specify the layout.
   auto layout = clblast::Layout::kColMajor;
@@ -109,17 +99,16 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int ti, index_t m,
 #ifdef BLAS_VERIFY_BENCHMARK
   // Run a first time with a verification of the results
   std::vector<scalar_t> v_y_ref = v_y;
-  reference_blas::gbmv(t_str, m, n, kl, ku, alpha, m_a.data(), lda, v_x.data(),
-                       incX, beta, v_y_ref.data(), incY);
+  reference_blas::sbmv(uplo_str, n, k, alpha, m_a.data(), lda, v_x.data(), incX,
+                       beta, v_y_ref.data(), incY);
   std::vector<scalar_t> v_y_temp = v_y;
   {
     MemBuffer<scalar_t> v_y_temp_gpu(executorPtr, v_y_temp.data(),
                                      static_cast<size_t>(ylen));
     cl_event event;
-    clblast::Gbmv<scalar_t>(layout, a_tr, m, n, kl, ku, alpha, m_a_gpu.dev(), 0,
-                            lda, v_x_gpu.dev(), 0, incX, beta,
-                            v_y_temp_gpu.dev(), 0, incY, executorPtr->_queue(),
-                            &event);
+    clblast::Sbmv<scalar_t>(layout, a_tr, n, k, alpha, m_a_gpu.dev(), 0, lda,
+                            v_x_gpu.dev(), 0, incX, beta, v_y_temp_gpu.dev(), 0,
+                            incY, executorPtr->_queue(), &event);
     CLEventHandler::wait(event);
   }
 
@@ -128,13 +117,13 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int ti, index_t m,
     const std::string& err_str = err_stream.str();
     state.SkipWithError(err_str.c_str());
     *success = false;
-  }
+  };
 #endif
 
   auto blas_method_def = [&]() -> std::vector<cl_event> {
     cl_event event;
-    clblast::Gbmv<scalar_t>(layout, a_tr, m, n, kl, ku, alpha, m_a_gpu.dev(), 0,
-                            lda, v_x_gpu.dev(), 0, incX, beta, v_y_gpu.dev(), 0,
+    clblast::Sbmv<scalar_t>(layout, a_tr, n, k, alpha, m_a_gpu.dev(), 0, lda,
+                            v_x_gpu.dev(), 0, incX, beta, v_y_gpu.dev(), 0,
                             incY, executorPtr->_queue(), &event);
     CLEventHandler::wait(event);
     return {event};
@@ -161,22 +150,21 @@ void run(benchmark::State& state, ExecutorType* executorPtr, int ti, index_t m,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
                         bool* success) {
-  auto gbmv_params = blas_benchmark::utils::get_gbmv_params<scalar_t>(args);
+  auto sbmv_params = blas_benchmark::utils::get_sbmv_params<scalar_t>(args);
 
-  for (auto p : gbmv_params) {
-    std::string ts;
-    index_t m, n, kl, ku;
+  for (auto p : sbmv_params) {
+    std::string uplos;
+    index_t n, k;
     scalar_t alpha, beta;
-    std::tie(ts, m, n, kl, ku, alpha, beta) = p;
-    int t = static_cast<int>(blas_benchmark::utils::to_transpose_enum(ts));
+    std::tie(uplos, n, k, alpha, beta) = p;
 
-    auto BM_lambda = [&](benchmark::State& st, ExecutorType* exPtr, int t,
-                         index_t m, index_t n, index_t kl, index_t ku,
+    auto BM_lambda = [&](benchmark::State& st, ExecutorType* exPtr,
+                         std::string uplos, index_t n, index_t k,
                          scalar_t alpha, scalar_t beta, bool* success) {
-      run<scalar_t>(st, exPtr, t, m, n, kl, ku, alpha, beta, success);
+      run<scalar_t>(st, exPtr, uplos, n, k, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n, kl, ku).c_str(),
-                                 BM_lambda, exPtr, t, m, n, kl, ku, alpha, beta,
+    benchmark::RegisterBenchmark(get_name<scalar_t>(uplos, n, k).c_str(),
+                                 BM_lambda, exPtr, uplos, n, k, alpha, beta,
                                  success);
   }
 }

--- a/benchmark/clBench/clblast/blas2/sbmv.cpp
+++ b/benchmark/clBench/clblast/blas2/sbmv.cpp
@@ -1,7 +1,7 @@
 /**************************************************************************
  *
  *  @license
- *  Copyright (C) 2023 Codeplay Software Limited
+ *  Copyright (C) Codeplay Software Limited
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at

--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -18,6 +18,7 @@ set(sources
   # Level 2 blas
   blas2/gbmv.cpp
   blas2/gemv.cpp
+  blas2/sbmv.cpp
   # Level 3 blas
   blas3/gemm.cpp
   blas3/gemm_batched.cpp

--- a/benchmark/syclblas/blas2/gbmv.cpp
+++ b/benchmark/syclblas/blas2/gbmv.cpp
@@ -1,7 +1,7 @@
 /**************************************************************************
  *
  *  @license
- *  Copyright (C) 2022 Codeplay Software Limited
+ *  Copyright (C) Codeplay Software Limited
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at

--- a/benchmark/syclblas/blas2/sbmv.cpp
+++ b/benchmark/syclblas/blas2/sbmv.cpp
@@ -1,7 +1,7 @@
 /**************************************************************************
  *
  *  @license
- *  Copyright (C) 2022 Codeplay Software Limited
+ *  Copyright (C) 2023 Codeplay Software Limited
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -19,52 +19,44 @@
  *
  *  SYCL-BLAS: BLAS implementation using SYCL
  *
- *  @filename gbmv.cpp
+ *  @filename sbmv.cpp
  *
  **************************************************************************/
 
 #include "../utils.hpp"
 
 template <typename scalar_t>
-std::string get_name(std::string t, int m, int n, int kl, int ku) {
+std::string get_name(std::string uplo, int n, int k) {
   std::ostringstream str{};
-  str << "BM_Gbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n << "/" << kl << "/" << ku;
+  str << "BM_Sbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n << "/" << k;
   return str.str();
 }
 
 template <typename scalar_t>
-void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int ti,
-         index_t m, index_t n, index_t kl, index_t ku, scalar_t alpha,
-         scalar_t beta, bool* success) {
+void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
+         std::string uplo, index_t n, index_t k, scalar_t alpha, scalar_t beta,
+         bool* success) {
   // Standard test setup.
-  std::string ts = blas_benchmark::utils::from_transpose_enum(
-      static_cast<blas_benchmark::utils::Transposition>(ti));
-  const char* t_str = ts.c_str();
+  const char* uplo_str = uplo.c_str();
 
-  index_t xlen = t_str[0] == 'n' ? n : m;
-  index_t ylen = t_str[0] == 'n' ? m : n;
+  index_t xlen = n;
+  index_t ylen = n;
 
-  index_t lda = (kl + ku + 1);
+  index_t lda = (k + 1);
   index_t incX = 1;
   index_t incY = 1;
 
-  // The counters are double. We convert m and n to double to avoid
+  // The counters are double. We convert n to double to avoid
   // integer overflows for n_fl_ops and bytes_processed
-  double m_d = static_cast<double>(m);
   double n_d = static_cast<double>(n);
-  double kl_d = static_cast<double>(kl);
-  double ku_d = static_cast<double>(ku);
+  double k_d = static_cast<double>(k);
 
-  state.counters["m"] = m_d;
   state.counters["n"] = n_d;
-  state.counters["kl"] = kl_d;
-  state.counters["ku"] = ku_d;
+  state.counters["k"] = k_d;
 
   // Compute the number of A non-zero elements.
-  const double A_validVal =
-      (t_str[0] == 'n' ? n_d : m_d) * (kl_d + ku_d + 1.0) -
-      0.5 * (kl_d * (kl_d + 1.0)) - 0.5 * (ku_d * (ku_d + 1.0));
+  const double A_validVal = (n_d * (2.0 * k_d + 1.0)) - (k_d * (k_d + 1.0));
 
   {
     double nflops_AtimesX = 2.0 * A_validVal;
@@ -99,14 +91,14 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int ti,
 #ifdef BLAS_VERIFY_BENCHMARK
   // Run a first time with a verification of the results
   std::vector<scalar_t> v_y_ref = v_y;
-  reference_blas::gbmv(t_str, m, n, kl, ku, alpha, m_a.data(), lda, v_x.data(),
-                       incX, beta, v_y_ref.data(), incY);
+  reference_blas::sbmv(uplo_str, n, k, alpha, m_a.data(), lda, v_x.data(), incX,
+                       beta, v_y_ref.data(), incY);
   std::vector<scalar_t> v_y_temp = v_y;
   {
     auto v_y_temp_gpu =
         blas::make_sycl_iterator_buffer<scalar_t>(v_y_temp, ylen);
-    auto event = _gbmv(sb_handle, *t_str, m, n, kl, ku, alpha, m_a_gpu, lda,
-                       v_x_gpu, incX, beta, v_y_temp_gpu, incY);
+    auto event = _sbmv(sb_handle, *uplo_str, n, k, alpha, m_a_gpu, lda, v_x_gpu,
+                       incX, beta, v_y_temp_gpu, incY);
     sb_handle.wait();
   }
 
@@ -119,8 +111,8 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int ti,
 #endif
 
   auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
-    auto event = _gbmv(sb_handle, *t_str, m, n, kl, ku, alpha, m_a_gpu, lda,
-                       v_x_gpu, incX, beta, v_y_gpu, incY);
+    auto event = _sbmv(sb_handle, *uplo_str, n, k, alpha, m_a_gpu, lda, v_x_gpu,
+                       incX, beta, v_y_gpu, incY);
     sb_handle.wait(event);
     return event;
   };
@@ -147,23 +139,22 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int ti,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         blas::SB_Handle* sb_handle_ptr, bool* success) {
-  auto gbmv_params = blas_benchmark::utils::get_gbmv_params<scalar_t>(args);
+  auto sbmv_params = blas_benchmark::utils::get_sbmv_params<scalar_t>(args);
 
-  for (auto p : gbmv_params) {
-    std::string ts;
-    index_t m, n, kl, ku;
+  for (auto p : sbmv_params) {
+    std::string uplos;
+    index_t n, k;
     scalar_t alpha, beta;
-    std::tie(ts, m, n, kl, ku, alpha, beta) = p;
-    int t = static_cast<int>(blas_benchmark::utils::to_transpose_enum(ts));
+    std::tie(uplos, n, k, alpha, beta) = p;
 
     auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
-                         int t, index_t m, index_t n, index_t kl, index_t ku,
+                         std::string uplos, index_t n, index_t k,
                          scalar_t alpha, scalar_t beta, bool* success) {
-      run<scalar_t>(st, sb_handle_ptr, t, m, n, kl, ku, alpha, beta, success);
+      run<scalar_t>(st, sb_handle_ptr, uplos, n, k, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n, kl, ku).c_str(),
-                                 BM_lambda, sb_handle_ptr, t, m, n, kl, ku,
-                                 alpha, beta, success);
+    benchmark::RegisterBenchmark(get_name<scalar_t>(uplos, n, k).c_str(),
+                                 BM_lambda, sb_handle_ptr, uplos, n, k, alpha,
+                                 beta, success);
   }
 }
 

--- a/benchmark/syclblas/blas2/sbmv.cpp
+++ b/benchmark/syclblas/blas2/sbmv.cpp
@@ -1,7 +1,7 @@
 /**************************************************************************
  *
  *  @license
- *  Copyright (C) 2023 Codeplay Software Limited
+ *  Copyright (C) Codeplay Software Limited
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -884,6 +884,7 @@ function (build_library LIB_NAME ENABLE_EXTENSIONS)
                 $<TARGET_OBJECTS:gbmv>
                 $<TARGET_OBJECTS:gemv>
                 $<TARGET_OBJECTS:ger>
+                $<TARGET_OBJECTS:sbmv>
                 $<TARGET_OBJECTS:symv>
                 $<TARGET_OBJECTS:syr>
                 $<TARGET_OBJECTS:syr2>

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -48,6 +48,10 @@ template <typename scalar_t>
 using gbmv_param_t = std::tuple<std::string, index_t, index_t, index_t, index_t,
                                 scalar_t, scalar_t>;
 
+template <typename scalar_t>
+using sbmv_param_t =
+    std::tuple<std::string, index_t, index_t, scalar_t, scalar_t>;
+
 namespace blas_benchmark {
 
 namespace utils {
@@ -463,9 +467,50 @@ static inline std::vector<gbmv_param_t<scalar_t>> get_gbmv_params(Args& args) {
           try {
             return std::make_tuple(
                 v[0].c_str(), str_to_int<index_t>(v[1]),
-                str_to_int<index_t>(v[2]), str_to_scalar<scalar_t>(v[3]),
-                str_to_scalar<scalar_t>(v[4]), str_to_scalar<scalar_t>(v[5]),
+                str_to_int<index_t>(v[2]), str_to_int<index_t>(v[3]),
+                str_to_int<index_t>(v[4]), str_to_scalar<scalar_t>(v[5]),
                 str_to_scalar<scalar_t>(v[6]));
+          } catch (...) {
+            throw std::runtime_error("invalid parameter");
+          }
+        });
+  }
+}
+
+/**
+ * @fn get_sbmv_params
+ * @brief Returns a vector containing the sbmv benchmark parameters, either
+ * read from a file according to the command-line args, or the default ones.
+ */
+template <typename scalar_t>
+static inline std::vector<sbmv_param_t<scalar_t>> get_sbmv_params(Args& args) {
+  if (args.csv_param.empty()) {
+    warning_no_csv();
+    std::vector<sbmv_param_t<scalar_t>> sbmv_default;
+    constexpr index_t dmin = 64, dmax = 1024;
+    constexpr index_t kmin = 1;
+    scalar_t alpha = 1;
+    scalar_t beta = 0;
+    for (std::string ul : {"u", "l"}) {
+      for (index_t n = dmin; n <= dmax; n *= 2) {
+        for (index_t k = kmin; k <= n / 4; k *= 2) {
+          sbmv_default.push_back(std::make_tuple(ul, n, k, alpha, beta));
+        }
+      }
+    }
+    return sbmv_default;
+  } else {
+    return parse_csv_file<sbmv_param_t<scalar_t>>(
+        args.csv_param, [&](std::vector<std::string>& v) {
+          if (v.size() != 5) {
+            throw std::runtime_error(
+                "invalid number of parameters (5 expected)");
+          }
+          try {
+            return std::make_tuple(v[0].c_str(), str_to_int<index_t>(v[1]),
+                                   str_to_int<index_t>(v[2]),
+                                   str_to_scalar<scalar_t>(v[3]),
+                                   str_to_scalar<scalar_t>(v[4]));
           } catch (...) {
             throw std::runtime_error("invalid parameter");
           }

--- a/common/include/common/system_reference_blas.hpp
+++ b/common/include/common/system_reference_blas.hpp
@@ -266,6 +266,15 @@ void trmv(const char *uplo, const char *trans, const char *diag, const int n,
 }
 
 template <typename scalar_t>
+void sbmv(const char *uplo, int n, int k, scalar_t alpha, const scalar_t a[],
+          int lda, const scalar_t x[], int incX, scalar_t beta, scalar_t y[],
+          int incY) {
+  auto func = blas_system_function<scalar_t>(&cblas_ssbmv, &cblas_dsbmv);
+  func(CblasColMajor, c_uplo(*uplo), n, k, alpha, a, lda, x, incX, beta, y,
+       incY);
+}
+
+template <typename scalar_t>
 void syr(const char *uplo, const int n, const scalar_t alpha, const scalar_t *x,
          const int incX, scalar_t *a, const int lda) {
   auto func = blas_system_function<scalar_t>(&cblas_ssyr, &cblas_dsyr);

--- a/include/blas_meta.h
+++ b/include/blas_meta.h
@@ -69,6 +69,12 @@ enum class transpose_type : char {
   Conjugate = 'c'
 };
 
+/**
+ * @enum Uplo
+ * @brief Specifies whether the lower or upper triangle needs to be accessed.
+ */
+enum class uplo_type : char { Upper = 'u', Lower = 'l' };
+
 // choosing value at compile-time
 template <bool Conds, typename val_t, val_t value_one_t, val_t value_two_t>
 struct Choose {

--- a/include/interface/blas2_interface.h
+++ b/include/interface/blas2_interface.h
@@ -258,6 +258,61 @@ typename sb_handle_t::event_t _gbmv(sb_handle_t& sb_handle, char _trans,
                                     element_t _beta, container_2_t _vy,
                                     increment_t _incy);
 
+template <uint32_t local_range, transpose_type trn, typename sb_handle_t,
+          typename index_t, typename element_t, typename container_t0,
+          typename container_t1, typename increment_t, typename container_t2>
+typename sb_handle_t::event_t _gbmv_impl(sb_handle_t& sb_handle, index_t _M,
+                                         index_t _N, index_t _KL, index_t _KU,
+                                         element_t _alpha, container_t0 _mA,
+                                         index_t _lda, container_t1 _vx,
+                                         increment_t _incx, element_t _beta,
+                                         container_t2 _vy, increment_t _incy);
+
+/**
+ * @brief Matrix vector product with symmetric band matrices.
+ *
+ * Matrix vector product with a symmetric band matrix, i.e. computing the
+ * mathematical operation:
+ *
+ * y = alpha*A*x + beta*y
+ *
+ * See the netlib blas interface documentation for more details of the
+ * interface: https://netlib.org/lapack/explore-html/d3/da1/ssbmv_8f.html
+ *
+ * @param sb_handle SB_handle
+ * @param _Uplo Specifies if A is upper or lower triangular
+ * @param _N Number of rows and columns of A
+ * @param _K Number of A super-diagonals
+ * @param _alpha Scalar parameter alpha
+ * @param _mA Buffer (_LDA,_N) containing the coefficient of A in the Band
+ *            Matrix format
+ * @param _lda Leading dimension _mA at least (_K + 1)
+ * @param _vx Buffer containing x of at least (1+(_N-1)*abs(_incx)) elements
+ * @param _incx Increment for _vx (nonzero)
+ * @param _beta Scalar parameter beta
+ * @param _vy Buffer containing y of at least (1+(_N-1)*abs(_incy)) elements
+ * @param _incy Increment for _vy
+ */
+template <typename sb_handle_t, typename index_t, typename element_t,
+          typename container_0_t, typename container_1_t, typename increment_t,
+          typename container_2_t>
+typename sb_handle_t::event_t _sbmv(sb_handle_t& sb_handle, char _Uplo,
+                                    index_t _N, index_t _K, element_t _alpha,
+                                    container_0_t _mA, index_t _lda,
+                                    container_1_t _vx, increment_t _incx,
+                                    element_t _beta, container_2_t _vy,
+                                    increment_t _incy);
+
+template <uint32_t local_range, uplo_type uplo, typename sb_handle_t,
+          typename index_t, typename element_t, typename container_t0,
+          typename container_t1, typename increment_t, typename container_t2>
+typename sb_handle_t::event_t _sbmv_impl(sb_handle_t& sb_handle, index_t _N,
+                                         index_t _K, element_t _alpha,
+                                         container_t0 _mA, index_t _lda,
+                                         container_t1 _vx, increment_t _incx,
+                                         element_t _beta, container_t2 _vy,
+                                         increment_t _incy);
+
 }  // namespace internal
 
 /*!
@@ -497,6 +552,44 @@ typename sb_handle_t::event_t inline _gbmv(sb_handle_t& sb_handle, char _trans,
                                            increment_t _incy) {
   return internal::_gbmv(sb_handle, _trans, _M, _N, _KL, _KU, _alpha, _mA, _lda,
                          _vx, _incx, _beta, _vy, _incy);
+}
+
+/**
+ * @brief Matrix vector product with symmetric band matrices.
+ *
+ * Matrix vector product with a symmetric band matrix, i.e. computing the
+ * mathematical operation:
+ *
+ * y = alpha*A*x + beta*y
+ *
+ * See the netlib blas interface documentation for more details of the
+ * interface: https://netlib.org/lapack/explore-html/d3/da1/ssbmv_8f.html
+ *
+ * @param sb_handle SB_handle
+ * @param _Uplo Specifies if A is upper or lower triangular
+ * @param _N Number of rows and columns of A
+ * @param _K Number of A super-diagonals
+ * @param _alpha Scalar parameter alpha
+ * @param _mA Buffer (_LDA,_N) containing the coefficient of A in the Band
+ *            Matrix format
+ * @param _lda Leading dimension _mA at least (_K + 1)
+ * @param _vx Buffer containing x of at least (1+(_N-1)*abs(_incx)) elements
+ * @param _incx Increment for _vx (nonzero)
+ * @param _beta Scalar parameter beta
+ * @param _vy Buffer containing y of at least (1+(_N-1)*abs(_incy)) elements
+ * @param _incy Increment for _vy
+ */
+template <typename sb_handle_t, typename index_t, typename element_t,
+          typename container_0_t, typename container_1_t, typename increment_t,
+          typename container_2_t>
+typename sb_handle_t::event_t _sbmv(sb_handle_t& sb_handle, char _Uplo,
+                                    index_t _N, index_t _K, element_t _alpha,
+                                    container_0_t _mA, index_t _lda,
+                                    container_1_t _vx, increment_t _incx,
+                                    element_t _beta, container_2_t _vy,
+                                    increment_t _incy) {
+  return internal::_sbmv(sb_handle, _Uplo, _N, _K, _alpha, _mA, _lda, _vx,
+                         _incx, _beta, _vy, _incy);
 }
 
 }  // namespace blas

--- a/include/operations/blas2_trees.h
+++ b/include/operations/blas2_trees.h
@@ -242,9 +242,10 @@ struct Gbmv {
   index_t kl_;
   index_t ku_;
   vector_t vector_;
+  value_t alpha_, beta_;
 
   Gbmv(lhs_t &_l, matrix_t &_matrix, index_t &_kl, index_t &_ku,
-       vector_t &_vector);
+       vector_t &_vector, value_t _alpha, value_t _beta);
   index_t get_size() const;
   bool valid_thread(cl::sycl::nd_item<1> ndItem) const;
   value_t eval(index_t i);
@@ -260,10 +261,52 @@ struct Gbmv {
 template <uint32_t local_range, bool is_transposed, typename lhs_t,
           typename matrix_t, typename vector_t>
 Gbmv<lhs_t, matrix_t, vector_t, local_range, is_transposed> make_gbmv(
-    lhs_t &lhs_, matrix_t &matrix_, typename vector_t::index_t kl_,
-    typename vector_t::index_t ku_, vector_t &vector_) {
+    typename vector_t::index_t kl_, typename vector_t::index_t ku_,
+    typename vector_t::value_t alpha_, matrix_t &matrix_, vector_t &vector_,
+    typename vector_t::value_t beta_, lhs_t &lhs_) {
   return Gbmv<lhs_t, matrix_t, vector_t, local_range, is_transposed>(
-      lhs_, matrix_, kl_, ku_, vector_);
+      lhs_, matrix_, kl_, ku_, vector_, alpha_, beta_);
+}
+
+/**
+ * @struct Sbmv
+ * @brief Tree node representing a symmetric band matrix_ vector_
+ * multiplication.
+ */
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool uplo>
+struct Sbmv {
+  using value_t = typename vector_t::value_t;
+  using index_t = typename vector_t::index_t;
+
+  lhs_t lhs_;
+  matrix_t matrix_;
+  index_t k_;
+  vector_t vector_;
+  value_t alpha_, beta_;
+
+  Sbmv(lhs_t &_l, matrix_t &_matrix, index_t &_k, vector_t &_vector,
+       value_t _alpha, value_t _beta);
+  index_t get_size() const;
+  bool valid_thread(cl::sycl::nd_item<1> ndItem) const;
+  value_t eval(index_t i);
+  value_t eval(cl::sycl::nd_item<1> ndItem);
+  template <typename sharedT>
+  value_t eval(sharedT shrMem, cl::sycl::nd_item<1> ndItem);
+  void bind(cl::sycl::handler &h);
+  void adjust_access_displacement();
+};
+/*!
+ @brief Generator/factory for SBMV trees.
+ */
+template <uint32_t local_range, bool uplo, typename lhs_t, typename matrix_t,
+          typename vector_t>
+Sbmv<lhs_t, matrix_t, vector_t, local_range, uplo> make_sbmv(
+    typename vector_t::index_t k_, typename vector_t::value_t alpha_,
+    matrix_t &matrix_, vector_t &vector_, typename vector_t::value_t beta_,
+    lhs_t &lhs_) {
+  return Sbmv<lhs_t, matrix_t, vector_t, local_range, uplo>(
+      lhs_, matrix_, k_, vector_, alpha_, beta_);
 }
 
 /**** GER BY ROWS M ROWS x N BLOCK USING PROPERLY THE SHARED MEMORY ****/

--- a/src/interface/blas2/CMakeLists.txt
+++ b/src/interface/blas2/CMakeLists.txt
@@ -27,6 +27,7 @@
 generate_blas_ternary_objects(blas2 gbmv)
 generate_blas_ternary_objects(blas2 gemv)
 generate_blas_ternary_objects(blas2 ger)
+generate_blas_ternary_objects(blas2 sbmv)
 generate_blas_ternary_objects(blas2 symv)
 generate_blas_ternary_objects(blas2 syr2)
 generate_blas_binary_objects(blas2 syr)

--- a/src/interface/blas2/backend/amd_gpu.hpp
+++ b/src/interface/blas2/backend/amd_gpu.hpp
@@ -50,5 +50,40 @@ typename SB_Handle::event_t _gemv(SB_Handle& sb_handle, index_t _M, index_t _N,
 }
 }  // namespace backend
 }  // namespace gemv
+
+namespace gbmv {
+namespace backend {
+template <transpose_type trn, typename SB_Handle, typename index_t,
+          typename element_t, typename container_t0, typename container_t1,
+          typename increment_t, typename container_t2>
+typename SB_Handle::event_t inline _gbmv(SB_Handle& sb_handle, index_t _M,
+                                         index_t _N, index_t _KL, index_t _KU,
+                                         element_t _alpha, container_t0 _mA,
+                                         index_t _lda, container_t1 _vx,
+                                         increment_t _incx, element_t _beta,
+                                         container_t2 _vy, increment_t _incy) {
+  return blas::internal::_gbmv_impl<64, trn>(sb_handle, _M, _N, _KL, _KU,
+                                             _alpha, _mA, _lda, _vx, _incx,
+                                             _beta, _vy, _incy);
+}
+}  // namespace backend
+}  // namespace gbmv
+
+namespace sbmv {
+namespace backend {
+template <uplo_type uplo, typename SB_Handle, typename index_t,
+          typename element_t, typename container_t0, typename container_t1,
+          typename increment_t, typename container_t2>
+typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
+                                         index_t _K, element_t _alpha,
+                                         container_t0 _mA, index_t _lda,
+                                         container_t1 _vx, increment_t _incx,
+                                         element_t _beta, container_t2 _vy,
+                                         increment_t _incy) {
+  return blas::internal::_sbmv_impl<64, uplo>(
+      sb_handle, _N, _K, _alpha, _mA, _lda, _vx, _incx, _beta, _vy, _incy);
+}
+}  // namespace backend
+}  // namespace sbmv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/default_cpu.hpp
+++ b/src/interface/blas2/backend/default_cpu.hpp
@@ -47,5 +47,40 @@ typename SB_Handle::event_t _gemv(SB_Handle& sb_handle, index_t _M, index_t _N,
 }
 }  // namespace backend
 }  // namespace gemv
+
+namespace gbmv {
+namespace backend {
+template <transpose_type trn, typename SB_Handle, typename index_t,
+          typename element_t, typename container_t0, typename container_t1,
+          typename increment_t, typename container_t2>
+typename SB_Handle::event_t inline _gbmv(SB_Handle& sb_handle, index_t _M,
+                                         index_t _N, index_t _KL, index_t _KU,
+                                         element_t _alpha, container_t0 _mA,
+                                         index_t _lda, container_t1 _vx,
+                                         increment_t _incx, element_t _beta,
+                                         container_t2 _vy, increment_t _incy) {
+  return blas::internal::_gbmv_impl<256, trn>(sb_handle, _M, _N, _KL, _KU,
+                                              _alpha, _mA, _lda, _vx, _incx,
+                                              _beta, _vy, _incy);
+}
+}  // namespace backend
+}  // namespace gbmv
+
+namespace sbmv {
+namespace backend {
+template <uplo_type uplo, typename SB_Handle, typename index_t,
+          typename element_t, typename container_t0, typename container_t1,
+          typename increment_t, typename container_t2>
+typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
+                                         index_t _K, element_t _alpha,
+                                         container_t0 _mA, index_t _lda,
+                                         container_t1 _vx, increment_t _incx,
+                                         element_t _beta, container_t2 _vy,
+                                         increment_t _incy) {
+  return blas::internal::_sbmv_impl<256, uplo>(
+      sb_handle, _N, _K, _alpha, _mA, _lda, _vx, _incx, _beta, _vy, _incy);
+}
+}  // namespace backend
+}  // namespace sbmv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/intel_gpu.hpp
+++ b/src/interface/blas2/backend/intel_gpu.hpp
@@ -47,5 +47,40 @@ typename SB_Handle::event_t _gemv(SB_Handle& sb_handle, index_t _M, index_t _N,
 }
 }  // namespace backend
 }  // namespace gemv
+
+namespace gbmv {
+namespace backend {
+template <transpose_type trn, typename SB_Handle, typename index_t,
+          typename element_t, typename container_t0, typename container_t1,
+          typename increment_t, typename container_t2>
+typename SB_Handle::event_t inline _gbmv(SB_Handle& sb_handle, index_t _M,
+                                         index_t _N, index_t _KL, index_t _KU,
+                                         element_t _alpha, container_t0 _mA,
+                                         index_t _lda, container_t1 _vx,
+                                         increment_t _incx, element_t _beta,
+                                         container_t2 _vy, increment_t _incy) {
+  return blas::internal::_gbmv_impl<64, trn>(sb_handle, _M, _N, _KL, _KU,
+                                             _alpha, _mA, _lda, _vx, _incx,
+                                             _beta, _vy, _incy);
+}
+}  // namespace backend
+}  // namespace gbmv
+
+namespace sbmv {
+namespace backend {
+template <uplo_type uplo, typename SB_Handle, typename index_t,
+          typename element_t, typename container_t0, typename container_t1,
+          typename increment_t, typename container_t2>
+typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
+                                         index_t _K, element_t _alpha,
+                                         container_t0 _mA, index_t _lda,
+                                         container_t1 _vx, increment_t _incx,
+                                         element_t _beta, container_t2 _vy,
+                                         increment_t _incy) {
+  return blas::internal::_sbmv_impl<64, uplo>(
+      sb_handle, _N, _K, _alpha, _mA, _lda, _vx, _incx, _beta, _vy, _incy);
+}
+}  // namespace backend
+}  // namespace sbmv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/nvidia_gpu.hpp
+++ b/src/interface/blas2/backend/nvidia_gpu.hpp
@@ -19,11 +19,11 @@
  *
  *  SYCL-BLAS: BLAS implementation using SYCL
  *
- *  @filename arm_gpu.hpp
+ *  @filename nvidia_gpu.hpp
  *
  **************************************************************************/
-#ifndef SYCL_BLAS_GEMV_ARM_GPU_BACKEND_HPP
-#define SYCL_BLAS_GEMV_ARM_GPU_BACKEND_HPP
+#ifndef SYCL_BLAS_GEMV_NVIDIA_GPU_BACKEND_HPP
+#define SYCL_BLAS_GEMV_NVIDIA_GPU_BACKEND_HPP
 #include "interface/blas2_interface.h"
 
 namespace blas {
@@ -38,10 +38,10 @@ typename SB_Handle::event_t _gemv(SB_Handle& sb_handle, index_t _M, index_t _N,
                                   increment_t _incx, element_t _beta,
                                   container_t2 _vy, increment_t _incy) {
   if (trn == transpose_type::Normal) {
-    return blas::internal::_gemv_impl<32, 32, gemv_memory_t::local, trn>(
+    return blas::internal::_gemv_impl<256, 32, gemv_memory_t::local, trn>(
         sb_handle, _M, _N, _alpha, _mA, _lda, _vx, _incx, _beta, _vy, _incy);
   } else {
-    return blas::internal::_gemv_impl<32, 32, gemv_memory_t::local, trn>(
+    return blas::internal::_gemv_impl<128, 32, gemv_memory_t::local, trn>(
         sb_handle, _M, _N, _alpha, _mA, _lda, _vx, _incx, _beta, _vy, _incy);
   }
 }
@@ -59,7 +59,7 @@ typename SB_Handle::event_t inline _gbmv(SB_Handle& sb_handle, index_t _M,
                                          index_t _lda, container_t1 _vx,
                                          increment_t _incx, element_t _beta,
                                          container_t2 _vy, increment_t _incy) {
-  return blas::internal::_gbmv_impl<32, trn>(sb_handle, _M, _N, _KL, _KU,
+  return blas::internal::_gbmv_impl<64, trn>(sb_handle, _M, _N, _KL, _KU,
                                              _alpha, _mA, _lda, _vx, _incx,
                                              _beta, _vy, _incy);
 }
@@ -77,7 +77,7 @@ typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
                                          container_t1 _vx, increment_t _incx,
                                          element_t _beta, container_t2 _vy,
                                          increment_t _incy) {
-  return blas::internal::_sbmv_impl<32, uplo>(
+  return blas::internal::_sbmv_impl<64, uplo>(
       sb_handle, _N, _K, _alpha, _mA, _lda, _vx, _incx, _beta, _vy, _incy);
 }
 }  // namespace backend

--- a/src/interface/blas2/backend/power_vr.hpp
+++ b/src/interface/blas2/backend/power_vr.hpp
@@ -47,5 +47,40 @@ typename SB_Handle::event_t _gemv(SB_Handle& sb_handle, index_t _M, index_t _N,
 }
 }  // namespace backend
 }  // namespace gemv
+
+namespace gbmv {
+namespace backend {
+template <transpose_type trn, typename SB_Handle, typename index_t,
+          typename element_t, typename container_t0, typename container_t1,
+          typename increment_t, typename container_t2>
+typename SB_Handle::event_t inline _gbmv(SB_Handle& sb_handle, index_t _M,
+                                         index_t _N, index_t _KL, index_t _KU,
+                                         element_t _alpha, container_t0 _mA,
+                                         index_t _lda, container_t1 _vx,
+                                         increment_t _incx, element_t _beta,
+                                         container_t2 _vy, increment_t _incy) {
+  return blas::internal::_gbmv_impl<256, trn>(sb_handle, _M, _N, _KL, _KU,
+                                              _alpha, _mA, _lda, _vx, _incx,
+                                              _beta, _vy, _incy);
+}
+}  // namespace backend
+}  // namespace gbmv
+
+namespace sbmv {
+namespace backend {
+template <uplo_type uplo, typename SB_Handle, typename index_t,
+          typename element_t, typename container_t0, typename container_t1,
+          typename increment_t, typename container_t2>
+typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
+                                         index_t _K, element_t _alpha,
+                                         container_t0 _mA, index_t _lda,
+                                         container_t1 _vx, increment_t _incx,
+                                         element_t _beta, container_t2 _vy,
+                                         increment_t _incy) {
+  return blas::internal::_sbmv_impl<256, uplo>(
+      sb_handle, _N, _K, _alpha, _mA, _lda, _vx, _incx, _beta, _vy, _incy);
+}
+}  // namespace backend
+}  // namespace sbmv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/rcar.hpp
+++ b/src/interface/blas2/backend/rcar.hpp
@@ -52,5 +52,40 @@ typename SB_Handle::event_t _gemv(SB_Handle& sb_handle, index_t _M, index_t _N,
 }
 }  // namespace backend
 }  // namespace gemv
+
+namespace gbmv {
+namespace backend {
+template <transpose_type trn, typename SB_Handle, typename index_t,
+          typename element_t, typename container_t0, typename container_t1,
+          typename increment_t, typename container_t2>
+typename SB_Handle::event_t inline _gbmv(SB_Handle& sb_handle, index_t _M,
+                                         index_t _N, index_t _KL, index_t _KU,
+                                         element_t _alpha, container_t0 _mA,
+                                         index_t _lda, container_t1 _vx,
+                                         increment_t _incx, element_t _beta,
+                                         container_t2 _vy, increment_t _incy) {
+  return blas::internal::_gbmv_impl<32, trn>(sb_handle, _M, _N, _KL, _KU,
+                                             _alpha, _mA, _lda, _vx, _incx,
+                                             _beta, _vy, _incy);
+}
+}  // namespace backend
+}  // namespace gbmv
+
+namespace sbmv {
+namespace backend {
+template <uplo_type uplo, typename SB_Handle, typename index_t,
+          typename element_t, typename container_t0, typename container_t1,
+          typename increment_t, typename container_t2>
+typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
+                                         index_t _K, element_t _alpha,
+                                         container_t0 _mA, index_t _lda,
+                                         container_t1 _vx, increment_t _incx,
+                                         element_t _beta, container_t2 _vy,
+                                         increment_t _incy) {
+  return blas::internal::_sbmv_impl<32, uplo>(
+      sb_handle, _N, _K, _alpha, _mA, _lda, _vx, _incx, _beta, _vy, _incy);
+}
+}  // namespace backend
+}  // namespace sbmv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/sbmv.cpp.in
+++ b/src/interface/blas2/sbmv.cpp.in
@@ -19,21 +19,26 @@
  *
  *  SYCL-BLAS: BLAS implementation using SYCL
  *
- *  @filename backend.hpp
+ *  @filename sbmv.cpp.in
  *
  **************************************************************************/
-#ifdef RCAR
-#include "interface/blas2/backend/rcar.hpp"
-#elif INTEL_GPU
-#include "interface/blas2/backend/intel_gpu.hpp"
-#elif AMD_GPU
-#include "interface/blas2/backend/amd_gpu.hpp"
-#elif ARM_GPU
-#include "interface/blas2/backend/arm_gpu.hpp"
-#elif POWER_VR
-#include "interface/blas2/backend/power_vr.hpp"
-#elif NVIDIA_GPU
-#include "interface/blas2/backend/nvidia_gpu.hpp"
-#else
-#include "interface/blas2/backend/default_cpu.hpp"
-#endif
+#include "container/sycl_iterator.hpp"
+#include "sb_handle/sycl_blas_handle.hpp"
+#include "sb_handle/kernel_constructor.hpp"
+#include "interface/blas2_interface.hpp"
+#include "operations/blas1_trees.hpp"
+#include "operations/blas2_trees.hpp"
+#include "operations/blas_constants.hpp"
+#include "views/view_sycl.hpp"
+
+namespace blas {
+namespace internal {
+template typename SB_Handle::event_t _sbmv(
+    SB_Handle& sb_handle, char _Uplo, ${INDEX_TYPE} _N,
+    ${INDEX_TYPE} _K,
+    ${DATA_TYPE} _alpha, ${container_t0} _mA, ${INDEX_TYPE} _lda,
+    ${container_t1} _vx, ${INCREMENT_TYPE} _incx, ${DATA_TYPE} _beta,
+    ${container_t2} _vy, ${INCREMENT_TYPE} _incy);
+
+}  // namespace internal
+}  // namespace blas

--- a/src/interface/blas2_interface.hpp
+++ b/src/interface/blas2_interface.hpp
@@ -430,7 +430,7 @@ typename sb_handle_t::event_t _gbmv_impl(sb_handle_t& sb_handle, index_t _M,
                                          increment_t _incx, element_t _beta,
                                          container_t2 _vy, increment_t _incy) {
   if ((_KL >= _M) || (_KU >= _N)) {
-    throw std::invalid_argument("Erroneous parameter");
+    throw std::invalid_argument("Erroneous parameter: _KL >= _M || _KU >= _N");
   }
 
   constexpr bool is_transposed = (trn != transpose_type::Normal);
@@ -464,7 +464,7 @@ typename sb_handle_t::event_t _sbmv_impl(sb_handle_t& sb_handle, index_t _N,
                                          element_t _beta, container_t2 _vy,
                                          increment_t _incy) {
   if (_K >= _N) {
-    throw std::invalid_argument("Erroneous parameter");
+    throw std::invalid_argument("Erroneous parameter: _K >= _N");
   }
 
   auto vector_size = _N;

--- a/src/interface/blas2_interface.hpp
+++ b/src/interface/blas2_interface.hpp
@@ -417,74 +417,67 @@ typename sb_handle_t::event_t _symv_impl(
 }
 
 /*! _gbmv_impl.
- * @brief Implementation of the Band Matrix Vector product.
+ * @brief Implementation of the Generic Band Matrix Vector product.
  *
  */
 template <uint32_t local_range, transpose_type trn, typename sb_handle_t,
           typename index_t, typename element_t, typename container_t0,
           typename container_t1, typename increment_t, typename container_t2>
-typename sb_handle_t::event_t _gbmv_impl(sb_handle_t& sb_handle, char _trans,
-                                         index_t _M, index_t _N, index_t _KL,
-                                         index_t _KU, element_t _alpha,
-                                         container_t0 _mA, index_t _lda,
-                                         container_t1 _vx, increment_t _incx,
-                                         element_t _beta, container_t2 _vy,
-                                         increment_t _incy) {
-  constexpr bool is_transposed = (trn != transpose_type::Normal);
-
+typename sb_handle_t::event_t _gbmv_impl(sb_handle_t& sb_handle, index_t _M,
+                                         index_t _N, index_t _KL, index_t _KU,
+                                         element_t _alpha, container_t0 _mA,
+                                         index_t _lda, container_t1 _vx,
+                                         increment_t _incx, element_t _beta,
+                                         container_t2 _vy, increment_t _incy) {
   if ((_KL >= _M) || (_KU >= _N)) {
     throw std::invalid_argument("Erroneous parameter");
   }
 
+  constexpr bool is_transposed = (trn != transpose_type::Normal);
+
   auto x_vector_size = is_transposed ? _M : _N;
   auto y_vector_size = is_transposed ? _N : _M;
 
-  auto mA = make_matrix_view<col_major>(_mA, _M, _N, _lda);
+  auto mA =
+      make_matrix_view<col_major>(_mA, _KL + _KU + 1, x_vector_size, _lda);
   auto vx = make_vector_view(_vx, _incx, x_vector_size);
   auto vy = make_vector_view(_vy, _incy, y_vector_size);
 
-  // Leading dimension for dot products matrix
-  const auto ld = is_transposed ? _N : _M;
-  constexpr index_t one = 1;
+  auto gbmv = make_gbmv<local_range, is_transposed>(_KL, _KU, _alpha, mA, vx,
+                                                    _beta, vy);
 
-  auto dot_products_buffer = blas::make_sycl_iterator_buffer<element_t>(ld);
+  return sb_handle.execute(gbmv, static_cast<index_t>(local_range),
+                           roundUp<index_t>(y_vector_size, local_range));
+}
 
-  auto dot_products_matrix =
-      make_matrix_view<col_major>(dot_products_buffer, ld, one, ld);
-
-  const index_t global_size = roundUp<index_t>(y_vector_size, local_range);
-  auto gbmv = make_gbmv<local_range, is_transposed>(dot_products_matrix, mA,
-                                                    _KL, _KU, vx);
-
-  // Execute the GBMV kernel that calculate the partial dot products of rows
-  auto gbmvEvent =
-      sb_handle.execute(gbmv, static_cast<index_t>(local_range), global_size);
-
-  // apply ALPHA and BETA
-  if (_beta != static_cast<element_t>(0)) {
-    // vec_y * b
-    auto betaMulYOp = make_op<ScalarOp, ProductOperator>(_beta, vy);
-
-    // alpha * vec_dot_products
-    auto alphaMulDotsOp =
-        make_op<ScalarOp, ProductOperator>(_alpha, dot_products_matrix);
-
-    // add up
-    auto addOp = make_op<BinaryOp, AddOperator>(betaMulYOp, alphaMulDotsOp);
-
-    // assign the result back to vec_y
-    auto assignOp = make_op<Assign>(vy, addOp);
-
-    // exectutes the above expression tree to yield the final GBMV result
-    return concatenate_vectors(gbmvEvent,
-                               sb_handle.execute(assignOp, local_range));
-  } else {
-    auto alphaMulDotsOp =
-        make_op<ScalarOp, ProductOperator>(_alpha, dot_products_matrix);
-    auto assignOp = make_op<Assign>(vy, alphaMulDotsOp);
-    return concatenate_vectors(gbmvEvent,
-                               sb_handle.execute(assignOp, local_range));
+/*! _sbmv_impl.
+ * @brief Implementation of the Symmetric Band Matrix Vector product.
+ *
+ */
+template <uint32_t local_range, uplo_type uplo, typename sb_handle_t,
+          typename index_t, typename element_t, typename container_t0,
+          typename container_t1, typename increment_t, typename container_t2>
+typename sb_handle_t::event_t _sbmv_impl(sb_handle_t& sb_handle, index_t _N,
+                                         index_t _K, element_t _alpha,
+                                         container_t0 _mA, index_t _lda,
+                                         container_t1 _vx, increment_t _incx,
+                                         element_t _beta, container_t2 _vy,
+                                         increment_t _incy) {
+  if (_K >= _N) {
+    throw std::invalid_argument("Erroneous parameter");
   }
+
+  auto vector_size = _N;
+
+  auto mA = make_matrix_view<col_major>(_mA, _K + 1, _N, _lda);
+  auto vx = make_vector_view(_vx, _incx, vector_size);
+  auto vy = make_vector_view(_vy, _incy, vector_size);
+
+  auto sbmv = make_sbmv<local_range, uplo == uplo_type::Upper>(_K, _alpha, mA,
+                                                               vx, _beta, vy);
+
+  return sb_handle.execute(sbmv, static_cast<index_t>(local_range),
+                           roundUp<index_t>(vector_size, local_range));
 }
 
 /**** RANK 1 MODIFICATION ****/
@@ -710,12 +703,12 @@ typename sb_handle_t::event_t inline _gbmv(sb_handle_t& sb_handle, char _trans,
                                            element_t _beta, container_t2 _vy,
                                            increment_t _incy) {
   return tolower(_trans) == 'n'
-             ? _gbmv_impl<32, transpose_type::Normal>(
-                   sb_handle, _trans, _M, _N, _KL, _KU, _alpha, _mA, _lda, _vx,
-                   _incx, _beta, _vy, _incy)
-             : _gbmv_impl<32, transpose_type::Transposed>(
-                   sb_handle, _trans, _M, _N, _KL, _KU, _alpha, _mA, _lda, _vx,
-                   _incx, _beta, _vy, _incy);
+             ? blas::gbmv::backend::_gbmv<transpose_type::Normal>(
+                   sb_handle, _M, _N, _KL, _KU, _alpha, _mA, _lda, _vx, _incx,
+                   _beta, _vy, _incy)
+             : blas::gbmv::backend::_gbmv<transpose_type::Transposed>(
+                   sb_handle, _M, _N, _KL, _KU, _alpha, _mA, _lda, _vx, _incx,
+                   _beta, _vy, _incy);
 }
 
 template <typename sb_handle_t, typename index_t, typename element_t,
@@ -731,6 +724,22 @@ typename sb_handle_t::event_t inline _ger(sb_handle_t& sb_handle, index_t _M,
   return _ger_impl(sb_handle, _M, _N, _alpha, _vx, _incx, _vy, _incy, _mA,
                    _lda);
 }
+
+template <typename sb_handle_t, typename index_t, typename element_t,
+          typename container_t0, typename container_t1, typename increment_t,
+          typename container_t2>
+typename sb_handle_t::event_t inline _sbmv(
+    sb_handle_t& sb_handle, char _Uplo, index_t _N, index_t _K,
+    element_t _alpha, container_t0 _mA, index_t _lda, container_t1 _vx,
+    increment_t _incx, element_t _beta, container_t2 _vy, increment_t _incy) {
+  return tolower(_Uplo) == 'u' ? blas::sbmv::backend::_sbmv<uplo_type::Upper>(
+                                     sb_handle, _N, _K, _alpha, _mA, _lda, _vx,
+                                     _incx, _beta, _vy, _incy)
+                               : blas::sbmv::backend::_sbmv<uplo_type::Lower>(
+                                     sb_handle, _N, _K, _alpha, _mA, _lda, _vx,
+                                     _incx, _beta, _vy, _incy);
+}
+
 template <typename sb_handle_t, typename index_t, typename element_t,
           typename container_t0, typename increment_t, typename container_t1>
 typename sb_handle_t::event_t inline _syr(sb_handle_t& sb_handle, char _Uplo,

--- a/src/operations/blas2/gbmv.hpp
+++ b/src/operations/blas2/gbmv.hpp
@@ -80,8 +80,7 @@ SYCL_BLAS_INLINE typename Gbmv<lhs_t, matrix_t, vector_t, local_range,
                                is_transposed>::value_t
 Gbmv<lhs_t, matrix_t, vector_t, local_range, is_transposed>::eval(
     cl::sycl::nd_item<1> ndItem) {
-  const index_t lhs_idx =
-      ndItem.get_group(0) * local_range + ndItem.get_local_id(0);
+  const index_t lhs_idx = ndItem.get_global_id(0);
   value_t val = 0;
 
   if (lhs_idx < lhs_.get_size()) {

--- a/src/operations/blas2/sbmv.hpp
+++ b/src/operations/blas2/sbmv.hpp
@@ -88,7 +88,7 @@ SYCL_BLAS_INLINE
       index_t K, J;
 
       if (is_upper) {
-        K = k_ + ((s_idx < lhs_idx) ? (s_idx - lhs_idx) : (lhs_idx - s_idx));
+        K = k_ + ((s_idx < lhs_idx) ? s_idx - lhs_idx : lhs_idx - s_idx);
         J = (s_idx < lhs_idx) ? lhs_idx : s_idx;
       } else {
         K = (s_idx < lhs_idx) ? lhs_idx - s_idx : s_idx - lhs_idx;

--- a/src/operations/blas2/sbmv.hpp
+++ b/src/operations/blas2/sbmv.hpp
@@ -77,8 +77,7 @@ SYCL_BLAS_INLINE
     typename Sbmv<lhs_t, matrix_t, vector_t, local_range, is_upper>::value_t
     Sbmv<lhs_t, matrix_t, vector_t, local_range, is_upper>::eval(
         cl::sycl::nd_item<1> ndItem) {
-  const index_t lhs_idx =
-      ndItem.get_group(0) * local_range + ndItem.get_local_id(0);
+  const index_t lhs_idx = ndItem.get_global_id(0);
   value_t val = 0;
 
   if (lhs_idx < lhs_.get_size()) {

--- a/src/operations/blas2/sbmv.hpp
+++ b/src/operations/blas2/sbmv.hpp
@@ -19,12 +19,12 @@
  *
  *  SYCL-BLAS: BLAS implementation using SYCL
  *
- *  @filename gbmv.hpp
+ *  @filename sbmv.hpp
  *
  **************************************************************************/
 
-#ifndef GBMV_HPP
-#define GBMV_HPP
+#ifndef SBMV_HPP
+#define SBMV_HPP
 #include "operations/blas2_trees.h"
 #include "operations/blas_operators.hpp"
 #include "views/view_sycl.hpp"
@@ -33,69 +33,69 @@
 namespace blas {
 
 /**
- * @struct Gbmv
- * @brief Tree node representing a band matrix_ vector_ multiplication.
+ * @struct Sbmv
+ * @brief Tree node representing a symmetric band matrix_ vector_
+ * multiplication.
  */
 template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_transposed>
-SYCL_BLAS_INLINE
-Gbmv<lhs_t, matrix_t, vector_t, local_range, is_transposed>::Gbmv(
+          uint32_t local_range, bool is_upper>
+SYCL_BLAS_INLINE Sbmv<lhs_t, matrix_t, vector_t, local_range, is_upper>::Sbmv(
     lhs_t &_l, matrix_t &_matrix,
-    typename Gbmv<lhs_t, matrix_t, vector_t, local_range,
-                  is_transposed>::index_t &_kl,
-    typename Gbmv<lhs_t, matrix_t, vector_t, local_range,
-                  is_transposed>::index_t &_ku,
+    typename Sbmv<lhs_t, matrix_t, vector_t, local_range, is_upper>::index_t
+        &_k,
     vector_t &_vector,
-    typename Gbmv<lhs_t, matrix_t, vector_t, local_range,
-                  is_transposed>::value_t _alpha,
-    typename Gbmv<lhs_t, matrix_t, vector_t, local_range,
-                  is_transposed>::value_t _beta)
+    typename Sbmv<lhs_t, matrix_t, vector_t, local_range, is_upper>::value_t
+        _alpha,
+    typename Sbmv<lhs_t, matrix_t, vector_t, local_range, is_upper>::value_t
+        _beta)
     : lhs_(_l),
       matrix_(_matrix),
       vector_(_vector),
-      kl_(_kl),
-      ku_(_ku),
+      k_(_k),
       alpha_(_alpha),
       beta_(_beta) {}
 
 template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_transposed>
-SYCL_BLAS_INLINE typename Gbmv<lhs_t, matrix_t, vector_t, local_range,
-                               is_transposed>::index_t
-Gbmv<lhs_t, matrix_t, vector_t, local_range, is_transposed>::get_size() const {
+          uint32_t local_range, bool is_upper>
+SYCL_BLAS_INLINE
+    typename Sbmv<lhs_t, matrix_t, vector_t, local_range, is_upper>::index_t
+    Sbmv<lhs_t, matrix_t, vector_t, local_range, is_upper>::get_size() const {
   return matrix_.get_size();
 }
 template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_transposed>
+          uint32_t local_range, bool is_upper>
 SYCL_BLAS_INLINE bool
-Gbmv<lhs_t, matrix_t, vector_t, local_range, is_transposed>::valid_thread(
+Sbmv<lhs_t, matrix_t, vector_t, local_range, is_upper>::valid_thread(
     cl::sycl::nd_item<1> ndItem) const {
   // Valid threads are established by ::eval.
   return true;
 }
 
 template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_transposed>
-SYCL_BLAS_INLINE typename Gbmv<lhs_t, matrix_t, vector_t, local_range,
-                               is_transposed>::value_t
-Gbmv<lhs_t, matrix_t, vector_t, local_range, is_transposed>::eval(
-    cl::sycl::nd_item<1> ndItem) {
+          uint32_t local_range, bool is_upper>
+SYCL_BLAS_INLINE
+    typename Sbmv<lhs_t, matrix_t, vector_t, local_range, is_upper>::value_t
+    Sbmv<lhs_t, matrix_t, vector_t, local_range, is_upper>::eval(
+        cl::sycl::nd_item<1> ndItem) {
   const index_t lhs_idx =
       ndItem.get_group(0) * local_range + ndItem.get_local_id(0);
   value_t val = 0;
 
   if (lhs_idx < lhs_.get_size()) {
-    const index_t k_lower = is_transposed ? ku_ : kl_;
-    const index_t k_upper = is_transposed ? kl_ : ku_;
-
-    const index_t k_beg = cl::sycl::max(index_t(0), lhs_idx - k_lower);
-    const index_t k_end =
-        cl::sycl::min(vector_.get_size(), lhs_idx + k_upper + 1);
-    const index_t k_off = ku_ + (is_transposed ? -lhs_idx : lhs_idx);
+    const index_t k_beg = cl::sycl::max(index_t(0), lhs_idx - k_);
+    const index_t k_end = cl::sycl::min(vector_.get_size(), lhs_idx + k_ + 1);
 
     for (index_t s_idx = k_beg; s_idx < k_end; ++s_idx) {
-      const index_t K = k_off + (is_transposed ? s_idx : -s_idx);
-      const index_t J = is_transposed ? lhs_idx : s_idx;
+      index_t K, J;
+
+      if (is_upper) {
+        K = k_ + ((s_idx < lhs_idx) ? (s_idx - lhs_idx) : (lhs_idx - s_idx));
+        J = (s_idx < lhs_idx) ? lhs_idx : s_idx;
+      } else {
+        K = (s_idx < lhs_idx) ? lhs_idx - s_idx : s_idx - lhs_idx;
+        J = (s_idx < lhs_idx) ? s_idx : lhs_idx;
+      }
+
       val = AddOperator::eval(
           val, ProductOperator::eval(matrix_.eval(K, J), vector_.eval(s_idx)));
     }
@@ -108,17 +108,17 @@ Gbmv<lhs_t, matrix_t, vector_t, local_range, is_transposed>::eval(
 }
 
 template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_transposed>
-SYCL_BLAS_INLINE void Gbmv<lhs_t, matrix_t, vector_t, local_range,
-                           is_transposed>::bind(cl::sycl::handler &h) {
+          uint32_t local_range, bool is_upper>
+SYCL_BLAS_INLINE void Sbmv<lhs_t, matrix_t, vector_t, local_range,
+                           is_upper>::bind(cl::sycl::handler &h) {
   lhs_.bind(h);
   matrix_.bind(h);
   vector_.bind(h);
 }
 template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_transposed>
-SYCL_BLAS_INLINE void Gbmv<lhs_t, matrix_t, vector_t, local_range,
-                           is_transposed>::adjust_access_displacement() {
+          uint32_t local_range, bool is_upper>
+SYCL_BLAS_INLINE void Sbmv<lhs_t, matrix_t, vector_t, local_range,
+                           is_upper>::adjust_access_displacement() {
   lhs_.adjust_access_displacement();
   matrix_.adjust_access_displacement();
   vector_.adjust_access_displacement();

--- a/src/operations/blas2_trees.hpp
+++ b/src/operations/blas2_trees.hpp
@@ -29,5 +29,6 @@
 #include "blas2/gbmv.hpp"
 #include "blas2/gemv.hpp"
 #include "blas2/ger.hpp"
+#include "blas2/sbmv.hpp"
 
 #endif  // BLAS2_TREES_HPP

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SYCL_UNITTEST_SRCS
   ${SYCLBLAS_UNITTEST}/blas2/blas2_gbmv_test.cpp
   ${SYCLBLAS_UNITTEST}/blas2/blas2_gemv_test.cpp
   ${SYCLBLAS_UNITTEST}/blas2/blas2_ger_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas2/blas2_sbmv_test.cpp
   ${SYCLBLAS_UNITTEST}/blas2/blas2_syr_test.cpp
   ${SYCLBLAS_UNITTEST}/blas2/blas2_syr2_test.cpp
   ${SYCLBLAS_UNITTEST}/blas2/blas2_symv_test.cpp

--- a/test/unittest/blas2/blas2_sbmv_test.cpp
+++ b/test/unittest/blas2/blas2_sbmv_test.cpp
@@ -1,0 +1,121 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename blas2_sbmv_test.cpp
+ *
+ **************************************************************************/
+
+#include "blas_test.hpp"
+
+template <typename T>
+using combination_t = std::tuple<int, int, T, T, bool, int, int, int>;
+
+template <typename scalar_t>
+void run_test(const combination_t<scalar_t> combi) {
+  index_t n;
+  index_t k;
+  bool upper;
+  scalar_t alpha;
+  scalar_t beta;
+  index_t incX;
+  index_t incY;
+  index_t lda_mul;
+  std::tie(n, k, alpha, beta, upper, incX, incY, lda_mul) = combi;
+
+  const char* uplo_str = upper ? "u" : "l";
+
+  int a_size = (k + 1) * n * lda_mul;
+  int x_size = (1 + (n - 1) * incX);
+  int y_size = (1 + (n - 1) * incY);
+
+  // Input matrix
+  std::vector<scalar_t> a_m(a_size, 10.0);
+  // Input Vector
+  std::vector<scalar_t> x_v(x_size, 10.0);
+  // output Vector
+  std::vector<scalar_t> y_v_gpu_result(y_size, scalar_t(10.0));
+  // output system vector
+  std::vector<scalar_t> y_v_cpu(y_size, scalar_t(10.0));
+
+  fill_random(a_m);
+  fill_random(x_v);
+
+  // SYSTEM SBMV
+  reference_blas::sbmv(uplo_str, n, k, alpha, a_m.data(), (k + 1) * lda_mul,
+                       x_v.data(), incX, beta, y_v_cpu.data(), incY);
+
+  auto q = make_queue();
+  blas::SB_Handle sb_handle(q);
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(a_m, a_size);
+  auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(x_v, x_size);
+  auto v_y_gpu =
+      blas::make_sycl_iterator_buffer<scalar_t>(y_v_gpu_result, y_size);
+
+  // SYCL SBMV
+  _sbmv(sb_handle, *uplo_str, n, k, alpha, m_a_gpu, (k + 1) * lda_mul, v_x_gpu,
+        incX, beta, v_y_gpu, incY);
+
+  auto event = blas::helper::copy_to_host(sb_handle.get_queue(), v_y_gpu,
+                                          y_v_gpu_result.data(), y_size);
+  sb_handle.wait(event);
+
+  const bool isAlmostEqual = utils::compare_vectors(y_v_gpu_result, y_v_cpu);
+  ASSERT_TRUE(isAlmostEqual);
+}
+
+#ifndef STRESS_TESTING
+template <typename scalar_t>
+const auto combi =
+    ::testing::Combine(::testing::Values(14, 63, 257, 1010),        // n
+                       ::testing::Values(3, 4, 9),                  // k
+                       ::testing::Values<scalar_t>(0.0, 1.0, 1.5),  // alpha
+                       ::testing::Values<scalar_t>(0.0, 1.0, 1.5),  // beta
+                       ::testing::Values(true, false),              // upper
+                       ::testing::Values(1, 2),                     // incX
+                       ::testing::Values(1, 3),                     // incY
+                       ::testing::Values(1, 2)                      // lda_mul
+    );
+#else
+// For the purpose of travis and other slower platforms, we need a faster test
+// (the stress_test above takes about ~5 minutes)
+template <typename scalar_t>
+const auto combi =
+    ::testing::Combine(::testing::Values(14, 1010),            // n
+                       ::testing::Values(3, 4),                // kl
+                       ::testing::Values<scalar_t>(1.5),       // alpha
+                       ::testing::Values<scalar_t>(0.0, 1.5),  // beta
+                       ::testing::Values(true, false),         // upper
+                       ::testing::Values(2),                   // incX
+                       ::testing::Values(3),                   // incY
+                       ::testing::Values(2)                    // lda_mul
+    );
+#endif
+
+template <class T>
+static std::string generate_name(
+    const ::testing::TestParamInfo<combination_t<T>>& info) {
+  int n, k, incX, incY, ldaMul;
+  T alpha, beta;
+  bool upper;
+  BLAS_GENERATE_NAME(info.param, n, k, alpha, beta, upper, incX, incY, ldaMul);
+}
+
+BLAS_REGISTER_TEST_ALL(Sbmv, combination_t, combi, generate_name);

--- a/test/unittest/blas2/blas2_sbmv_test.cpp
+++ b/test/unittest/blas2/blas2_sbmv_test.cpp
@@ -81,7 +81,7 @@ void run_test(const combination_t<scalar_t> combi) {
   ASSERT_TRUE(isAlmostEqual);
 }
 
-#ifndef STRESS_TESTING
+#ifdef STRESS_TESTING
 template <typename scalar_t>
 const auto combi =
     ::testing::Combine(::testing::Values(14, 63, 257, 1010),        // n


### PR DESCRIPTION
This patch
 * adds a baseline implementation of `SBMV` compatible with `TUNING_TARGET` specialization,
 * allows `TUNING_TARGET` specialization for `GBMV`.