### PR TITLE
Add TRSV baseline implementation

### DIFF
--- a/benchmark/clBench/clblas/CMakeLists.txt
+++ b/benchmark/clBench/clblas/CMakeLists.txt
@@ -30,7 +30,10 @@ endif()
 find_package(clBLAS REQUIRED)
 
 set(sources
-  "blas3/trsm.cpp"
+  # Level 2 blas
+  blas2/trsv.cpp
+  # Level 3 blas
+  blas3/trsm.cpp
 )
 
 foreach(clblas_benchmark ${sources})

--- a/benchmark/clBench/clblas/blas2/trsv.cpp
+++ b/benchmark/clBench/clblas/blas2/trsv.cpp
@@ -1,0 +1,239 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trsv.cpp
+ *
+ **************************************************************************/
+
+// This does not work due to a clBLAS bug, see
+// https://github.com/clMathLibraries/clBLAS/issues/341
+//
+// error: variables in the local address space can only be declared in the
+// outermost scope of a kernel function
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
+  std::ostringstream str{};
+  str << "BM_Trsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << t << "/" << diag << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
+         std::string t, std::string diag, index_t n, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+  const char* t_str = t.c_str();
+  const char* diag_str = diag.c_str();
+
+  index_t xlen = n;
+  index_t lda = n;
+  index_t incX = 1;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = .5 * n_d * (n_d + 1);
+
+  {
+    double nflops = n_d * n_d;
+    state.counters["n_fl_ops"] = nflops;
+  }
+
+  {
+    double mem_readA = A_validVal;
+    double mem_readX = A_validVal;
+    double mem_writeX = A_validVal;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+  }
+
+  ExecutorType& ex = *executorPtr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+
+  // Populate the main diagonal with larger values.
+  for (int i = 0; i < n; ++i)
+    for (int j = 0; j < n; ++j)
+      m_a[(i * lda) + i] = (i == j) ? blas_benchmark::utils::random_scalar(
+                                          scalar_t{9}, scalar_t{11})
+                                    : blas_benchmark::utils::random_scalar(
+                                          scalar_t{-0.1}, scalar_t{0.1});
+
+  // Specify the layout.
+  auto layout = clblasColumnMajor;
+
+  // Specify the triangle.
+  clblasUplo a_uplo = blas_benchmark::utils::translate_triangle(uplo_str);
+
+  // Specify the transposition.
+  clblasTranspose a_tr = blas_benchmark::utils::translate_transposition(t_str);
+
+  // Specify the unit-diagonal.
+  clblasDiag a_diag = blas_benchmark::utils::translate_diagonal(diag_str);
+
+  if (clblasSetup() != CL_SUCCESS) {
+    state.SkipWithError("error initiazing clblas");
+    *success = false;
+    return;
+  }
+
+  cl_int err = CL_SUCCESS;
+  cl_mem m_a_gpu = clCreateBuffer(executorPtr->ctx(), CL_MEM_READ_ONLY,
+                                  lda * n * sizeof(scalar_t), nullptr, &err);
+  cl_mem v_x_gpu = clCreateBuffer(executorPtr->ctx(), CL_MEM_READ_WRITE,
+                                  xlen * sizeof(scalar_t), nullptr, &err);
+  cl_mem v_x_temp_gpu = clCreateBuffer(executorPtr->ctx(), CL_MEM_READ_WRITE,
+                                       xlen * sizeof(scalar_t), nullptr, &err);
+
+  if (err != CL_SUCCESS) {
+    state.SkipWithError("error creating opencl buffers");
+    *success = false;
+    return;
+  }
+
+  err = clEnqueueWriteBuffer(executorPtr->queue(), m_a_gpu, CL_TRUE, 0,
+                             lda * n * sizeof(scalar_t), m_a.data(), 0, nullptr,
+                             nullptr);
+  err = clEnqueueWriteBuffer(executorPtr->queue(), v_x_gpu, CL_TRUE, 0,
+                             xlen * sizeof(scalar_t), v_x.data(), 0, nullptr,
+                             nullptr);
+
+  if (err != CL_SUCCESS) {
+    state.SkipWithError("error writing opencl buffers");
+    *success = false;
+    return;
+  }
+
+  cl_command_queue clQueue = executorPtr->queue();
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> v_x_ref = v_x;
+  reference_blas::trsv(uplo_str, t_str, diag_str, n, m_a.data(), lda,
+                       v_x_ref.data(), incX);
+  std::vector<scalar_t> v_x_temp = v_x;
+  {
+    err = clEnqueueWriteBuffer(executorPtr->queue(), v_x_temp_gpu, CL_TRUE, 0,
+                               xlen * sizeof(scalar_t), v_x_temp.data(), 0,
+                               nullptr, nullptr);
+
+    cl_event event;
+    err = clblasStrsv(layout, a_uplo, a_tr, a_diag, n, m_a_gpu, 0, lda,
+                      v_x_temp_gpu, 0, incX, 1, &clQueue, 0, nullptr, &event);
+    err = clWaitForEvents(1, &event);
+
+    if (err != CL_SUCCESS) {
+      state.SkipWithError("error running clblasStrsm");
+      *success = false;
+      return;
+    }
+
+    err = clEnqueueReadBuffer(clQueue, v_x_temp_gpu, CL_TRUE, 0,
+                              xlen * sizeof(scalar_t), v_x_temp.data(), 0,
+                              nullptr, nullptr);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(v_x_temp, v_x_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl_event> {
+    cl_event event;
+    clblasStatus ret =
+        clblasStrsv(layout, a_uplo, a_tr, a_diag, n, m_a_gpu, 0, lda,
+                    v_x_temp_gpu, 0, incX, 1, &clQueue, 0, nullptr, &event);
+
+    if (ret != clblasSuccess) {
+      *success = false;
+      state.SkipWithError("Failed");
+      return {};
+    } else {
+      CLEventHandler::wait(event);
+      return {event};
+    }
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
+                        bool* success) {
+  auto tbmv_params = blas_benchmark::utils::get_tbmv_params(args);
+
+  for (auto p : tbmv_params) {
+    std::string uplos;
+    std::string ts;
+    std::string diags;
+    index_t n;
+    index_t k;
+    std::tie(uplos, ts, diags, n, k) = p;
+
+    // Repurpose tbmv_params.
+    if (k != 1) continue;
+
+    auto BM_lambda = [&](benchmark::State& st, ExecutorType* exPtr,
+                         std::string uplos, std::string ts, std::string diags,
+                         index_t n, bool* success) {
+      run<scalar_t>(st, exPtr, uplos, ts, diags, n, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda, exPtr,
+        uplos, ts, diags, n, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, exPtr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/clBench/clblas/blas2/trsv.cpp
+++ b/benchmark/clBench/clblas/blas2/trsv.cpp
@@ -207,9 +207,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
                         bool* success) {
-  auto tbmv_params = blas_benchmark::utils::get_tbmv_params(args);
+  auto trsv_params = blas_benchmark::utils::get_tbmv_params(args);
 
-  for (auto p : tbmv_params) {
+  for (auto p : trsv_params) {
     std::string uplos;
     std::string ts;
     std::string diags;
@@ -217,7 +217,7 @@ void register_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
     index_t k;
     std::tie(uplos, ts, diags, n, k) = p;
 
-    // Repurpose tbmv_params.
+    // Repurpose tbmv parameters.
     if (k != 1) continue;
 
     auto BM_lambda = [&](benchmark::State& st, ExecutorType* exPtr,

--- a/benchmark/clBench/clblas/blas2/trsv.cpp
+++ b/benchmark/clBench/clblas/blas2/trsv.cpp
@@ -82,8 +82,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
 
   // Populate the main diagonal with larger values.
   for (int i = 0; i < n; ++i)
-    for (int j = 0; j < n; ++j)
-      m_a[(i * lda) + i] = (i == j) ? blas_benchmark::utils::random_scalar(
+    for (int j = 0; j < lda; ++j)
+      m_a[(i * lda) + j] = (i == j) ? blas_benchmark::utils::random_scalar(
                                           scalar_t{9}, scalar_t{11})
                                     : blas_benchmark::utils::random_scalar(
                                           scalar_t{-0.1}, scalar_t{0.1});
@@ -207,18 +207,14 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
                         bool* success) {
-  auto trsv_params = blas_benchmark::utils::get_tbmv_params(args);
+  auto trsv_params = blas_benchmark::utils::get_trsv_params(args);
 
   for (auto p : trsv_params) {
     std::string uplos;
     std::string ts;
     std::string diags;
     index_t n;
-    index_t k;
-    std::tie(uplos, ts, diags, n, k) = p;
-
-    // Repurpose tbmv parameters.
-    if (k != 1) continue;
+    std::tie(uplos, ts, diags, n) = p;
 
     auto BM_lambda = [&](benchmark::State& st, ExecutorType* exPtr,
                          std::string uplos, std::string ts, std::string diags,

--- a/benchmark/clBench/clblas/blas2/trsv.cpp
+++ b/benchmark/clBench/clblas/blas2/trsv.cpp
@@ -60,18 +60,15 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
   // Compute the number of A non-zero elements.
   const double A_validVal = .5 * n_d * (n_d + 1);
 
-  {
-    double nflops = n_d * n_d;
-    state.counters["n_fl_ops"] = nflops;
-  }
+  const double nflops_tot = n_d * n_d;
+  state.counters["n_fl_ops"] = nflops_tot;
 
-  {
-    double mem_readA = A_validVal;
-    double mem_readX = A_validVal;
-    double mem_writeX = A_validVal;
-    state.counters["bytes_processed"] =
-        (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
-  }
+  const double mem_readA = A_validVal;
+  const double mem_readX = A_validVal;
+  const double mem_writeX = A_validVal;
+  const double memproc_tot =
+      (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = memproc_tot;
 
   ExecutorType& ex = *executorPtr;
 
@@ -201,6 +198,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
     // Report
     blas_benchmark::utils::update_counters(state, times);
   }
+
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+  state.SetBytesProcessed(state.iterations() * memproc_tot);
 
   blas_benchmark::utils::calc_avg_counters(state);
 }

--- a/benchmark/clBench/clblas/blas2/trsv.cpp
+++ b/benchmark/clBench/clblas/blas2/trsv.cpp
@@ -86,7 +86,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
       m_a[(i * lda) + j] = (i == j) ? blas_benchmark::utils::random_scalar(
                                           scalar_t{9}, scalar_t{11})
                                     : blas_benchmark::utils::random_scalar(
-                                          scalar_t{-0.1}, scalar_t{0.1});
+                                          scalar_t{-10}, scalar_t{10}) /
+                                          scalar_t(n);
 
   // Specify the layout.
   auto layout = clblasColumnMajor;

--- a/benchmark/clBench/clblast/CMakeLists.txt
+++ b/benchmark/clBench/clblast/CMakeLists.txt
@@ -48,6 +48,7 @@ set(sources
   blas2/tbmv.cpp
   blas2/trmv.cpp
   blas2/spr.cpp
+  blas2/trsv.cpp
   # Level 3 blas
   blas3/gemm.cpp
   blas3/gemm_batched.cpp

--- a/benchmark/clBench/clblast/blas2/trsv.cpp
+++ b/benchmark/clBench/clblast/blas2/trsv.cpp
@@ -156,9 +156,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
                         bool* success) {
-  auto tbmv_params = blas_benchmark::utils::get_tbmv_params(args);
+  auto trsv_params = blas_benchmark::utils::get_tbmv_params(args);
 
-  for (auto p : tbmv_params) {
+  for (auto p : trsv_params) {
     std::string uplos;
     std::string ts;
     std::string diags;
@@ -166,7 +166,7 @@ void register_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
     index_t k;
     std::tie(uplos, ts, diags, n, k) = p;
 
-    // Repurpose tbmv_params.
+    // Repurpose tbmv parameters.
     if (k != 1) continue;
 
     auto BM_lambda = [&](benchmark::State& st, ExecutorType* exPtr,

--- a/benchmark/clBench/clblast/blas2/trsv.cpp
+++ b/benchmark/clBench/clblast/blas2/trsv.cpp
@@ -1,0 +1,188 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trsv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
+  std::ostringstream str{};
+  str << "BM_Trsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << t << "/" << diag << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
+         std::string t, std::string diag, index_t n, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+  const char* t_str = t.c_str();
+  const char* diag_str = diag.c_str();
+
+  index_t xlen = n;
+  index_t lda = n;
+  index_t incX = 1;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = .5 * n_d * (n_d + 1);
+
+  {
+    double nflops = n_d * n_d;
+    state.counters["n_fl_ops"] = nflops;
+  }
+
+  {
+    double mem_readA = A_validVal;
+    double mem_readX = A_validVal;
+    double mem_writeX = A_validVal;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+  }
+
+  ExecutorType& ex = *executorPtr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+
+  // Populate the main diagonal with larger values.
+  for (int i = 0; i < n; ++i)
+    for (int j = 0; j < n; ++j)
+      m_a[(i * lda) + i] = (i == j) ? blas_benchmark::utils::random_scalar(
+                                          scalar_t{9}, scalar_t{11})
+                                    : blas_benchmark::utils::random_scalar(
+                                          scalar_t{-0.1}, scalar_t{0.1});
+
+  // Specify the layout.
+  auto layout = clblast::Layout::kColMajor;
+
+  MemBuffer<scalar_t> m_a_gpu(executorPtr, m_a.data(),
+                              static_cast<size_t>(lda * n));
+  MemBuffer<scalar_t> v_x_gpu(executorPtr, v_x.data(),
+                              static_cast<size_t>(xlen));
+
+  // Specify the triangle.
+  clblast::Triangle a_uplo =
+      blas_benchmark::utils::translate_triangle(uplo_str);
+
+  // Specify the transposition.
+  clblast::Transpose a_tr =
+      blas_benchmark::utils::translate_transposition(t_str);
+
+  // Specify the unit-diagonal.
+  clblast::Diagonal a_diag =
+      blas_benchmark::utils::translate_diagonal(diag_str);
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> v_x_ref = v_x;
+  reference_blas::trsv(uplo_str, t_str, diag_str, n, m_a.data(), lda,
+                       v_x_ref.data(), incX);
+  std::vector<scalar_t> v_x_temp = v_x;
+  {
+    MemBuffer<scalar_t> v_x_temp_gpu(executorPtr, v_x_temp.data(),
+                                     static_cast<size_t>(xlen));
+    cl_event event;
+    clblast::Trsv<scalar_t>(layout, a_uplo, a_tr, a_diag, n, m_a_gpu.dev(), 0,
+                            lda, v_x_temp_gpu.dev(), 0, incX,
+                            executorPtr->_queue(), &event);
+    CLEventHandler::wait(event);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(v_x_temp, v_x_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl_event> {
+    cl_event event;
+    clblast::Trsv<scalar_t>(layout, a_uplo, a_tr, a_diag, n, m_a_gpu.dev(), 0,
+                            lda, v_x_gpu.dev(), 0, incX, executorPtr->_queue(),
+                            &event);
+    CLEventHandler::wait(event);
+    return {event};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
+                        bool* success) {
+  auto tbmv_params = blas_benchmark::utils::get_tbmv_params(args);
+
+  for (auto p : tbmv_params) {
+    std::string uplos;
+    std::string ts;
+    std::string diags;
+    index_t n;
+    index_t k;
+    std::tie(uplos, ts, diags, n, k) = p;
+
+    // Repurpose tbmv_params.
+    if (k != 1) continue;
+
+    auto BM_lambda = [&](benchmark::State& st, ExecutorType* exPtr,
+                         std::string uplos, std::string ts, std::string diags,
+                         index_t n, bool* success) {
+      run<scalar_t>(st, exPtr, uplos, ts, diags, n, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda, exPtr,
+        uplos, ts, diags, n, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, exPtr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/clBench/clblast/blas2/trsv.cpp
+++ b/benchmark/clBench/clblast/blas2/trsv.cpp
@@ -76,8 +76,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
 
   // Populate the main diagonal with larger values.
   for (int i = 0; i < n; ++i)
-    for (int j = 0; j < n; ++j)
-      m_a[(i * lda) + i] = (i == j) ? blas_benchmark::utils::random_scalar(
+    for (int j = 0; j < lda; ++j)
+      m_a[(i * lda) + j] = (i == j) ? blas_benchmark::utils::random_scalar(
                                           scalar_t{9}, scalar_t{11})
                                     : blas_benchmark::utils::random_scalar(
                                           scalar_t{-0.1}, scalar_t{0.1});
@@ -156,18 +156,14 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, ExecutorType* exPtr,
                         bool* success) {
-  auto trsv_params = blas_benchmark::utils::get_tbmv_params(args);
+  auto trsv_params = blas_benchmark::utils::get_trsv_params(args);
 
   for (auto p : trsv_params) {
     std::string uplos;
     std::string ts;
     std::string diags;
     index_t n;
-    index_t k;
-    std::tie(uplos, ts, diags, n, k) = p;
-
-    // Repurpose tbmv parameters.
-    if (k != 1) continue;
+    std::tie(uplos, ts, diags, n) = p;
 
     auto BM_lambda = [&](benchmark::State& st, ExecutorType* exPtr,
                          std::string uplos, std::string ts, std::string diags,

--- a/benchmark/clBench/clblast/blas2/trsv.cpp
+++ b/benchmark/clBench/clblast/blas2/trsv.cpp
@@ -80,7 +80,8 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
       m_a[(i * lda) + j] = (i == j) ? blas_benchmark::utils::random_scalar(
                                           scalar_t{9}, scalar_t{11})
                                     : blas_benchmark::utils::random_scalar(
-                                          scalar_t{-0.1}, scalar_t{0.1});
+                                          scalar_t{-10}, scalar_t{10}) /
+                                          scalar_t(n);
 
   // Specify the layout.
   auto layout = clblast::Layout::kColMajor;

--- a/benchmark/clBench/clblast/blas2/trsv.cpp
+++ b/benchmark/clBench/clblast/blas2/trsv.cpp
@@ -54,18 +54,15 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
   // Compute the number of A non-zero elements.
   const double A_validVal = .5 * n_d * (n_d + 1);
 
-  {
-    double nflops = n_d * n_d;
-    state.counters["n_fl_ops"] = nflops;
-  }
+  const double nflops_tot = n_d * n_d;
+  state.counters["n_fl_ops"] = nflops_tot;
 
-  {
-    double mem_readA = A_validVal;
-    double mem_readX = A_validVal;
-    double mem_writeX = A_validVal;
-    state.counters["bytes_processed"] =
-        (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
-  }
+  const double mem_readA = A_validVal;
+  const double mem_readX = A_validVal;
+  const double mem_writeX = A_validVal;
+  const double memproc_tot =
+      (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = memproc_tot;
 
   ExecutorType& ex = *executorPtr;
 
@@ -150,6 +147,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
     // Report
     blas_benchmark::utils::update_counters(state, times);
   }
+
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+  state.SetBytesProcessed(state.iterations() * memproc_tot);
 
   blas_benchmark::utils::calc_avg_counters(state);
 }

--- a/benchmark/cublas/blas2/trsv.cpp
+++ b/benchmark/cublas/blas2/trsv.cpp
@@ -87,7 +87,8 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
       m_a[(i * lda) + j] = (i == j) ? blas_benchmark::utils::random_scalar(
                                           scalar_t{9}, scalar_t{11})
                                     : blas_benchmark::utils::random_scalar(
-                                          scalar_t{-0.1}, scalar_t{0.1});
+                                          scalar_t{-10}, scalar_t{10}) /
+                                          scalar_t(n);
 
   blas_benchmark::utils::CUDAVector<scalar_t> m_a_gpu(lda * n, m_a.data());
   blas_benchmark::utils::CUDAVector<scalar_t> v_x_gpu(xlen, v_x.data());

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -98,7 +98,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       m_a[(i * lda) + j] = (i == j) ? blas_benchmark::utils::random_scalar(
                                           scalar_t{9}, scalar_t{11})
                                     : blas_benchmark::utils::random_scalar(
-                                          scalar_t{-0.1}, scalar_t{0.1});
+                                          scalar_t{-10}, scalar_t{10}) /
+                                          scalar_t(n);
 
   {
     // Device memory allocation & H2D copy

--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -50,6 +50,7 @@ set(sources
   blas2/syr2.cpp
   blas2/tbmv.cpp
   blas2/trmv.cpp
+  blas2/trsv.cpp
   # Level 3 blas
   blas3/gemm.cpp
   blas3/gemm_batched.cpp

--- a/benchmark/syclblas/blas2/trsv.cpp
+++ b/benchmark/syclblas/blas2/trsv.cpp
@@ -137,9 +137,9 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         blas::SB_Handle* sb_handle_ptr, bool* success) {
-  auto tbmv_params = blas_benchmark::utils::get_tbmv_params(args);
+  auto trsv_params = blas_benchmark::utils::get_tbmv_params(args);
 
-  for (auto p : tbmv_params) {
+  for (auto p : trsv_params) {
     std::string uplos;
     std::string ts;
     std::string diags;
@@ -147,7 +147,7 @@ void register_benchmark(blas_benchmark::Args& args,
     index_t k;
     std::tie(uplos, ts, diags, n, k) = p;
 
-    // Repurpose tbmv_params.
+    // Repurpose tbmv parameters.
     if (k != 1) continue;
 
     auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,

--- a/benchmark/syclblas/blas2/trsv.cpp
+++ b/benchmark/syclblas/blas2/trsv.cpp
@@ -1,0 +1,169 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trsv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
+  std::ostringstream str{};
+  str << "BM_Trsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << t << "/" << diag << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
+         std::string uplo, std::string t, std::string diag, index_t n,
+         bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+  const char* t_str = t.c_str();
+  const char* diag_str = diag.c_str();
+
+  index_t xlen = n;
+  index_t lda = n;
+  index_t incX = 1;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = .5 * n_d * (n_d + 1);
+
+  {
+    double nflops = n_d * n_d;
+    state.counters["n_fl_ops"] = nflops;
+  }
+
+  {
+    double mem_readA = A_validVal;
+    double mem_readX = A_validVal;
+    double mem_writeX = A_validVal;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+  }
+
+  blas::SB_Handle& sb_handle = *sb_handle_ptr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+
+  // Populate the main diagonal with larger values.
+  for (int i = 0; i < n; ++i)
+    for (int j = 0; j < n; ++j)
+      m_a[(i * lda) + i] = (i == j) ? blas_benchmark::utils::random_scalar(
+                                          scalar_t{9}, scalar_t{11})
+                                    : blas_benchmark::utils::random_scalar(
+                                          scalar_t{-0.1}, scalar_t{0.1});
+
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_a, lda * n);
+  auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_x, xlen);
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> v_x_ref = v_x;
+  reference_blas::trsv(uplo_str, t_str, diag_str, n, m_a.data(), lda,
+                       v_x_ref.data(), incX);
+  std::vector<scalar_t> v_x_temp = v_x;
+  {
+    auto v_x_temp_gpu =
+        blas::make_sycl_iterator_buffer<scalar_t>(v_x_temp, xlen);
+    auto event = _trsv(sb_handle, *uplo_str, *t_str, *diag_str, n, m_a_gpu, lda,
+                       v_x_temp_gpu, incX);
+    sb_handle.wait();
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(v_x_temp, v_x_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
+    auto event = _trsv(sb_handle, *uplo_str, *t_str, *diag_str, n, m_a_gpu, lda,
+                       v_x_gpu, incX);
+    sb_handle.wait(event);
+    return event;
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+  sb_handle.wait();
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        blas::SB_Handle* sb_handle_ptr, bool* success) {
+  auto tbmv_params = blas_benchmark::utils::get_tbmv_params(args);
+
+  for (auto p : tbmv_params) {
+    std::string uplos;
+    std::string ts;
+    std::string diags;
+    index_t n;
+    index_t k;
+    std::tie(uplos, ts, diags, n, k) = p;
+
+    // Repurpose tbmv_params.
+    if (k != 1) continue;
+
+    auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
+                         std::string uplos, std::string ts, std::string diags,
+                         index_t n, bool* success) {
+      run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
+        sb_handle_ptr, uplos, ts, diags, n, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      blas::SB_Handle* sb_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, sb_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/syclblas/blas2/trsv.cpp
+++ b/benchmark/syclblas/blas2/trsv.cpp
@@ -77,8 +77,8 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
 
   // Populate the main diagonal with larger values.
   for (int i = 0; i < n; ++i)
-    for (int j = 0; j < n; ++j)
-      m_a[(i * lda) + i] = (i == j) ? blas_benchmark::utils::random_scalar(
+    for (int j = 0; j < lda; ++j)
+      m_a[(i * lda) + j] = (i == j) ? blas_benchmark::utils::random_scalar(
                                           scalar_t{9}, scalar_t{11})
                                     : blas_benchmark::utils::random_scalar(
                                           scalar_t{-0.1}, scalar_t{0.1});
@@ -137,18 +137,14 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         blas::SB_Handle* sb_handle_ptr, bool* success) {
-  auto trsv_params = blas_benchmark::utils::get_tbmv_params(args);
+  auto trsv_params = blas_benchmark::utils::get_trsv_params(args);
 
   for (auto p : trsv_params) {
     std::string uplos;
     std::string ts;
     std::string diags;
     index_t n;
-    index_t k;
-    std::tie(uplos, ts, diags, n, k) = p;
-
-    // Repurpose tbmv parameters.
-    if (k != 1) continue;
+    std::tie(uplos, ts, diags, n) = p;
 
     auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
                          std::string uplos, std::string ts, std::string diags,

--- a/benchmark/syclblas/blas2/trsv.cpp
+++ b/benchmark/syclblas/blas2/trsv.cpp
@@ -81,7 +81,8 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
       m_a[(i * lda) + j] = (i == j) ? blas_benchmark::utils::random_scalar(
                                           scalar_t{9}, scalar_t{11})
                                     : blas_benchmark::utils::random_scalar(
-                                          scalar_t{-0.1}, scalar_t{0.1});
+                                          scalar_t{-10}, scalar_t{10}) /
+                                          scalar_t(n);
 
   auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_a, lda * n);
   auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_x, xlen);

--- a/benchmark/syclblas/blas2/trsv.cpp
+++ b/benchmark/syclblas/blas2/trsv.cpp
@@ -55,18 +55,15 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
   // Compute the number of A non-zero elements.
   const double A_validVal = .5 * n_d * (n_d + 1);
 
-  {
-    double nflops = n_d * n_d;
-    state.counters["n_fl_ops"] = nflops;
-  }
+  const double nflops_tot = n_d * n_d;
+  state.counters["n_fl_ops"] = nflops_tot;
 
-  {
-    double mem_readA = A_validVal;
-    double mem_readX = A_validVal;
-    double mem_writeX = A_validVal;
-    state.counters["bytes_processed"] =
-        (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
-  }
+  const double mem_readA = A_validVal;
+  const double mem_readX = A_validVal;
+  const double mem_writeX = A_validVal;
+  const double memproc_tot =
+      (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = memproc_tot;
 
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
 
@@ -131,6 +128,9 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
     // Report
     blas_benchmark::utils::update_counters(state, times);
   }
+
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+  state.SetBytesProcessed(state.iterations() * memproc_tot);
 
   blas_benchmark::utils::calc_avg_counters(state);
 }

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -891,6 +891,7 @@ function (build_library LIB_NAME ENABLE_EXTENSIONS)
                 $<TARGET_OBJECTS:syr2>
                 $<TARGET_OBJECTS:tbmv>
                 $<TARGET_OBJECTS:trmv>
+                $<TARGET_OBJECTS:trsv>
                 $<TARGET_OBJECTS:gemm_launcher>
                 $<TARGET_OBJECTS:gemm>
                 $<TARGET_OBJECTS:trsm>)

--- a/include/interface/blas2_interface.h
+++ b/include/interface/blas2_interface.h
@@ -133,9 +133,10 @@ typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, char _Uplo,
                                     container_0_t _mA, index_t _lda,
                                     container_1_t _vx, increment_t _incx);
 
-template <uint32_t local_range, uplo_type uplo, transpose_type trn,
-          diag_type diag, typename sb_handle_t, typename index_t,
-          typename container_t0, typename container_t1, typename increment_t>
+template <uint32_t x_range, uint32_t subgroups, uplo_type uplo,
+          transpose_type trn, diag_type diag, typename sb_handle_t,
+          typename index_t, typename container_t0, typename container_t1,
+          typename increment_t>
 typename sb_handle_t::event_t _trsv_impl(sb_handle_t& sb_handle, index_t _N,
                                          container_t0 _mA, index_t _lda,
                                          container_t1 _vx, increment_t _incx);

--- a/include/interface/blas2_interface.h
+++ b/include/interface/blas2_interface.h
@@ -106,6 +106,40 @@ typename sb_handle_t::event_t _trmv(
     increment_t _incx        // !=0 The increment for the elements of X
 );
 
+/**
+ * @brief Linear system solver for triangular matrices.
+ *
+ * Linear system solver for triangular matrices, i.e., computing x s.t.
+ *
+ * op(A)*x = x
+ *
+ * See the netlib blas interface documentation for more details of the
+ * interface: https://netlib.org/lapack/explore-html/d0/d2a/strsv_8f.html
+ *
+ * @param sb_handle SB_handle
+ * @param _Uplo Specifies if A is upper or lower triangular
+ * @param _trans Transposition operation applied to A ('n', 't', 'c')
+ * @param _Diag Specifies if A unit triangular or not
+ * @param _N Number of rows and columns of A
+ * @param _mA A buffer (_LDA,_N) containing the coefficient of A
+ * @param _lda Leading dimension _mA at least _N
+ * @param _vx Buffer containing x of at least (1+(_N-1)*abs(_incx)) elements
+ * @param _incx Increment for _vx (nonzero)
+ */
+template <typename sb_handle_t, typename index_t, typename container_0_t,
+          typename container_1_t, typename increment_t>
+typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, char _Uplo,
+                                    char _trans, char _Diag, index_t _N,
+                                    container_0_t _mA, index_t _lda,
+                                    container_1_t _vx, increment_t _incx);
+
+template <uint32_t local_range, uplo_type uplo, transpose_type trn,
+          diag_type diag, typename sb_handle_t, typename index_t,
+          typename container_t0, typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _trsv_impl(sb_handle_t& sb_handle, index_t _N,
+                                         container_t0 _mA, index_t _lda,
+                                         container_t1 _vx, increment_t _incx);
+
 /*!
  @brief Generalised matrix vector product with a square symmetric matrix,
  followed by a vector sum.
@@ -445,6 +479,37 @@ typename sb_handle_t::event_t inline _trmv(
     increment_t _incx        // !=0 The increment for the elements of X
 ) {
   return internal::_trmv(sb_handle, _Uplo, _trans, _Diag, _N, _mA, _lda, _vx,
+                         _incx);
+}
+
+/**
+ * @brief Linear system solver for triangular matrices.
+ *
+ * Linear system solver for triangular matrices, i.e., computing x s.t.
+ *
+ * op(A)*x = x
+ *
+ * See the netlib blas interface documentation for more details of the
+ * interface: https://netlib.org/lapack/explore-html/d0/d2a/strsv_8f.html
+ *
+ * @param sb_handle SB_handle
+ * @param _Uplo Specifies if A is upper or lower triangular
+ * @param _trans Transposition operation applied to A ('n', 't', 'c')
+ * @param _Diag Specifies if A unit triangular or not
+ * @param _N Number of rows and columns of A
+ * @param _mA A buffer (_LDA,_N) containing the coefficient of A
+ * @param _lda Leading dimension _mA at least _N
+ * @param _vx Buffer containing x of at least (1+(_N-1)*abs(_incx)) elements
+ * @param _incx Increment for _vx (nonzero)
+ */
+template <typename sb_handle_t, typename index_t, typename container_0_t,
+          typename container_1_t, typename increment_t>
+typename sb_handle_t::event_t inline _trsv(sb_handle_t& sb_handle, char _Uplo,
+                                           char _trans, char _Diag, index_t _N,
+                                           container_0_t _mA, index_t _lda,
+                                           container_1_t _vx,
+                                           increment_t _incx) {
+  return internal::_trsv(sb_handle, _Uplo, _trans, _Diag, _N, _mA, _lda, _vx,
                          _incx);
 }
 

--- a/include/operations/blas2_trees.h
+++ b/include/operations/blas2_trees.h
@@ -366,8 +366,6 @@ struct Trsv {
   Trsv(lhs_t &_l, matrix_t &_matrix, index_t &_k, vector_t &_vector);
   index_t get_size() const;
   bool valid_thread(cl::sycl::nd_item<1> ndItem) const;
-  value_t eval(index_t i);
-  value_t eval(cl::sycl::nd_item<1> ndItem);
   template <typename local_memory_t>
   value_t eval(local_memory_t local_mem, cl::sycl::nd_item<1> ndItem);
   void bind(cl::sycl::handler &h);

--- a/include/operations/blas2_trees.h
+++ b/include/operations/blas2_trees.h
@@ -347,6 +347,44 @@ make_tbmv(lhs_t &lhs_, matrix_t &matrix_, typename vector_t::index_t k_,
               is_unit>(lhs_, matrix_, k_, vector_);
 }
 
+/**
+ * @struct Trsv
+ * @brief Tree node representing a triangular matrix_ vector_
+ * multiplication.
+ */
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed, bool is_unit>
+struct Trsv {
+  using value_t = typename vector_t::value_t;
+  using index_t = typename vector_t::index_t;
+
+  lhs_t lhs_;
+  matrix_t matrix_;
+  index_t blk_id_;
+  vector_t vector_;
+
+  Trsv(lhs_t &_l, matrix_t &_matrix, index_t &_k, vector_t &_vector);
+  index_t get_size() const;
+  bool valid_thread(cl::sycl::nd_item<1> ndItem) const;
+  value_t eval(index_t i);
+  value_t eval(cl::sycl::nd_item<1> ndItem);
+  template <typename local_memory_t>
+  value_t eval(local_memory_t local_mem, cl::sycl::nd_item<1> ndItem);
+  void bind(cl::sycl::handler &h);
+  void adjust_access_displacement();
+};
+/*!
+ @brief Generator/factory for TBMV trees.
+ */
+template <uint32_t local_range, bool is_upper, bool is_transposed, bool is_unit,
+          typename lhs_t, typename matrix_t, typename vector_t>
+Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed, is_unit>
+make_trsv(lhs_t &lhs_, matrix_t &matrix_, typename vector_t::index_t blk_id_,
+          vector_t &vector_) {
+  return Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+              is_unit>(lhs_, matrix_, blk_id_, vector_);
+}
+
 /**** GER BY ROWS M ROWS x N BLOCK USING PROPERLY THE SHARED MEMORY ****/
 // template <typename lhs_t,typename rhs_1_t,typename rhs_2_t>
 template <bool Single, bool Lower, bool Diag, bool Upper, typename lhs_t,

--- a/include/operations/blas2_trees.h
+++ b/include/operations/blas2_trees.h
@@ -374,7 +374,7 @@ struct Trsv {
   void adjust_access_displacement();
 };
 /*!
- @brief Generator/factory for TBMV trees.
+ @brief Generator/factory for TRSV trees.
  */
 template <uint32_t local_range, bool is_upper, bool is_transposed, bool is_unit,
           typename lhs_t, typename matrix_t, typename vector_t>

--- a/include/operations/blas2_trees.h
+++ b/include/operations/blas2_trees.h
@@ -352,18 +352,19 @@ make_tbmv(lhs_t &lhs_, matrix_t &matrix_, typename vector_t::index_t k_,
  * @brief Tree node representing a triangular matrix_ vector_
  * multiplication.
  */
-template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_upper, bool is_transposed, bool is_unit>
+template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
+          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          bool is_transposed, bool is_unit>
 struct Trsv {
   using value_t = typename vector_t::value_t;
   using index_t = typename vector_t::index_t;
 
   lhs_t lhs_;
   matrix_t matrix_;
-  index_t blk_id_;
   vector_t vector_;
+  sync_t sync_;
 
-  Trsv(lhs_t &_l, matrix_t &_matrix, index_t &_k, vector_t &_vector);
+  Trsv(lhs_t &_l, matrix_t &_matrix, vector_t &_vector, sync_t &_sync);
   index_t get_size() const;
   bool valid_thread(cl::sycl::nd_item<1> ndItem) const;
   template <typename local_memory_t>
@@ -374,13 +375,14 @@ struct Trsv {
 /*!
  @brief Generator/factory for TRSV trees.
  */
-template <uint32_t local_range, bool is_upper, bool is_transposed, bool is_unit,
-          typename lhs_t, typename matrix_t, typename vector_t>
-Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed, is_unit>
-make_trsv(lhs_t &lhs_, matrix_t &matrix_, typename vector_t::index_t blk_id_,
-          vector_t &vector_) {
-  return Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
-              is_unit>(lhs_, matrix_, blk_id_, vector_);
+template <uint32_t x_range, uint32_t subgroups, bool is_upper,
+          bool is_transposed, bool is_unit, typename lhs_t, typename matrix_t,
+          typename vector_t, typename sync_t>
+Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+     is_transposed, is_unit>
+make_trsv(lhs_t &lhs_, matrix_t &matrix_, vector_t &vector_, sync_t &sync_) {
+  return Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+              is_transposed, is_unit>(lhs_, matrix_, vector_, sync_);
 }
 
 /**** GER BY ROWS M ROWS x N BLOCK USING PROPERLY THE SHARED MEMORY ****/

--- a/src/interface/blas2/CMakeLists.txt
+++ b/src/interface/blas2/CMakeLists.txt
@@ -34,6 +34,7 @@ generate_blas_binary_objects(blas2 syr)
 generate_blas_binary_objects(blas2 tbmv)
 generate_blas_binary_objects(blas2 spr)
 generate_blas_binary_objects(blas2 trmv)
+generate_blas_binary_objects(blas2 trsv)
 
 if(BLAS_ENABLE_CONST_INPUT)
     generate_blas_ternary_objects(blas2 gemv_const)

--- a/src/interface/blas2/backend/amd_gpu.hpp
+++ b/src/interface/blas2/backend/amd_gpu.hpp
@@ -99,5 +99,19 @@ typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace tbmv
+
+namespace trsv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
+                                    container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_trsv_impl<64, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                         _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace trsv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/amd_gpu.hpp
+++ b/src/interface/blas2/backend/amd_gpu.hpp
@@ -108,7 +108,7 @@ template <uplo_type uplo, transpose_type trn, diag_type diag,
 typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
                                     container_t0 _mA, index_t _lda,
                                     container_t1 _vx, increment_t _incx) {
-  return blas::internal::_trsv_impl<64, 4, uplo, trn, diag>(sb_handle, _N, _mA,
+  return blas::internal::_trsv_impl<32, 4, uplo, trn, diag>(sb_handle, _N, _mA,
                                                             _lda, _vx, _incx);
 }
 }  // namespace backend

--- a/src/interface/blas2/backend/amd_gpu.hpp
+++ b/src/interface/blas2/backend/amd_gpu.hpp
@@ -108,8 +108,8 @@ template <uplo_type uplo, transpose_type trn, diag_type diag,
 typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
                                     container_t0 _mA, index_t _lda,
                                     container_t1 _vx, increment_t _incx) {
-  return blas::internal::_trsv_impl<64, uplo, trn, diag>(sb_handle, _N, _mA,
-                                                         _lda, _vx, _incx);
+  return blas::internal::_trsv_impl<64, 4, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                            _lda, _vx, _incx);
 }
 }  // namespace backend
 }  // namespace trsv

--- a/src/interface/blas2/backend/arm_gpu.hpp
+++ b/src/interface/blas2/backend/arm_gpu.hpp
@@ -96,5 +96,19 @@ typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace tbmv
+
+namespace trsv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
+                                    container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_trsv_impl<64, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                         _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace trsv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/arm_gpu.hpp
+++ b/src/interface/blas2/backend/arm_gpu.hpp
@@ -105,8 +105,8 @@ template <uplo_type uplo, transpose_type trn, diag_type diag,
 typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
                                     container_t0 _mA, index_t _lda,
                                     container_t1 _vx, increment_t _incx) {
-  return blas::internal::_trsv_impl<64, uplo, trn, diag>(sb_handle, _N, _mA,
-                                                         _lda, _vx, _incx);
+  return blas::internal::_trsv_impl<64, 2, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                            _lda, _vx, _incx);
 }
 }  // namespace backend
 }  // namespace trsv

--- a/src/interface/blas2/backend/default_cpu.hpp
+++ b/src/interface/blas2/backend/default_cpu.hpp
@@ -96,5 +96,19 @@ typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace tbmv
+
+namespace trsv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
+                                    container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_trsv_impl<128, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                          _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace trsv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/default_cpu.hpp
+++ b/src/interface/blas2/backend/default_cpu.hpp
@@ -106,7 +106,7 @@ typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
                                     container_t0 _mA, index_t _lda,
                                     container_t1 _vx, increment_t _incx) {
   return blas::internal::_trsv_impl<4, 2, uplo, trn, diag>(sb_handle, _N, _mA,
-                                                             _lda, _vx, _incx);
+                                                           _lda, _vx, _incx);
 }
 }  // namespace backend
 }  // namespace trsv

--- a/src/interface/blas2/backend/default_cpu.hpp
+++ b/src/interface/blas2/backend/default_cpu.hpp
@@ -105,8 +105,8 @@ template <uplo_type uplo, transpose_type trn, diag_type diag,
 typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
                                     container_t0 _mA, index_t _lda,
                                     container_t1 _vx, increment_t _incx) {
-  return blas::internal::_trsv_impl<128, uplo, trn, diag>(sb_handle, _N, _mA,
-                                                          _lda, _vx, _incx);
+  return blas::internal::_trsv_impl<128, 4, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                             _lda, _vx, _incx);
 }
 }  // namespace backend
 }  // namespace trsv

--- a/src/interface/blas2/backend/default_cpu.hpp
+++ b/src/interface/blas2/backend/default_cpu.hpp
@@ -105,7 +105,7 @@ template <uplo_type uplo, transpose_type trn, diag_type diag,
 typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
                                     container_t0 _mA, index_t _lda,
                                     container_t1 _vx, increment_t _incx) {
-  return blas::internal::_trsv_impl<128, 4, uplo, trn, diag>(sb_handle, _N, _mA,
+  return blas::internal::_trsv_impl<4, 2, uplo, trn, diag>(sb_handle, _N, _mA,
                                                              _lda, _vx, _incx);
 }
 }  // namespace backend

--- a/src/interface/blas2/backend/intel_gpu.hpp
+++ b/src/interface/blas2/backend/intel_gpu.hpp
@@ -96,5 +96,19 @@ typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace tbmv
+
+namespace trsv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
+                                    container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_trsv_impl<256, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                          _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace trsv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/intel_gpu.hpp
+++ b/src/interface/blas2/backend/intel_gpu.hpp
@@ -105,8 +105,8 @@ template <uplo_type uplo, transpose_type trn, diag_type diag,
 typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
                                     container_t0 _mA, index_t _lda,
                                     container_t1 _vx, increment_t _incx) {
-  return blas::internal::_trsv_impl<256, uplo, trn, diag>(sb_handle, _N, _mA,
-                                                          _lda, _vx, _incx);
+  return blas::internal::_trsv_impl<16, 4, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                            _lda, _vx, _incx);
 }
 }  // namespace backend
 }  // namespace trsv

--- a/src/interface/blas2/backend/nvidia_gpu.hpp
+++ b/src/interface/blas2/backend/nvidia_gpu.hpp
@@ -96,5 +96,19 @@ typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace tbmv
+
+namespace trsv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
+                                    container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_trsv_impl<256, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                          _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace trsv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/nvidia_gpu.hpp
+++ b/src/interface/blas2/backend/nvidia_gpu.hpp
@@ -105,8 +105,8 @@ template <uplo_type uplo, transpose_type trn, diag_type diag,
 typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
                                     container_t0 _mA, index_t _lda,
                                     container_t1 _vx, increment_t _incx) {
-  return blas::internal::_trsv_impl<256, uplo, trn, diag>(sb_handle, _N, _mA,
-                                                          _lda, _vx, _incx);
+  return blas::internal::_trsv_impl<32, 4, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                            _lda, _vx, _incx);
 }
 }  // namespace backend
 }  // namespace trsv

--- a/src/interface/blas2/backend/power_vr.hpp
+++ b/src/interface/blas2/backend/power_vr.hpp
@@ -96,5 +96,19 @@ typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace tbmv
+
+namespace trsv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
+                                    container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_trsv_impl<256, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                          _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace trsv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/power_vr.hpp
+++ b/src/interface/blas2/backend/power_vr.hpp
@@ -105,8 +105,8 @@ template <uplo_type uplo, transpose_type trn, diag_type diag,
 typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
                                     container_t0 _mA, index_t _lda,
                                     container_t1 _vx, increment_t _incx) {
-  return blas::internal::_trsv_impl<256, uplo, trn, diag>(sb_handle, _N, _mA,
-                                                          _lda, _vx, _incx);
+  return blas::internal::_trsv_impl<64, 4, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                            _lda, _vx, _incx);
 }
 }  // namespace backend
 }  // namespace trsv

--- a/src/interface/blas2/backend/rcar.hpp
+++ b/src/interface/blas2/backend/rcar.hpp
@@ -101,5 +101,19 @@ typename sb_handle_t::event_t _tbmv(sb_handle_t& sb_handle, index_t _N,
 }
 }  // namespace backend
 }  // namespace tbmv
+
+namespace trsv {
+namespace backend {
+template <uplo_type uplo, transpose_type trn, diag_type diag,
+          typename sb_handle_t, typename index_t, typename container_t0,
+          typename container_t1, typename increment_t>
+typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
+                                    container_t0 _mA, index_t _lda,
+                                    container_t1 _vx, increment_t _incx) {
+  return blas::internal::_trsv_impl<256, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                          _lda, _vx, _incx);
+}
+}  // namespace backend
+}  // namespace trsv
 }  // namespace blas
 #endif

--- a/src/interface/blas2/backend/rcar.hpp
+++ b/src/interface/blas2/backend/rcar.hpp
@@ -110,8 +110,8 @@ template <uplo_type uplo, transpose_type trn, diag_type diag,
 typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, index_t _N,
                                     container_t0 _mA, index_t _lda,
                                     container_t1 _vx, increment_t _incx) {
-  return blas::internal::_trsv_impl<256, uplo, trn, diag>(sb_handle, _N, _mA,
-                                                          _lda, _vx, _incx);
+  return blas::internal::_trsv_impl<64, 4, uplo, trn, diag>(sb_handle, _N, _mA,
+                                                            _lda, _vx, _incx);
 }
 }  // namespace backend
 }  // namespace trsv

--- a/src/interface/blas2/trsv.cpp.in
+++ b/src/interface/blas2/trsv.cpp.in
@@ -22,14 +22,9 @@
  *  @filename trsv.cpp.in
  *
  **************************************************************************/
-#include "container/sycl_iterator.hpp"
 #include "sb_handle/sycl_blas_handle.hpp"
 #include "sb_handle/kernel_constructor.hpp"
 #include "interface/blas2_interface.hpp"
-#include "operations/blas1_trees.hpp"
-#include "operations/blas2_trees.hpp"
-#include "operations/blas_constants.hpp"
-#include "views/view_sycl.hpp"
 
 namespace blas {
 namespace internal {

--- a/src/interface/blas2/trsv.cpp.in
+++ b/src/interface/blas2/trsv.cpp.in
@@ -19,19 +19,24 @@
  *
  *  SYCL-BLAS: BLAS implementation using SYCL
  *
- *  @filename blas2_trees.hpp
+ *  @filename trsv.cpp.in
  *
  **************************************************************************/
+#include "container/sycl_iterator.hpp"
+#include "sb_handle/sycl_blas_handle.hpp"
+#include "sb_handle/kernel_constructor.hpp"
+#include "interface/blas2_interface.hpp"
+#include "operations/blas1_trees.hpp"
+#include "operations/blas2_trees.hpp"
+#include "operations/blas_constants.hpp"
+#include "views/view_sycl.hpp"
 
-#ifndef SYCL_BLAS_BLAS2_TREES_HPP
-#define SYCL_BLAS_BLAS2_TREES_HPP
+namespace blas {
+namespace internal {
 
-#include "blas2/gbmv.hpp"
-#include "blas2/gemv.hpp"
-#include "blas2/ger.hpp"
-#include "blas2/sbmv.hpp"
-#include "blas2/tbmv.hpp"
-#include "blas2/gerp.hpp"
-#include "blas2/trsv.hpp"
-
-#endif  // BLAS2_TREES_HPP
+template typename SB_Handle::event_t _trsv(
+    SB_Handle& sb_handle, char _Uplo, char _trans, char _Diag,
+    ${INDEX_TYPE} _N, ${container_t0} _mA, ${INDEX_TYPE} _lda,
+    ${container_t1} _vx, ${INCREMENT_TYPE} _incx);
+}  // namespace internal
+}  // end namespace blas

--- a/src/interface/blas2_interface.hpp
+++ b/src/interface/blas2_interface.hpp
@@ -325,6 +325,10 @@ template <uint32_t x_range, uint32_t subgroups, uplo_type uplo,
 typename sb_handle_t::event_t _trsv_impl(sb_handle_t& sb_handle, index_t _N,
                                          container_t0 _mA, index_t _lda,
                                          container_t1 _vx, increment_t _incx) {
+#ifdef __COMPUTECPP__
+  throw std::runtime_error("Unimplemented for ComputeCPP");
+#endif
+
   constexpr bool is_upper = (uplo == uplo_type::Upper);
   constexpr bool is_transposed = (trn != transpose_type::Normal);
   constexpr bool is_unit = (diag == diag_type::Unit);

--- a/src/operations/blas2/trsv.hpp
+++ b/src/operations/blas2/trsv.hpp
@@ -1,0 +1,142 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trsv.hpp
+ *
+ **************************************************************************/
+
+#ifndef TBSV_HPP
+#define TBSV_HPP
+#include "operations/blas2_trees.h"
+#include "operations/blas_operators.hpp"
+#include "views/view_sycl.hpp"
+#include <stdexcept>
+#include <vector>
+namespace blas {
+
+/**
+ * @struct Trsv
+ * @brief Tree node representing a triangular band matrix_ vector_
+ * multiplication.
+ */
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed,
+          bool is_unitdiag>
+SYCL_BLAS_INLINE
+Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+     is_unitdiag>::Trsv(lhs_t &_l, matrix_t &_matrix,
+                        typename Trsv<lhs_t, matrix_t, vector_t, local_range,
+                                      is_upper, is_transposed,
+                                      is_unitdiag>::index_t &_blk_id,
+                        vector_t &_vector)
+    : lhs_(_l), matrix_(_matrix), vector_(_vector), blk_id_(_blk_id) {}
+
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed,
+          bool is_unitdiag>
+SYCL_BLAS_INLINE typename Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper,
+                               is_transposed, is_unitdiag>::index_t
+Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+     is_unitdiag>::get_size() const {
+  return matrix_.get_size();
+}
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed,
+          bool is_unitdiag>
+SYCL_BLAS_INLINE bool
+Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+     is_unitdiag>::valid_thread(cl::sycl::nd_item<1> ndItem) const {
+  // Valid threads are established by ::eval.
+  return true;
+}
+
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed,
+          bool is_unitdiag>
+template <typename local_memory_t>
+SYCL_BLAS_INLINE typename Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper,
+                               is_transposed, is_unitdiag>::value_t
+Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+     is_unitdiag>::eval(local_memory_t local_mem, cl::sycl::nd_item<1> ndItem) {
+  const index_t _offset = blk_id_ * local_range;
+
+  const index_t g_idx = _offset + ndItem.get_local_id(0);
+  const index_t l_idx = ndItem.get_local_id(0);
+
+  const index_t _N = lhs_.get_size();
+  auto l_x = local_mem.localAcc;
+
+  // copy lhs_ local memory + sync thread
+  if (g_idx < _N) l_x[l_idx] = lhs_.eval(g_idx);
+
+  ndItem.barrier(cl::sycl::access::fence_space::global_and_local);
+
+  constexpr bool is_forward =
+      (is_upper && is_transposed) || (!is_upper && !is_transposed);
+
+  const index_t n_it =
+      (_offset + local_range < _N) ? local_range : _N - _offset;
+  for (index_t _it = 0; _it < n_it; ++_it) {
+    const index_t l_diag = (is_forward) ? _it : n_it - 1 - _it;
+    const index_t g_diag = _offset + l_diag;
+
+    if (!is_unitdiag && !l_idx) l_x[l_diag] /= matrix_.eval(g_diag, g_diag);
+
+    ndItem.barrier(cl::sycl::access::fence_space::local_space);
+
+    if (((g_idx > g_diag) && (g_idx < _N) && is_forward) ||
+        ((g_idx < g_diag) && !is_forward)) {
+      const value_t val = (is_transposed) ? matrix_.eval(g_diag, g_idx)
+                                          : matrix_.eval(g_idx, g_diag);
+      l_x[l_idx] -= val * l_x[l_diag];
+    }
+
+    ndItem.barrier(cl::sycl::access::fence_space::local_space);
+  }
+
+  if (g_idx < _N) lhs_.eval(g_idx) = l_x[l_idx];
+
+  return 0;
+}
+
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed,
+          bool is_unitdiag>
+SYCL_BLAS_INLINE void
+Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+     is_unitdiag>::bind(cl::sycl::handler &h) {
+  lhs_.bind(h);
+  matrix_.bind(h);
+  vector_.bind(h);
+}
+template <typename lhs_t, typename matrix_t, typename vector_t,
+          uint32_t local_range, bool is_upper, bool is_transposed,
+          bool is_unitdiag>
+SYCL_BLAS_INLINE void
+Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
+     is_unitdiag>::adjust_access_displacement() {
+  lhs_.adjust_access_displacement();
+  matrix_.adjust_access_displacement();
+  vector_.adjust_access_displacement();
+}
+
+}  // namespace blas
+#endif

--- a/src/operations/blas2/trsv.hpp
+++ b/src/operations/blas2/trsv.hpp
@@ -26,10 +26,6 @@
 #ifndef TRSV_HPP
 #define TRSV_HPP
 #include "operations/blas2_trees.h"
-#include "operations/blas_operators.hpp"
-#include "views/view_sycl.hpp"
-#include <stdexcept>
-#include <vector>
 namespace blas {
 
 /**

--- a/src/operations/blas2/trsv.hpp
+++ b/src/operations/blas2/trsv.hpp
@@ -23,8 +23,8 @@
  *
  **************************************************************************/
 
-#ifndef TBSV_HPP
-#define TBSV_HPP
+#ifndef TRSV_HPP
+#define TRSV_HPP
 #include "operations/blas2_trees.h"
 #include "operations/blas_operators.hpp"
 #include "views/view_sycl.hpp"

--- a/src/operations/blas2/trsv.hpp
+++ b/src/operations/blas2/trsv.hpp
@@ -73,6 +73,8 @@ SYCL_BLAS_INLINE
     Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
          is_transposed, is_unitdiag>::eval(local_memory_t local_mem,
                                            cl::sycl::nd_item<1> ndItem) {
+#ifndef __COMPUTECPP__
+
   constexpr bool is_forward =
       (is_upper && is_transposed) || (!is_upper && !is_transposed);
 
@@ -266,6 +268,7 @@ SYCL_BLAS_INLINE
 
   sycl::atomic_fence(sycl::memory_order::seq_cst, sycl::memory_scope::device);
 
+#endif
   return 0;
 }
 

--- a/src/operations/blas2/trsv.hpp
+++ b/src/operations/blas2/trsv.hpp
@@ -33,102 +33,262 @@ namespace blas {
  * @brief Tree node representing a triangular band matrix_ vector_
  * multiplication.
  */
-template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_upper, bool is_transposed,
-          bool is_unitdiag>
+template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
+          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          bool is_transposed, bool is_unitdiag>
 SYCL_BLAS_INLINE
-Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
-     is_unitdiag>::Trsv(lhs_t &_l, matrix_t &_matrix,
-                        typename Trsv<lhs_t, matrix_t, vector_t, local_range,
-                                      is_upper, is_transposed,
-                                      is_unitdiag>::index_t &_blk_id,
-                        vector_t &_vector)
-    : lhs_(_l), matrix_(_matrix), vector_(_vector), blk_id_(_blk_id) {}
+Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+     is_transposed, is_unitdiag>::Trsv(lhs_t &_l, matrix_t &_matrix,
+                                       vector_t &_vector, sync_t &_sync)
+    : lhs_(_l), matrix_(_matrix), vector_(_vector), sync_(_sync) {}
 
-template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_upper, bool is_transposed,
-          bool is_unitdiag>
-SYCL_BLAS_INLINE typename Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper,
-                               is_transposed, is_unitdiag>::index_t
-Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
-     is_unitdiag>::get_size() const {
+template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
+          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          bool is_transposed, bool is_unitdiag>
+SYCL_BLAS_INLINE
+    typename Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups,
+                  is_upper, is_transposed, is_unitdiag>::index_t
+    Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+         is_transposed, is_unitdiag>::get_size() const {
   return matrix_.get_size();
 }
-template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_upper, bool is_transposed,
-          bool is_unitdiag>
+template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
+          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          bool is_transposed, bool is_unitdiag>
 SYCL_BLAS_INLINE bool
-Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
-     is_unitdiag>::valid_thread(cl::sycl::nd_item<1> ndItem) const {
+Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+     is_transposed, is_unitdiag>::valid_thread(cl::sycl::nd_item<1> ndItem)
+    const {
   // Valid threads are established by ::eval.
   return true;
 }
 
-template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_upper, bool is_transposed,
-          bool is_unitdiag>
+template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
+          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          bool is_transposed, bool is_unitdiag>
 template <typename local_memory_t>
-SYCL_BLAS_INLINE typename Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper,
-                               is_transposed, is_unitdiag>::value_t
-Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
-     is_unitdiag>::eval(local_memory_t local_mem, cl::sycl::nd_item<1> ndItem) {
-  const index_t _offset = blk_id_ * local_range;
-
-  const index_t g_idx = _offset + ndItem.get_local_id(0);
-  const index_t l_idx = ndItem.get_local_id(0);
-
-  const index_t _N = lhs_.get_size();
-  auto l_x = local_mem.localAcc;
-
-  // copy lhs_ local memory + sync thread
-  if (g_idx < _N) l_x[l_idx] = lhs_.eval(g_idx);
-
+SYCL_BLAS_INLINE
+    typename Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups,
+                  is_upper, is_transposed, is_unitdiag>::value_t
+    Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+         is_transposed, is_unitdiag>::eval(local_memory_t local_mem,
+                                           cl::sycl::nd_item<1> ndItem) {
   constexpr bool is_forward =
       (is_upper && is_transposed) || (!is_upper && !is_transposed);
 
-  const index_t n_it =
-      (_offset + local_range < _N) ? local_range : _N - _offset;
-  for (index_t _it = 0; _it < n_it; ++_it) {
-    const index_t l_diag = (is_forward) ? _it : n_it - 1 - _it;
-    const index_t g_diag = _offset + l_diag;
+  // Number of sub-groups per work-group
+  constexpr index_t sub_num = subgroups;
+  constexpr index_t y_range = x_range / sub_num;
 
-    if (!is_unitdiag && (l_idx == l_diag))
-      l_x[l_diag] /= matrix_.eval(g_diag, g_diag);
+  const index_t _N = lhs_.get_size();
 
-    ndItem.barrier(cl::sycl::access::fence_space::local_space);
+  // True if not work-item 0
+  const bool not_wi0 = ndItem.get_local_id(0);
 
-    if (((g_idx > g_diag) && (g_idx < _N) && is_forward) ||
-        ((g_idx < g_diag) && !is_forward)) {
-      const value_t val = (is_transposed) ? matrix_.eval(g_diag, g_idx)
-                                          : matrix_.eval(g_idx, g_diag);
-      l_x[l_idx] -= val * l_x[l_diag];
+  // Local bi-dimensional indexes
+  const index_t _idx = ndItem.get_local_id(0) % x_range;
+  const index_t _idy = ndItem.get_local_id(0) / x_range;
+
+  // Private memory
+  value_t priv_A[y_range];
+  value_t priv_val = 0;
+
+  // Local memory stride
+  const index_t _llda = x_range + 1;
+
+  // Pointers to local memory
+  value_t *const loc_A = local_mem.localAcc.get_pointer();
+  value_t *const sub_A = loc_A + _llda * y_range * _idy + _idx;
+  value_t *const sub_At = loc_A + _llda * _idx + y_range * _idy;
+
+  value_t *const loc_x = loc_A + _llda * x_range;
+  value_t *const sub_x = loc_x + y_range * _idy;
+
+  value_t *const par_x = loc_x + x_range + x_range * _idy;
+  value_t *const loc_recip = loc_x + x_range;
+
+  auto a = sycl::atomic_ref<index_t, sycl::memory_order::relaxed,
+                            sycl::memory_scope::device,
+                            sycl::access::address_space::global_space>(
+      sync_.eval(0));
+
+  // Get the wg_id of actual workgroup
+  const index_t wg_id =
+      group_broadcast(ndItem.get_group(), not_wi0        ? 0
+                                          : (is_forward) ? a++
+                                                         : a--);
+
+  // Actual extra-diagonal block processed
+  index_t curr_block = ((is_forward) ? 0 : ((_N + x_range - 1) / x_range) - 1);
+  index_t curr_offset = curr_block * x_range + _idx;
+
+  // Global memory offsets
+  const index_t g_idx = wg_id * x_range + _idx;
+  value_t *glo_A =
+      matrix_.get_pointer() +
+      (is_transposed
+           ? matrix_.getSizeL() * (wg_id * x_range + y_range * _idy) +
+                 curr_block * x_range + _idx
+           : matrix_.getSizeL() * (curr_block * x_range + y_range * _idy) +
+                 wg_id * x_range + _idx);
+
+  // Read first block
+  {
+    value_t *lA = sub_A;
+    value_t *gA = glo_A;
+
+    for (index_t i = 0; i < y_range; ++i) {
+      const bool read_it =
+          (is_transposed) ? ((wg_id * x_range + y_range * _idy + i < _N) &&
+                             (curr_offset < _N))
+                          : ((curr_block * x_range + y_range * _idy + i < _N) &&
+                             (g_idx < _N));
+      *lA = read_it ? *gA : value_t(0);
+      lA += _llda;
+      gA += matrix_.getSizeL();
     }
   }
 
-  if (g_idx < _N) lhs_.eval(g_idx) = l_x[l_idx];
+  // Solve extra-diagonal blocks
+
+  volatile int *p = &sync_.eval(1);
+  index_t ready_block =
+      (_idy == 0)
+          ? sycl::group_broadcast(ndItem.get_sub_group(), not_wi0 ? 0 : *p)
+          : 0;
+
+  int steps = is_forward ? wg_id : (curr_block - wg_id);
+  for (int s = 0; s < steps; ++s) {
+    const index_t next_offset = curr_offset + (is_forward ? x_range : -x_range);
+    const index_t next_block = curr_block + (is_forward ? 1 : -1);
+    if (is_forward)
+      glo_A += x_range * (is_transposed ? 1 : matrix_.getSizeL());
+    else
+      glo_A -= x_range * (is_transposed ? 1 : matrix_.getSizeL());
+
+    // Read next block
+    {
+      value_t *gA = glo_A;
+#pragma unroll
+      for (index_t i = 0; i < y_range; ++i) {
+        const bool read_it =
+            (is_transposed)
+                ? ((wg_id * x_range + y_range * _idy + i < _N) &&
+                   (next_offset < _N))
+                : ((next_block * x_range + y_range * _idy + i < _N) &&
+                   (g_idx < _N));
+        priv_A[i] = read_it ? *gA : value_t(0);
+        gA += matrix_.getSizeL();
+      }
+    }
+
+    if (_idy == 0) {
+      while (!((is_forward && (curr_block < ready_block)) ||
+               (!is_forward && (curr_block > ready_block))))
+        ready_block =
+            sycl::group_broadcast(ndItem.get_sub_group(), not_wi0 ? 0 : *p);
+
+      loc_x[_idx] = (curr_offset < _N) ? lhs_.eval(curr_offset) : value_t(0);
+    }
+
+    curr_offset = next_offset;
+    curr_block = next_block;
+
+    ndItem.barrier(cl::sycl::access::fence_space::local_space);
+
+    // Multiply current block
+    {
+      value_t *lx = sub_x;
+      value_t *lA = is_transposed ? sub_At : sub_A;
+#pragma unroll
+      for (index_t i = 0; i < y_range; ++i) {
+        priv_val += *lA * *(lx++);
+        lA += is_transposed ? 1 : _llda;
+      }
+    }
+
+    if (is_transposed)
+      ndItem.barrier(cl::sycl::access::fence_space::local_space);
+
+    // Copy next block to local memory
+    {
+      value_t *lA = sub_A;
+#pragma unroll
+      for (index_t i = 0; i < y_range; ++i) {
+        *lA = priv_A[i];
+        lA += _llda;
+      }
+    }
+  }
+
+  // Store partial values
+  if (_idy != 0) par_x[_idx] = priv_val;
+
+  // Pre-compute diagonal recip
+  if (!is_unitdiag && (_idx >= y_range * _idy) && (_idx < y_range * (_idy + 1)))
+    loc_recip[_idx] = value_t(1) / (loc_A[_llda * _idx + _idx]);
+
+  ndItem.barrier(cl::sycl::access::fence_space::local_space);
+
+  if (_idy == 0) {
+// Accumulate partial values
+#pragma unroll
+    for (index_t y = 1; y < sub_num; ++y) priv_val += par_x[x_range * y + _idx];
+
+    // Solve diagonal block
+    value_t r_x = g_idx < _N ? (lhs_.eval(g_idx) - priv_val) : value_t(0);
+    const value_t A_diag_recip =
+        (!is_unitdiag && g_idx < _N) ? loc_recip[_idx] : value_t(0);
+    value_t _A, r_diag;
+
+#pragma unroll
+    for (index_t _it = 0; _it < x_range; ++_it) {
+      const index_t l_diag = is_forward ? _it : (x_range - 1 - _it);
+
+      r_diag =
+          sycl::group_broadcast(ndItem.get_sub_group(),
+                                is_unitdiag ? r_x : r_x * A_diag_recip, l_diag);
+      _A = (is_transposed) ? loc_A[_llda * _idx + l_diag]
+                           : loc_A[_llda * l_diag + _idx];
+      r_x -= _A * r_diag;
+
+      if (_idx == l_diag) loc_x[_idx] = r_diag;
+    }
+
+    if (g_idx < _N) lhs_.eval(g_idx) = loc_x[_idx];
+  }
+
+  sycl::atomic_fence(sycl::memory_order::seq_cst, sycl::memory_scope::device);
+
+  volatile int *sync = sync_.get_pointer() + 1;
+  if (!not_wi0) *sync = wg_id + (is_forward ? 1 : -1);
+
+  sycl::atomic_fence(sycl::memory_order::seq_cst, sycl::memory_scope::device);
 
   return 0;
 }
 
-template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_upper, bool is_transposed,
-          bool is_unitdiag>
+template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
+          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          bool is_transposed, bool is_unitdiag>
 SYCL_BLAS_INLINE void
-Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
-     is_unitdiag>::bind(cl::sycl::handler &h) {
+Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+     is_transposed, is_unitdiag>::bind(cl::sycl::handler &h) {
   lhs_.bind(h);
   matrix_.bind(h);
   vector_.bind(h);
+  sync_.bind(h);
 }
-template <typename lhs_t, typename matrix_t, typename vector_t,
-          uint32_t local_range, bool is_upper, bool is_transposed,
-          bool is_unitdiag>
+template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
+          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          bool is_transposed, bool is_unitdiag>
 SYCL_BLAS_INLINE void
-Trsv<lhs_t, matrix_t, vector_t, local_range, is_upper, is_transposed,
-     is_unitdiag>::adjust_access_displacement() {
+Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+     is_transposed, is_unitdiag>::adjust_access_displacement() {
   lhs_.adjust_access_displacement();
   matrix_.adjust_access_displacement();
   vector_.adjust_access_displacement();
+  sync_.adjust_access_displacement();
 }
 
 }  // namespace blas

--- a/src/operations/blas2/trsv.hpp
+++ b/src/operations/blas2/trsv.hpp
@@ -255,7 +255,8 @@ SYCL_BLAS_INLINE
       if (_idx == l_diag) loc_x[_idx] = r_diag;
     }
 
-    if (g_idx < _N) lhs_.eval(g_idx) = loc_x[_idx];
+    volatile value_t *lhs_p = lhs_.get_pointer() + lhs_.get_stride() * g_idx;
+    if (g_idx < _N) *lhs_p = loc_x[_idx];
   }
 
   sycl::atomic_fence(sycl::memory_order::seq_cst, sycl::memory_scope::device);

--- a/src/operations/blas2_trees.hpp
+++ b/src/operations/blas2_trees.hpp
@@ -29,9 +29,9 @@
 #include "blas2/gbmv.hpp"
 #include "blas2/gemv.hpp"
 #include "blas2/ger.hpp"
+#include "blas2/gerp.hpp"
 #include "blas2/sbmv.hpp"
 #include "blas2/tbmv.hpp"
-#include "blas2/gerp.hpp"
 #include "blas2/trsv.hpp"
 
 #endif  // BLAS2_TREES_HPP

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -65,6 +65,7 @@ if(is_computecpp)
     ${SYCLBLAS_UNITTEST}/blas1/blas1_iamin_test.cpp
     # Blas 2 tests
     ${SYCLBLAS_UNITTEST}/blas2/blas2_trmv_test.cpp
+    ${SYCLBLAS_UNITTEST}/blas2/blas2_trsv_test.cpp
     ${SYCLBLAS_UNITTEST}/blas2/blas2_tbmv_test.cpp
     # Blas buffer tests
     ${SYCLBLAS_UNITTEST}/buffers/sycl_buffer_test.cpp

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SYCL_UNITTEST_SRCS
   ${SYCLBLAS_UNITTEST}/blas2/blas2_spr_test.cpp
   ${SYCLBLAS_UNITTEST}/blas2/blas2_syr2_test.cpp
   ${SYCLBLAS_UNITTEST}/blas2/blas2_symv_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas2/blas2_trsv_test.cpp
   # Blas 3 tests
   ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_test.cpp
   ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_batched_test.cpp
@@ -65,7 +66,6 @@ if(is_computecpp)
     ${SYCLBLAS_UNITTEST}/blas1/blas1_iamin_test.cpp
     # Blas 2 tests
     ${SYCLBLAS_UNITTEST}/blas2/blas2_trmv_test.cpp
-    ${SYCLBLAS_UNITTEST}/blas2/blas2_trsv_test.cpp
     ${SYCLBLAS_UNITTEST}/blas2/blas2_tbmv_test.cpp
     # Blas buffer tests
     ${SYCLBLAS_UNITTEST}/buffers/sycl_buffer_test.cpp

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -46,12 +46,18 @@ set(SYCL_UNITTEST_SRCS
   ${SYCLBLAS_UNITTEST}/blas2/blas2_spr_test.cpp
   ${SYCLBLAS_UNITTEST}/blas2/blas2_syr2_test.cpp
   ${SYCLBLAS_UNITTEST}/blas2/blas2_symv_test.cpp
-  ${SYCLBLAS_UNITTEST}/blas2/blas2_trsv_test.cpp
   # Blas 3 tests
   ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_test.cpp
   ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_batched_test.cpp
   ${SYCLBLAS_UNITTEST}/blas3/blas3_trsm_test.cpp
 )
+
+# Enable testing of the sycl 2020 routines just for Intel DPC++
+if(is_dpcpp)
+  set(SYCL_UNITTEST_SRCS ${SYCL_UNITTEST_SRCS}
+    ${SYCLBLAS_UNITTEST}/blas2/blas2_trsv_test.cpp
+  )
+endif()
 
 # Temporary disabling the following tests fro Intel DPC++ as currently Intel compiler crashes while running the following tests
 if(is_computecpp)

--- a/test/unittest/blas2/blas2_trsv_test.cpp
+++ b/test/unittest/blas2/blas2_trsv_test.cpp
@@ -1,0 +1,128 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename blas2_trsv_test.cpp
+ *
+ **************************************************************************/
+
+#include "blas_test.hpp"
+
+template <typename T>
+using combination_t = std::tuple<int, bool, bool, bool, int, int>;
+
+template <typename scalar_t>
+void run_test(const combination_t<scalar_t> combi) {
+  index_t n;
+  bool trans;
+  bool is_upper;
+  bool is_unit;
+  index_t incX;
+  index_t lda_mul;
+  std::tie(n, is_upper, trans, is_unit, incX, lda_mul) = combi;
+
+  const char* t_str = trans ? "t" : "n";
+  const char* uplo_str = is_upper ? "u" : "l";
+  const char* diag_str = is_unit ? "u" : "n";
+
+  int a_size = n * n * lda_mul;
+  int x_size = 1 + (n - 1) * incX;
+
+  // Input matrix
+  std::vector<scalar_t> a_m(a_size);
+  // Input/output vector
+  std::vector<scalar_t> x_v(x_size);
+  // Input/output system vector
+  std::vector<scalar_t> x_v_cpu(x_size);
+
+  // Control the magnitude of extra-diagonal elements
+  fill_random_with_range(a_m, scalar_t(-0.05), scalar_t(0.05));
+  if (!is_unit) {
+    // Populate main diagonal with dominant elements
+    for (index_t i = 0; i < n; ++i)
+      a_m[(i * n * lda_mul) + i] = random_scalar(scalar_t(9), scalar_t(11));
+  }
+
+  fill_random(x_v);
+  x_v_cpu = x_v;
+
+  // SYSTEM TRSV
+  reference_blas::trsv(uplo_str, t_str, diag_str, n, a_m.data(), n * lda_mul,
+                       x_v_cpu.data(), incX);
+
+  auto q = make_queue();
+  blas::SB_Handle sb_handle(q);
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(a_m, a_size);
+  auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(x_v, x_size);
+
+  // SYCL TRSV
+  _trsv(sb_handle, *uplo_str, *t_str, *diag_str, n, m_a_gpu, n * lda_mul,
+        v_x_gpu, incX);
+
+  auto event = blas::helper::copy_to_host(sb_handle.get_queue(), v_x_gpu,
+                                          x_v.data(), x_size);
+  sb_handle.wait(event);
+
+#ifdef PRINTMAXERR
+  double maxerr = -1.0;
+  for (index_t i = 0; i < x_size; i += incX)
+    maxerr = std::max(maxerr, std::fabs(double(x_v[i]) - double(x_v_cpu[i])));
+  std::cerr << " Maximum error compared to reference: " << maxerr << std::endl;
+#endif
+
+  const bool isAlmostEqual = utils::compare_vectors(x_v, x_v_cpu);
+  ASSERT_TRUE(isAlmostEqual);
+}
+
+#ifdef STRESS_TESTING
+template <typename scalar_t>
+const auto combi =
+    ::testing::Combine(::testing::Values(14, 127, 504, 780, 1010, 1140),  // n
+                       ::testing::Values(true, false),  // is_upper
+                       ::testing::Values(true, false),  // trans
+                       ::testing::Values(true, false),  // is_unit
+                       ::testing::Values(1, 2),         // incX
+                       ::testing::Values(1, 2)          // lda_mul
+    );
+#else
+// For the purpose of travis and other slower platforms, we need a faster test
+// (the stress_test above takes about ~5 minutes)
+template <typename scalar_t>
+const auto combi =
+    ::testing::Combine(::testing::Values(14, 63, 257, 1010),  // n
+                       ::testing::Values(true, false),        // is_upper
+                       ::testing::Values(true, false),        // trans
+                       ::testing::Values(true, false),        // is_unit
+                       ::testing::Values(2),                  // incX
+                       ::testing::Values(2)                   // lda_mul
+    );
+#endif
+
+template <class T>
+static std::string generate_name(
+    const ::testing::TestParamInfo<combination_t<T>>& info) {
+  int n, incX, ldaMul;
+  bool is_upper;
+  bool trans;
+  bool is_unit;
+  BLAS_GENERATE_NAME(info.param, n, is_upper, trans, is_unit, incX, ldaMul);
+}
+
+BLAS_REGISTER_TEST_ALL(Trsv, combination_t, combi, generate_name);

--- a/test/unittest/blas2/blas2_trsv_test.cpp
+++ b/test/unittest/blas2/blas2_trsv_test.cpp
@@ -26,7 +26,7 @@
 #include "blas_test.hpp"
 
 template <typename T>
-using combination_t = std::tuple<int, bool, bool, bool, int, int>;
+using combination_t = std::tuple<index_t, bool, bool, bool, index_t, index_t>;
 
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
@@ -42,8 +42,8 @@ void run_test(const combination_t<scalar_t> combi) {
   const char* uplo_str = is_upper ? "u" : "l";
   const char* diag_str = is_unit ? "u" : "n";
 
-  int a_size = n * n * lda_mul;
-  int x_size = 1 + (n - 1) * incX;
+  index_t a_size = n * n * lda_mul;
+  index_t x_size = 1 + (n - 1) * incX;
 
   // Input matrix
   std::vector<scalar_t> a_m(a_size);
@@ -118,7 +118,7 @@ const auto combi =
 template <class T>
 static std::string generate_name(
     const ::testing::TestParamInfo<combination_t<T>>& info) {
-  int n, incX, ldaMul;
+  index_t n, incX, ldaMul;
   bool is_upper;
   bool trans;
   bool is_unit;

--- a/test/unittest/blas2/blas2_trsv_test.cpp
+++ b/test/unittest/blas2/blas2_trsv_test.cpp
@@ -48,7 +48,7 @@ void run_test(const combination_t<scalar_t> combi) {
   index_t x_size = 1 + (n - 1) * incX;
 
   // Input matrix
-  std::vector<scalar_t> a_m(a_size, 1);
+  std::vector<scalar_t> a_m(a_size);
   // Input/output vector
   std::vector<scalar_t> x_v(x_size);
   // Input/output system vector
@@ -103,24 +103,25 @@ void run_test(const combination_t<scalar_t> combi) {
 #ifdef STRESS_TESTING
 template <typename scalar_t>
 const auto combi =
-    ::testing::Combine(::testing::Values(14, 64, 33, 515, 1024, 1200, 3000),  // n
-                       ::testing::Values(true, false),  // is_upper
-                       ::testing::Values(true, false),  // trans
-                       ::testing::Values(true, false),  // is_unit
-                       ::testing::Values(1, 2),         // incX
-                       ::testing::Values(1, 2),         // lda_mul
+    ::testing::Combine(::testing::Values(32, 64, 128, 512, 14, 127, 504, 780,
+                                         1010, 1140, 2300, 8192),  // n
+                       ::testing::Values(true, false),             // is_upper
+                       ::testing::Values(true, false),             // trans
+                       ::testing::Values(true, false),             // is_unit
+                       ::testing::Values(1, 2),                    // incX
+                       ::testing::Values(1, 2),                    // lda_mul
                        ::testing::Values(0));
 #else
 // For the purpose of travis and other slower platforms, we need a faster test
 // (the stress_test above takes about ~5 minutes)
 template <typename scalar_t>
 const auto combi = ::testing::Combine(
-    ::testing::Values(14, 127, 504, 780, 1010, 1140, 2300),  // n
-    ::testing::Values(true, false),                          // is_upper
-    ::testing::Values(false, true),                          // trans
-    ::testing::Values(true, false),                          // is_unit
-    ::testing::Values(2),                                    // incX
-    ::testing::Values(2),                                    // lda_mul
+    ::testing::Values(14, 64, 33, 515, 1024, 1200, 3000),  // n
+    ::testing::Values(true, false),                        // is_upper
+    ::testing::Values(true, false),                        // trans
+    ::testing::Values(true, false),                        // is_unit
+    ::testing::Values(4),                                  // incX
+    ::testing::Values(3),                                  // lda_mul
     ::testing::Values(0));
 #endif
 

--- a/test/unittest/blas2/blas2_trsv_test.cpp
+++ b/test/unittest/blas2/blas2_trsv_test.cpp
@@ -59,7 +59,7 @@ void run_test(const combination_t<scalar_t> combi) {
     for (index_t j = 0; j < n; ++j)
       a_m[(j * n * lda_mul) + i] =
           ((!is_upper && (i > j)) || (is_upper && (i < j)))
-              ? random_scalar(scalar_t(-0.05), scalar_t(0.05))
+              ? random_scalar(scalar_t(-10), scalar_t(10)) / scalar_t(n)
               : NAN;
 
   if (!is_unit) {


### PR DESCRIPTION
This patch adds a baseline implementation of `TRSV` compatible with `TUNING_TARGET` specializations.