### PR TITLE
Fixed a GEMM Config causing drop in performance with DPCPP on intel GPU

### DIFF
--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -597,7 +597,7 @@ if(${TUNING_TARGET} STREQUAL "INTEL_GPU")
       64 4 4 8 8 1 1 1 1 1 1 1 1 1 float float "local" "standard" "full" 4 "strided" "false")
     add_gemm_configuration(
       "${data}" 64 "false" "false" "false"
-      64 8 8 8 8 1 1 1 1 1 1 1 1 1 float float "local" "standard" "full" 4 "strided" "false")
+      64 4 8 16 8 1 1 1 1 1 1 1 1 1 float float "local" "standard" "full" 4 "strided" "false")
     add_gemm_configuration(
       "${data}" 64 "false" "false" "false"
       64 8 8 8 8 1 1 1 1 1 1 1 1 1 float float "no_local" "standard" "partial" 4 "strided" "false")

--- a/src/interface/blas3/backend/intel_gpu.hpp
+++ b/src/interface/blas3/backend/intel_gpu.hpp
@@ -227,7 +227,7 @@ typename sb_handle_t::event_t _gemm(sb_handle_t& sb_handle, index_t _M,
                                                                 batch_size);
   } else {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<8, 8, 8, 8>, _t_a, _t_b,
+        64, false, false, false, 64, Tile<4, 8, 16, 8>, _t_a, _t_b,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,


### PR DESCRIPTION
This small patch rectifies the tiling parameters of a tuned GEMM configuration for intel GPUs that was causing a considerable drop in performance _(2 orders of magnitude)_ when used with DPC++ _(observed using the default benchmarking setup, mainly visible on high `mnk` values as they end up picking that particular GEMM kernel)_.
