### PR TITLE
Disable -ffast-math in tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(SystemBLAS REQUIRED)
 set(SYCLBLAS_TEST ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -Wno-shorten-64-to-32 -Wno-cast-align") 
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-deprecated-copy-with-user-provided-copy -Wno-unused-variable")
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fno-fast-math")
 
 # Download and build googletest
 # The following operations are derived from the official advice on building googletest as a subproject,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(SystemBLAS REQUIRED)
 set(SYCLBLAS_TEST ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -Wno-shorten-64-to-32 -Wno-cast-align") 
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-deprecated-copy-with-user-provided-copy -Wno-unused-variable")
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fno-fast-math")
 
 # Download and build googletest
 # The following operations are derived from the official advice on building googletest as a subproject,

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -74,6 +74,12 @@ if(is_computecpp)
   endif()
 endif()
 
+# Contains tests that fail if compiled with -ffast-math
+set(SYCL_UNITTEST_NOFASTMATH
+  ${SYCLBLAS_UNITTEST}/blas1/blas1_rotg_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas1/blas1_rotmg_test.cpp
+)
+
 if(GEMM_TALL_SKINNY_SUPPORT)
   list(APPEND SYCL_UNITTEST_SRCS ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_tall_skinny_test.cpp)
 endif()
@@ -90,6 +96,12 @@ foreach(blas_test ${SYCL_UNITTEST_SRCS})
   target_compile_definitions(${test_exec} PRIVATE -DBLAS_INDEX_T=${BLAS_TEST_INDEX_TYPE})
   target_link_libraries(${test_exec} PRIVATE gtest_main Clara::Clara blas::blas sycl_blas)
   target_include_directories(${test_exec} PRIVATE ${CBLAS_INCLUDE} ${SYCLBLAS_COMMON_INCLUDE_DIR})
+
+  list (FIND SYCL_UNITTEST_NOFASTMATH ${blas_test} _index)
+  if (${_index} GREATER -1)
+    target_compile_options(${test_exec} PRIVATE "-fno-fast-math")
+  endif()
+
   if(TEST_DEVICE)
     add_test(NAME ${test_exec} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${test_exec} --device ${TEST_DEVICE} --gtest_output=xml:output/)
   else()


### PR DESCRIPTION
This patch disables the fast math optimizations for the test compilation. These optimizations cause test failures in `blas1_rotmg_test` and `blas1_rotg_test`.

Fast math optimizations are applied by default by `Intel(R) oneAPI DPC++/C++ Compiler 2023.0.0` binary release.