### PR TITLE
Add TBMV baseline implementation

### DIFF
--- a/benchmark/clBench/clblast/CMakeLists.txt
+++ b/benchmark/clBench/clblast/CMakeLists.txt
@@ -17,6 +17,7 @@ set(sources
   blas2/gbmv.cpp
   blas2/gemv.cpp
   blas2/sbmv.cpp
+  blas2/tbmv.cpp
   # Level 3 blas
   blas3/gemm.cpp
   blas3/gemm_batched.cpp

--- a/benchmark/clBench/clblast/blas2/tbmv.cpp
+++ b/benchmark/clBench/clblast/blas2/tbmv.cpp
@@ -1,0 +1,181 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) 2023 Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename tbmv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, std::string t, std::string diag, int n,
+                     int k) {
+  std::ostringstream str{};
+  str << "BM_Tbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
+         std::string t, std::string diag, index_t n, index_t k, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+  const char* t_str = t.c_str();
+  const char* diag_str = diag.c_str();
+
+  index_t xlen = n;
+  index_t lda = (k + 1);
+  index_t incX = 1;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+  double k_d = static_cast<double>(k);
+
+  state.counters["n"] = n_d;
+  state.counters["k"] = k_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = (n_d * (k_d + 1.0)) - (0.5 * (k_d * (k_d + 1.0)));
+
+  {
+    double nflops_AtimesX = 2.0 * A_validVal;
+    state.counters["n_fl_ops"] = nflops_AtimesX;
+  }
+
+  {
+    double mem_readA = A_validVal;
+    double mem_readX = xlen;
+    double mem_writeX = xlen;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+  }
+
+  ExecutorType& ex = *executorPtr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+
+  // Specify the layout.
+  auto layout = clblast::Layout::kColMajor;
+
+  MemBuffer<scalar_t> m_a_gpu(executorPtr, m_a.data(),
+                              static_cast<size_t>(lda * n));
+  MemBuffer<scalar_t> v_x_gpu(executorPtr, v_x.data(),
+                              static_cast<size_t>(xlen));
+
+  // Specify the triangle.
+  clblast::Triangle a_uplo =
+      blas_benchmark::utils::translate_triangle(uplo_str);
+
+  // Specify the transposition.
+  clblast::Transpose a_tr =
+      blas_benchmark::utils::translate_transposition(t_str);
+
+  // Specify the unit-diagonal.
+  clblast::Diagonal a_diag =
+      blas_benchmark::utils::translate_diagonal(diag_str);
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> v_x_ref = v_x;
+  reference_blas::tbmv(uplo_str, t_str, diag_str, n, k, m_a.data(), lda,
+                       v_x_ref.data(), incX);
+  std::vector<scalar_t> v_x_temp = v_x;
+  {
+    MemBuffer<scalar_t> v_x_temp_gpu(executorPtr, v_x_temp.data(),
+                                     static_cast<size_t>(xlen));
+    cl_event event;
+    clblast::Tbmv<scalar_t>(layout, a_uplo, a_tr, a_diag, n, k, m_a_gpu.dev(),
+                            0, lda, v_x_temp_gpu.dev(), 0, incX,
+                            executorPtr->_queue(), &event);
+    CLEventHandler::wait(event);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(v_x_temp, v_x_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl_event> {
+    cl_event event;
+    clblast::Tbmv<scalar_t>(layout, a_uplo, a_tr, a_diag, n, k, m_a_gpu.dev(),
+                            0, lda, v_x_gpu.dev(), 0, incX,
+                            executorPtr->_queue(), &event);
+    CLEventHandler::wait(event);
+    return {event};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
+                        bool* success) {
+  auto tbmv_params = blas_benchmark::utils::get_tbmv_params(args);
+
+  for (auto p : tbmv_params) {
+    std::string uplos;
+    std::string ts;
+    std::string diags;
+    index_t n;
+    index_t k;
+    std::tie(uplos, ts, diags, n, k) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, ExecutorType* exPtr,
+                         std::string uplos, std::string ts, std::string diags,
+                         index_t n, index_t k, bool* success) {
+      run<scalar_t>(st, exPtr, uplos, ts, diags, n, k, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda, exPtr,
+        uplos, ts, diags, n, k, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, exPtr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/clBench/clblast/blas2/tbmv.cpp
+++ b/benchmark/clBench/clblast/blas2/tbmv.cpp
@@ -1,7 +1,7 @@
 /**************************************************************************
  *
  *  @license
- *  Copyright (C) 2023 Codeplay Software Limited
+ *  Copyright (C) Codeplay Software Limited
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at

--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -19,6 +19,7 @@ set(sources
   blas2/gbmv.cpp
   blas2/gemv.cpp
   blas2/sbmv.cpp
+  blas2/tbmv.cpp
   # Level 3 blas
   blas3/gemm.cpp
   blas3/gemm_batched.cpp

--- a/benchmark/syclblas/blas2/tbmv.cpp
+++ b/benchmark/syclblas/blas2/tbmv.cpp
@@ -1,0 +1,162 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) 2023 Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename tbmv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, std::string t, std::string diag, int n,
+                     int k) {
+  std::ostringstream str{};
+  str << "BM_Tbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
+         std::string uplo, std::string t, std::string diag, index_t n,
+         index_t k, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+  const char* t_str = t.c_str();
+  const char* diag_str = diag.c_str();
+
+  index_t xlen = n;
+  index_t lda = (k + 1);
+  index_t incX = 1;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+  double k_d = static_cast<double>(k);
+
+  state.counters["n"] = n_d;
+  state.counters["k"] = k_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = (n_d * (k_d + 1.0)) - (0.5 * (k_d * (k_d + 1.0)));
+
+  {
+    double nflops_AtimesX = 2.0 * A_validVal;
+    state.counters["n_fl_ops"] = nflops_AtimesX;
+  }
+
+  {
+    double mem_readA = A_validVal;
+    double mem_readX = xlen;
+    double mem_writeX = xlen;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+  }
+
+  blas::SB_Handle& sb_handle = *sb_handle_ptr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_a, lda * n);
+  auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_x, xlen);
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> v_x_ref = v_x;
+  reference_blas::tbmv(uplo_str, t_str, diag_str, n, k, m_a.data(), lda,
+                       v_x_ref.data(), incX);
+  std::vector<scalar_t> v_x_temp = v_x;
+  {
+    auto v_x_temp_gpu =
+        blas::make_sycl_iterator_buffer<scalar_t>(v_x_temp, xlen);
+    auto event = _tbmv(sb_handle, *uplo_str, *t_str, *diag_str, n, k, m_a_gpu,
+                       lda, v_x_temp_gpu, incX);
+    sb_handle.wait();
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(v_x_temp, v_x_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
+    auto event = _tbmv(sb_handle, *uplo_str, *t_str, *diag_str, n, k, m_a_gpu,
+                       lda, v_x_gpu, incX);
+    sb_handle.wait(event);
+    return event;
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+  sb_handle.wait();
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        blas::SB_Handle* sb_handle_ptr, bool* success) {
+  auto tbmv_params = blas_benchmark::utils::get_tbmv_params(args);
+
+  for (auto p : tbmv_params) {
+    std::string uplos;
+    std::string ts;
+    std::string diags;
+    index_t n;
+    index_t k;
+    std::tie(uplos, ts, diags, n, k) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
+                         std::string uplos, std::string ts, std::string diags,
+                         index_t n, index_t k, bool* success) {
+      run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, k, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
+        sb_handle_ptr, uplos, ts, diags, n, k, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      blas::SB_Handle* sb_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, sb_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/syclblas/blas2/tbmv.cpp
+++ b/benchmark/syclblas/blas2/tbmv.cpp
@@ -1,7 +1,7 @@
 /**************************************************************************
  *
  *  @license
- *  Copyright (C) 2023 Codeplay Software Limited
+ *  Copyright (C) Codeplay Software Limited
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -888,6 +888,7 @@ function (build_library LIB_NAME ENABLE_EXTENSIONS)
                 $<TARGET_OBJECTS:symv>
                 $<TARGET_OBJECTS:syr>
                 $<TARGET_OBJECTS:syr2>
+                $<TARGET_OBJECTS:tbmv>
                 $<TARGET_OBJECTS:trmv>
                 $<TARGET_OBJECTS:gemm_launcher>
                 $<TARGET_OBJECTS:gemm>

--- a/common/include/common/system_reference_blas.hpp
+++ b/common/include/common/system_reference_blas.hpp
@@ -258,6 +258,14 @@ void ger(int m, int n, scalar_t alpha, const scalar_t a[], int incX,
 }
 
 template <typename scalar_t>
+void tbmv(const char *uplo, const char *trans, const char *diag, int n, int k,
+          const scalar_t *a, int lda, scalar_t *x, int incX) {
+  auto func = blas_system_function<scalar_t>(&cblas_stbmv, &cblas_dtbmv);
+  func(CblasColMajor, c_uplo(*uplo), c_trans(*trans), c_diag(*diag), n, k, a,
+       lda, x, incX);
+}
+
+template <typename scalar_t>
 void trmv(const char *uplo, const char *trans, const char *diag, const int n,
           const scalar_t *a, const int lda, scalar_t *x, const int incX) {
   auto func = blas_system_function<scalar_t>(&cblas_strmv, &cblas_dtrmv);

--- a/include/blas_meta.h
+++ b/include/blas_meta.h
@@ -75,6 +75,12 @@ enum class transpose_type : char {
  */
 enum class uplo_type : char { Upper = 'u', Lower = 'l' };
 
+/**
+ * @enum Diag
+ * @brief Specifies the values on the diagonal of a triangular matrix.
+ */
+enum class diag_type : char { Nonunit = 'n', Unit = 'u' };
+
 // choosing value at compile-time
 template <bool Conds, typename val_t, val_t value_one_t, val_t value_two_t>
 struct Choose {

--- a/include/interface/blas2_interface.h
+++ b/include/interface/blas2_interface.h
@@ -313,6 +313,43 @@ typename sb_handle_t::event_t _sbmv_impl(sb_handle_t& sb_handle, index_t _N,
                                          element_t _beta, container_t2 _vy,
                                          increment_t _incy);
 
+/**
+ * @brief Matrix vector product with triangular band matrices.
+ *
+ * Matrix vector product with a triangular band matrix, i.e. computing the
+ * mathematical operation:
+ *
+ * x = op(A)*x
+ *
+ * See the netlib blas interface documentation for more details of the
+ * interface: https://netlib.org/lapack/explore-html/d6/d7d/stbmv_8f.html
+ *
+ * @param sb_handle SB_handle
+ * @param _Uplo Specifies if A is upper or lower triangular
+ * @param _trans Transposition operation applied to A ('n', 't', 'c')
+ * @param _Diag Specifies if A unit triangular or not
+ * @param _N Number of rows and columns of A
+ * @param _K Number of A super-diagonals
+ * @param _mA Buffer (_LDA,_N) containing the coefficient of A in the Band
+ *            Matrix format
+ * @param _lda Leading dimension _mA at least (_K + 1)
+ * @param _vx Buffer containing x of at least (1+(_N-1)*abs(_incx)) elements
+ * @param _incx Increment for _vx (nonzero)
+ */
+template <typename sb_handle_t, typename index_t, typename container_0_t,
+          typename container_1_t, typename increment_t>
+typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, char _Uplo,
+                                    char _trans, char _Diag, index_t _N,
+                                    index_t _K, container_0_t _mA, index_t _lda,
+                                    container_1_t _vx, increment_t _incx);
+
+template <uint32_t local_range, uplo_type uplo, transpose_type trn,
+          diag_type diag, typename sb_handle_t, typename index_t,
+          typename container_t0, typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _tbmv_impl(sb_handle_t& sb_handle, index_t _N,
+                                         index_t _K, container_t0 _mA,
+                                         index_t _lda, container_t1 _vx,
+                                         increment_t _incx);
 }  // namespace internal
 
 /*!
@@ -590,6 +627,39 @@ typename sb_handle_t::event_t _sbmv(sb_handle_t& sb_handle, char _Uplo,
                                     increment_t _incy) {
   return internal::_sbmv(sb_handle, _Uplo, _N, _K, _alpha, _mA, _lda, _vx,
                          _incx, _beta, _vy, _incy);
+}
+
+/**
+ * @brief Matrix vector product with triangular band matrices.
+ *
+ * Matrix vector product with a triangular band matrix, i.e. computing the
+ * mathematical operation:
+ *
+ * x = op(A)*x
+ *
+ * See the netlib blas interface documentation for more details of the
+ * interface: https://netlib.org/lapack/explore-html/d6/d7d/stbmv_8f.html
+ *
+ * @param sb_handle SB_handle
+ * @param _Uplo Specifies if A is upper or lower triangular
+ * @param _trans Transposition operation applied to A ('n', 't', 'c')
+ * @param _Diag Specifies if A unit triangular or not
+ * @param _N Number of rows and columns of A
+ * @param _K Number of A super-diagonals
+ * @param _mA Buffer (_LDA,_N) containing the coefficient of A in the Band
+ *            Matrix format
+ * @param _lda Leading dimension _mA at least (_K + 1)
+ * @param _vx Buffer containing x of at least (1+(_N-1)*abs(_incx)) elements
+ * @param _incx Increment for _vx (nonzero)
+ */
+template <typename sb_handle_t, typename index_t, typename container_0_t,
+          typename container_1_t, typename increment_t>
+typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, char _Uplo,
+                                    char _trans, char _Diag, index_t _N,
+                                    index_t _K, container_0_t _mA, index_t _lda,
+                                    container_1_t _vx, increment_t _incx) {
+  return internal::_tbmv(sb_handle, _Uplo, _trans, _Diag, _N, _K, _mA, _lda,
+                         _vx, _incx);
 }
 
 }  // namespace blas

--- a/include/operations/blas2_trees.h
+++ b/include/operations/blas2_trees.h
@@ -309,6 +309,44 @@ Sbmv<lhs_t, matrix_t, vector_t, local_range, uplo> make_sbmv(
       lhs_, matrix_, k_, vector_, alpha_, beta_);
 }
 
+/**
+ * @struct Tbmv
+ * @brief Tree node representing a triangular band matrix_ vector_
+ * multiplication.
+ */
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed, bool is_unit>
+struct Tbmv {
+  using value_t = typename vector_t::value_t;
+  using index_t = typename vector_t::index_t;
+
+  lhs_t lhs_;
+  matrix_t matrix_;
+  index_t k_;
+  vector_t vector_;
+
+  Tbmv(lhs_t &_l, matrix_t &_matrix, index_t &_k, vector_t &_vector);
+  index_t get_size() const;
+  bool valid_thread(cl::sycl::nd_item<1> ndItem) const;
+  value_t eval(index_t i);
+  value_t eval(cl::sycl::nd_item<1> ndItem);
+  template <typename sharedT>
+  value_t eval(sharedT shrMem, cl::sycl::nd_item<1> ndItem);
+  void bind(cl::sycl::handler &h);
+  void adjust_access_displacement();
+};
+/*!
+ @brief Generator/factory for TBMV trees.
+ */
+template <uint32_t local_range, bool is_upper, bool is_transposed, bool is_unit,
+          typename lhs_t, typename matrix_t, typename vector_t>
+Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed, is_unit>
+make_tbmv(lhs_t &lhs_, matrix_t &matrix_, typename vector_t::index_t k_,
+          vector_t &vector_) {
+  return Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+              is_unit>(lhs_, matrix_, k_, vector_);
+}
+
 /**** GER BY ROWS M ROWS x N BLOCK USING PROPERLY THE SHARED MEMORY ****/
 // template <typename lhs_t,typename rhs_1_t,typename rhs_2_t>
 template <bool Single, bool Lower, bool Diag, bool Upper, typename lhs_t,

--- a/src/interface/blas2/CMakeLists.txt
+++ b/src/interface/blas2/CMakeLists.txt
@@ -31,6 +31,7 @@ generate_blas_ternary_objects(blas2 sbmv)
 generate_blas_ternary_objects(blas2 symv)
 generate_blas_ternary_objects(blas2 syr2)
 generate_blas_binary_objects(blas2 syr)
+generate_blas_binary_objects(blas2 tbmv)
 generate_blas_binary_objects(blas2 trmv)
 
 if(BLAS_ENABLE_CONST_INPUT)

--- a/src/interface/blas2/backend/amd_gpu.hpp
+++ b/src/interface/blas2/backend/amd_gpu.hpp
@@ -85,5 +85,19 @@ typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace sbmv
+
+namespace tbmv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
+                                    index_t _K, container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_tbmv_impl<64, uplo, trn, diag>(sb_handle, _N, _K, _mA,
+                                                         _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace tbmv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/arm_gpu.hpp
+++ b/src/interface/blas2/backend/arm_gpu.hpp
@@ -82,5 +82,19 @@ typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace sbmv
+
+namespace tbmv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
+                                    index_t _K, container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_tbmv_impl<32, uplo, trn, diag>(sb_handle, _N, _K, _mA,
+                                                         _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace tbmv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/default_cpu.hpp
+++ b/src/interface/blas2/backend/default_cpu.hpp
@@ -82,5 +82,19 @@ typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace sbmv
+
+namespace tbmv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
+                                    index_t _K, container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_tbmv_impl<256, uplo, trn, diag>(
+      sb_handle, _N, _K, _mA, _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace tbmv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/intel_gpu.hpp
+++ b/src/interface/blas2/backend/intel_gpu.hpp
@@ -82,5 +82,19 @@ typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace sbmv
+
+namespace tbmv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
+                                    index_t _K, container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_tbmv_impl<64, uplo, trn, diag>(sb_handle, _N, _K, _mA,
+                                                         _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace tbmv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/nvidia_gpu.hpp
+++ b/src/interface/blas2/backend/nvidia_gpu.hpp
@@ -82,5 +82,19 @@ typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace sbmv
+
+namespace tbmv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
+                                    index_t _K, container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_tbmv_impl<64, uplo, trn, diag>(sb_handle, _N, _K, _mA,
+                                                         _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace tbmv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/power_vr.hpp
+++ b/src/interface/blas2/backend/power_vr.hpp
@@ -82,5 +82,19 @@ typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace sbmv
+
+namespace tbmv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
+                                    index_t _K, container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_tbmv_impl<256, uplo, trn, diag>(
+      sb_handle, _N, _K, _mA, _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace tbmv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/rcar.hpp
+++ b/src/interface/blas2/backend/rcar.hpp
@@ -87,5 +87,19 @@ typename SB_Handle::event_t inline _sbmv(SB_Handle& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace sbmv
+
+namespace tbmv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
+                                    index_t _K, container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_tbmv_impl<32, uplo, trn, diag>(sb_handle, _N, _K, _mA,
+                                                         _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace tbmv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/tbmv.cpp.in
+++ b/src/interface/blas2/tbmv.cpp.in
@@ -19,17 +19,25 @@
  *
  *  SYCL-BLAS: BLAS implementation using SYCL
  *
- *  @filename blas2_trees.hpp
+ *  @filename tbmv.cpp.in
  *
  **************************************************************************/
+#include "container/sycl_iterator.hpp"
+#include "sb_handle/sycl_blas_handle.hpp"
+#include "sb_handle/kernel_constructor.hpp"
+#include "interface/blas2_interface.hpp"
+#include "operations/blas1_trees.hpp"
+#include "operations/blas2_trees.hpp"
+#include "operations/blas_constants.hpp"
+#include "views/view_sycl.hpp"
 
-#ifndef SYCL_BLAS_BLAS2_TREES_HPP
-#define SYCL_BLAS_BLAS2_TREES_HPP
+namespace blas {
+namespace internal {
+template typename SB_Handle::event_t _tbmv(
+    SB_Handle& sb_handle, char _Uplo, char _trans, char _Diag,
+    ${INDEX_TYPE} _N, ${INDEX_TYPE} _K,
+    ${container_t0} _mA, ${INDEX_TYPE} _lda,
+    ${container_t1} _vx, ${INCREMENT_TYPE} _incx);
 
-#include "blas2/gbmv.hpp"
-#include "blas2/gemv.hpp"
-#include "blas2/ger.hpp"
-#include "blas2/sbmv.hpp"
-#include "blas2/tbmv.hpp"
-
-#endif  // BLAS2_TREES_HPP
+}  // namespace internal
+}  // namespace blas

--- a/src/interface/blas2_interface.hpp
+++ b/src/interface/blas2_interface.hpp
@@ -480,6 +480,43 @@ typename sb_handle_t::event_t _sbmv_impl(sb_handle_t& sb_handle, index_t _N,
                            roundUp<index_t>(vector_size, local_range));
 }
 
+template <uint32_t local_range, uplo_type uplo, transpose_type trn,
+          diag_type diag, typename sb_handle_t, typename index_t,
+          typename container_t0, typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _tbmv_impl(sb_handle_t& sb_handle, index_t _N,
+                                         index_t _K, container_t0 _mA,
+                                         index_t _lda, container_t1 _vx,
+                                         increment_t _incx) {
+  constexpr bool is_upper = (uplo == uplo_type::Upper);
+  constexpr bool is_transposed = (trn != transpose_type::Normal);
+  constexpr bool is_unit = (diag == diag_type::Unit);
+
+  if (_K >= _N) {
+    throw std::invalid_argument("Erroneous parameter");
+  }
+
+  constexpr index_t one = 1;
+  auto x_vector_size = _N;
+  auto res_buffer =
+      blas::make_sycl_iterator_buffer<typename container_t0::scalar_t>(
+          x_vector_size);
+
+  auto mA = make_matrix_view<col_major>(_mA, _K + 1, _N, _lda);
+  auto vx = make_vector_view(_vx, _incx, x_vector_size);
+  auto vres = make_vector_view(res_buffer, one, x_vector_size);
+
+  const index_t global_size = roundUp<index_t>(x_vector_size, local_range);
+  auto tbmv = make_tbmv<local_range, is_upper, is_transposed, is_unit>(vres, mA,
+                                                                       _K, vx);
+
+  auto tbmvEvent =
+      sb_handle.execute(tbmv, static_cast<index_t>(local_range), global_size);
+
+  auto assignOp = make_op<Assign>(vx, vres);
+  return concatenate_vectors(tbmvEvent,
+                             sb_handle.execute(assignOp, local_range));
+}
+
 /**** RANK 1 MODIFICATION ****/
 
 template <typename sb_handle_t, typename index_t, typename element_t,
@@ -762,6 +799,58 @@ typename sb_handle_t::event_t inline _syr2(sb_handle_t& sb_handle, char _Uplo,
   // scratch size per device
   return _syr2_impl(sb_handle, _Uplo, _N, _alpha, _vx, _incx, _vy, _incy, _mA,
                     _lda);
+}
+template <typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, char _Uplo,
+                                    char _trans, char _Diag, index_t _N,
+                                    index_t _K, container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  if (tolower(_Uplo) == 'u') {
+    if (tolower(_trans) == 'n') {
+      if (tolower(_Diag) == 'n') {
+        return blas::tbmv::backend::_tbmv<
+            uplo_type::Upper, transpose_type::Normal, diag_type::Nonunit>(
+            sb_handle, _N, _K, _mA, _lda, _vx, _incx);
+      } else {
+        return blas::tbmv::backend::_tbmv<
+            uplo_type::Upper, transpose_type::Normal, diag_type::Unit>(
+            sb_handle, _N, _K, _mA, _lda, _vx, _incx);
+      }
+    } else {
+      if (tolower(_Diag) == 'n') {
+        return blas::tbmv::backend::_tbmv<
+            uplo_type::Upper, transpose_type::Transposed, diag_type::Nonunit>(
+            sb_handle, _N, _K, _mA, _lda, _vx, _incx);
+      } else {
+        return blas::tbmv::backend::_tbmv<
+            uplo_type::Upper, transpose_type::Transposed, diag_type::Unit>(
+            sb_handle, _N, _K, _mA, _lda, _vx, _incx);
+      }
+    }
+  } else {
+    if (tolower(_trans) == 'n') {
+      if (tolower(_Diag) == 'n') {
+        return blas::tbmv::backend::_tbmv<
+            uplo_type::Lower, transpose_type::Normal, diag_type::Nonunit>(
+            sb_handle, _N, _K, _mA, _lda, _vx, _incx);
+      } else {
+        return blas::tbmv::backend::_tbmv<
+            uplo_type::Lower, transpose_type::Normal, diag_type::Unit>(
+            sb_handle, _N, _K, _mA, _lda, _vx, _incx);
+      }
+    } else {
+      if (tolower(_Diag) == 'n') {
+        return blas::tbmv::backend::_tbmv<
+            uplo_type::Lower, transpose_type::Transposed, diag_type::Nonunit>(
+            sb_handle, _N, _K, _mA, _lda, _vx, _incx);
+      } else {
+        return blas::tbmv::backend::_tbmv<
+            uplo_type::Lower, transpose_type::Transposed, diag_type::Unit>(
+            sb_handle, _N, _K, _mA, _lda, _vx, _incx);
+      }
+    }
+  }
 }
 
 }  // namespace internal

--- a/src/interface/blas2_interface.hpp
+++ b/src/interface/blas2_interface.hpp
@@ -495,7 +495,7 @@ typename sb_handle_t::event_t _tbmv_impl(sb_handle_t& sb_handle, index_t _N,
     throw std::invalid_argument("Erroneous parameter: _K >= _N");
   }
 
-  constexpr index_t one = 1;
+  using one = constant<index_t, const_val::one>;
   auto x_vector_size = _N;
   auto res_buffer =
       blas::make_sycl_iterator_buffer<typename container_t0::scalar_t>(
@@ -503,7 +503,7 @@ typename sb_handle_t::event_t _tbmv_impl(sb_handle_t& sb_handle, index_t _N,
 
   auto mA = make_matrix_view<col_major>(_mA, _K + 1, _N, _lda);
   auto vx = make_vector_view(_vx, _incx, x_vector_size);
-  auto vres = make_vector_view(res_buffer, one, x_vector_size);
+  auto vres = make_vector_view(res_buffer, one::value(), x_vector_size);
 
   const index_t global_size = roundUp<index_t>(x_vector_size, local_range);
   auto tbmv = make_tbmv<local_range, is_upper, is_transposed, is_unit>(vres, mA,

--- a/src/interface/blas2_interface.hpp
+++ b/src/interface/blas2_interface.hpp
@@ -492,7 +492,7 @@ typename sb_handle_t::event_t _tbmv_impl(sb_handle_t& sb_handle, index_t _N,
   constexpr bool is_unit = (diag == diag_type::Unit);
 
   if (_K >= _N) {
-    throw std::invalid_argument("Erroneous parameter");
+    throw std::invalid_argument("Erroneous parameter: _K >= _N");
   }
 
   constexpr index_t one = 1;

--- a/src/operations/blas2/tbmv.hpp
+++ b/src/operations/blas2/tbmv.hpp
@@ -75,8 +75,8 @@ SYCL_BLAS_INLINE typename Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper,
                                is_transposed, is_unitdiag>::value_t
 Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
      is_unitdiag>::eval(cl::sycl::nd_item<1> ndItem) {
-  const index_t lhs_idx =
-      ndItem.get_group(0) * local_range + ndItem.get_local_id(0);
+  const index_t lhs_idx = ndItem.get_global(0);
+
   value_t val = 0;
 
   if (lhs_idx < lhs_.get_size()) {

--- a/src/operations/blas2/tbmv.hpp
+++ b/src/operations/blas2/tbmv.hpp
@@ -75,7 +75,7 @@ SYCL_BLAS_INLINE typename Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper,
                                is_transposed, is_unitdiag>::value_t
 Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
      is_unitdiag>::eval(cl::sycl::nd_item<1> ndItem) {
-  const index_t lhs_idx = ndItem.get_global(0);
+  const index_t lhs_idx = ndItem.get_global_id(0);
 
   value_t val = 0;
 

--- a/src/operations/blas2/tbmv.hpp
+++ b/src/operations/blas2/tbmv.hpp
@@ -1,0 +1,132 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename tbmv.hpp
+ *
+ **************************************************************************/
+
+#ifndef TBMV_HPP
+#define TBMV_HPP
+#include "operations/blas2_trees.h"
+#include "operations/blas_operators.hpp"
+#include "views/view_sycl.hpp"
+#include <stdexcept>
+#include <vector>
+namespace blas {
+
+/**
+ * @struct Tbmv
+ * @brief Tree node representing a triangular band matrix_ vector_
+ * multiplication.
+ */
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed,
+          bool is_unitdiag>
+SYCL_BLAS_INLINE
+Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+     is_unitdiag>::Tbmv(lhs_t &_l, matrix_t &_matrix,
+                        typename Tbmv<lhs_t, matrix_t, vector_t, local_range,
+                                      is_upper, is_transposed,
+                                      is_unitdiag>::index_t &_k,
+                        vector_t &_vector)
+    : lhs_(_l), matrix_(_matrix), vector_(_vector), k_(_k) {}
+
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed,
+          bool is_unitdiag>
+SYCL_BLAS_INLINE typename Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper,
+                               is_transposed, is_unitdiag>::index_t
+Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+     is_unitdiag>::get_size() const {
+  return matrix_.get_size();
+}
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed,
+          bool is_unitdiag>
+SYCL_BLAS_INLINE bool
+Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+     is_unitdiag>::valid_thread(cl::sycl::nd_item<1> ndItem) const {
+  // Valid threads are established by ::eval.
+  return true;
+}
+
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed,
+          bool is_unitdiag>
+SYCL_BLAS_INLINE typename Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper,
+                               is_transposed, is_unitdiag>::value_t
+Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+     is_unitdiag>::eval(cl::sycl::nd_item<1> ndItem) {
+  const index_t lhs_idx =
+      ndItem.get_group(0) * local_range + ndItem.get_local_id(0);
+  value_t val = 0;
+
+  if (lhs_idx < lhs_.get_size()) {
+    const index_t kl_ = is_upper ? 0 : k_;
+    const index_t ku_ = is_upper ? k_ : 0;
+
+    const index_t k_lower = is_transposed ? ku_ : kl_;
+    const index_t k_upper = is_transposed ? kl_ : ku_;
+
+    const index_t k_beg = cl::sycl::max(index_t(0), lhs_idx - k_lower);
+    const index_t k_end =
+        cl::sycl::min(vector_.get_size(), lhs_idx + k_upper + 1);
+    const index_t k_off = ku_ + (is_transposed ? -lhs_idx : lhs_idx);
+
+    for (index_t s_idx = k_beg; s_idx < k_end; ++s_idx) {
+      const index_t K = k_off + (is_transposed ? s_idx : -s_idx);
+      const index_t J = is_transposed ? lhs_idx : s_idx;
+      val = AddOperator::eval(
+          val, ProductOperator::eval(is_unitdiag && ((is_upper && (K == k_)) ||
+                                                     (!is_upper && (K == 0)))
+                                         ? value_t(1)
+                                         : matrix_.eval(K, J),
+                                     vector_.eval(s_idx)));
+    }
+
+    lhs_.eval(lhs_idx) = val;
+  }
+  return val;
+}
+
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed,
+          bool is_unitdiag>
+SYCL_BLAS_INLINE void
+Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+     is_unitdiag>::bind(cl::sycl::handler &h) {
+  lhs_.bind(h);
+  matrix_.bind(h);
+  vector_.bind(h);
+}
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed,
+          bool is_unitdiag>
+SYCL_BLAS_INLINE void
+Tbmv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+     is_unitdiag>::adjust_access_displacement() {
+  lhs_.adjust_access_displacement();
+  matrix_.adjust_access_displacement();
+  vector_.adjust_access_displacement();
+}
+
+}  // namespace blas
+#endif

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -64,6 +64,7 @@ if(is_computecpp)
     ${SYCLBLAS_UNITTEST}/blas1/blas1_iamin_test.cpp
     # Blas 2 tests
     ${SYCLBLAS_UNITTEST}/blas2/blas2_trmv_test.cpp
+    ${SYCLBLAS_UNITTEST}/blas2/blas2_tbmv_test.cpp
     # Blas buffer tests
     ${SYCLBLAS_UNITTEST}/buffers/sycl_buffer_test.cpp
   )

--- a/test/unittest/blas2/blas2_tbmv_test.cpp
+++ b/test/unittest/blas2/blas2_tbmv_test.cpp
@@ -1,0 +1,118 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename blas2_tbmv_test.cpp
+ *
+ **************************************************************************/
+
+#include "blas_test.hpp"
+
+template <typename T>
+using combination_t = std::tuple<int, int, bool, bool, bool, int, int>;
+
+template <typename scalar_t>
+void run_test(const combination_t<scalar_t> combi) {
+  index_t n;
+  index_t k;
+  bool trans;
+  bool is_upper;
+  bool is_unit;
+  index_t incX;
+  index_t lda_mul;
+  std::tie(n, k, is_upper, trans, is_unit, incX, lda_mul) = combi;
+
+  const char* t_str = trans ? "t" : "n";
+  const char* uplo_str = is_upper ? "u" : "l";
+  const char* diag_str = is_unit ? "u" : "n";
+
+  int a_size = (k + 1) * n * lda_mul;
+  int x_size = 1 + (n - 1) * incX;
+
+  // Input matrix
+  std::vector<scalar_t> a_m(a_size, 10.0);
+  // Input/output vector
+  std::vector<scalar_t> x_v(x_size, 10.0);
+  // Input/output system vector
+  std::vector<scalar_t> x_v_cpu(x_size, scalar_t(10.0));
+
+  fill_random(a_m);
+  fill_random(x_v);
+
+  x_v_cpu = x_v;
+
+  // SYSTEM TBMV
+  reference_blas::tbmv(uplo_str, t_str, diag_str, n, k, a_m.data(),
+                       (k + 1) * lda_mul, x_v_cpu.data(), incX);
+
+  auto q = make_queue();
+  blas::SB_Handle sb_handle(q);
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(a_m, a_size);
+  auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(x_v, x_size);
+
+  // SYCL TBMV
+  _tbmv(sb_handle, *uplo_str, *t_str, *diag_str, n, k, m_a_gpu,
+        (k + 1) * lda_mul, v_x_gpu, incX);
+
+  auto event = blas::helper::copy_to_host(sb_handle.get_queue(), v_x_gpu,
+                                          x_v.data(), x_size);
+  sb_handle.wait(event);
+
+  const bool isAlmostEqual = utils::compare_vectors(x_v, x_v_cpu);
+  ASSERT_TRUE(isAlmostEqual);
+}
+
+#ifdef STRESS_TESTING
+template <typename scalar_t>
+const auto combi =
+    ::testing::Combine(::testing::Values(14, 63, 257, 1010),  // n
+                       ::testing::Values(3, 4, 9),            // k
+                       ::testing::Values(true, false),        // is_upper
+                       ::testing::Values(true, false),        // trans
+                       ::testing::Values(true, false),        // is_unit
+                       ::testing::Values(1, 2),               // incX
+                       ::testing::Values(1, 2)                // lda_mul
+    );
+#else
+// For the purpose of travis and other slower platforms, we need a faster test
+// (the stress_test above takes about ~5 minutes)
+template <typename scalar_t>
+const auto combi =
+    ::testing::Combine(::testing::Values(14, 1010),     // n
+                       ::testing::Values(3, 4),         // k
+                       ::testing::Values(true, false),  // is_upper
+                       ::testing::Values(true, false),  // trans
+                       ::testing::Values(true, false),  // is_unit
+                       ::testing::Values(2),            // incX
+                       ::testing::Values(2)             // lda_mul
+    );
+#endif
+
+template <class T>
+static std::string generate_name(
+    const ::testing::TestParamInfo<combination_t<T>>& info) {
+  int n, k, incX, ldaMul;
+  bool is_upper;
+  bool trans;
+  bool is_unit;
+  BLAS_GENERATE_NAME(info.param, n, k, is_upper, trans, is_unit, incX, ldaMul);
+}
+
+BLAS_REGISTER_TEST_ALL(Tbmv, combination_t, combi, generate_name);


### PR DESCRIPTION
This patch adds a baseline implementation of `TBMV` compatible with `TUNING_TARGET` specialization.