### PR TITLE
Added RocBLAS benchmarks for Level 2 operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ api_doc/
 #Visual Studio files
 .vs/
 CMakeSettings.json
+
+builini*

--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,3 @@ api_doc/
 #Visual Studio files
 .vs/
 CMakeSettings.json
-
-builini*

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -49,6 +49,7 @@ set(sources
   blas2/tbmv.cpp
   blas2/trsv.cpp
   blas2/spr.cpp
+  blas2/symv.cpp
 
 )
 

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -57,6 +57,8 @@ set(sources
   blas2/tbsv.cpp
   blas2/tpsv.cpp
   blas2/tpmv.cpp
+  blas2/trmv.cpp
+  blas2/spmv.cpp
 
 )
 

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -42,6 +42,14 @@ set(sources
   blas1/rotm.cpp
   blas1/rotmg.cpp
 
+  # Level 2 blas
+  blas2/gemv.cpp
+  blas2/gbmv.cpp
+  blas2/sbmv.cpp
+  blas2/tbmv.cpp
+
+)
+
 )
 
 # Add individual benchmarks for each method

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -49,10 +49,12 @@ set(sources
   blas2/tbmv.cpp
   blas2/trsv.cpp
   blas2/spr.cpp
+  blas2/spr2.cpp
   blas2/symv.cpp
   blas2/syr.cpp
   blas2/syr2.cpp
   blas2/ger.cpp
+  blas2/tbsv.cpp
 
 )
 

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -48,6 +48,7 @@ set(sources
   blas2/sbmv.cpp
   blas2/tbmv.cpp
   blas2/trsv.cpp
+  blas2/spr.cpp
 
 )
 

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -52,6 +52,7 @@ set(sources
   blas2/symv.cpp
   blas2/syr.cpp
   blas2/syr2.cpp
+  blas2/ger.cpp
 
 )
 

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -47,6 +47,7 @@ set(sources
   blas2/gbmv.cpp
   blas2/sbmv.cpp
   blas2/tbmv.cpp
+  blas2/trsv.cpp
 
 )
 

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -50,6 +50,8 @@ set(sources
   blas2/trsv.cpp
   blas2/spr.cpp
   blas2/symv.cpp
+  blas2/syr.cpp
+  blas2/syr2.cpp
 
 )
 

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -55,6 +55,8 @@ set(sources
   blas2/syr2.cpp
   blas2/ger.cpp
   blas2/tbsv.cpp
+  blas2/tpsv.cpp
+  blas2/tpmv.cpp
 
 )
 

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -51,8 +51,6 @@ set(sources
 
 )
 
-)
-
 # Add individual benchmarks for each method
 foreach(rocblas_benchmark ${sources})
   get_filename_component(rocblas_bench_exec ${rocblas_benchmark} NAME_WE)

--- a/benchmark/rocblas/blas2/gbmv.cpp
+++ b/benchmark/rocblas/blas2/gbmv.cpp
@@ -174,6 +174,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
     }
 
     blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
   }  // release device memory via utils::DeviceVector destructors
 }
 

--- a/benchmark/rocblas/blas2/gbmv.cpp
+++ b/benchmark/rocblas/blas2/gbmv.cpp
@@ -146,7 +146,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
     auto blas_warmup = [&]() -> void {
       rocblas_gbmv_f<scalar_t>(rb_handle, transA, m, n, kl, ku, &alpha, m_a_gpu,
                                lda, v_x_gpu, incX, &beta, v_y_gpu, incY);
-      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
       return;
     };
 
@@ -165,6 +164,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
 
     // Warmup
     blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);
 

--- a/benchmark/rocblas/blas2/gbmv.cpp
+++ b/benchmark/rocblas/blas2/gbmv.cpp
@@ -76,13 +76,12 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
       (t_str[0] == 'n' ? n_d : m_d) * (kl_d + ku_d + 1.0) -
       0.5 * (kl_d * (kl_d + 1.0)) - 0.5 * (ku_d * (ku_d + 1.0));
 
-  {
-    double nflops_AtimesX = 2.0 * A_validVal;
-    double nflops_timesAlpha = ylen;
-    double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
-    state.counters["n_fl_ops"] =
-        nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
-  }
+  double nflops_AtimesX = 2.0 * A_validVal;
+  double nflops_timesAlpha = ylen;
+  double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
+  double nflops_tot = nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
+  state.counters["n_fl_ops"] = nflops_tot;
+
   {
     double mem_readA = A_validVal;
     double mem_readX = xlen;
@@ -177,6 +176,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas2/gbmv.cpp
+++ b/benchmark/rocblas/blas2/gbmv.cpp
@@ -96,19 +96,24 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
   const rocblas_operation transA =
       t_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
 
+  // Data sizes
+  const int m_size = lda * n;
+  const int v_x_size = 1 + (xlen - 1) * incX;
+  const int v_y_size = 1 + (ylen - 1) * incY;
+
   // Input matrix/vector, output vector.
   std::vector<scalar_t> m_a =
-      blas_benchmark::utils::random_data<scalar_t>(lda * n);
+      blas_benchmark::utils::random_data<scalar_t>(m_size);
   std::vector<scalar_t> v_x =
-      blas_benchmark::utils::random_data<scalar_t>(xlen);
+      blas_benchmark::utils::random_data<scalar_t>(v_x_size);
   std::vector<scalar_t> v_y =
-      blas_benchmark::utils::random_data<scalar_t>(ylen);
+      blas_benchmark::utils::random_data<scalar_t>(v_y_size);
 
   {
     // Device memory allocation & H2D copy
-    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(lda * n, m_a.data());
-    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(xlen, v_x.data());
-    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(ylen, v_y.data());
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_x_size, v_x.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(v_y_size, v_y.data());
 
     CHECK_ROCBLAS_STATUS(
         rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));

--- a/benchmark/rocblas/blas2/gbmv.cpp
+++ b/benchmark/rocblas/blas2/gbmv.cpp
@@ -1,0 +1,208 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename gbmv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string t, int m, int n, int kl, int ku) {
+  std::ostringstream str{};
+  str << "BM_Gbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << t << "/" << m << "/" << n << "/" << kl << "/" << ku;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_gbmv_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_sgbmv(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dgbmv(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
+         index_t n, index_t kl, index_t ku, scalar_t alpha, scalar_t beta,
+         bool* success) {
+  // Standard test setup.
+  std::string ts = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(ti));
+  const char* t_str = ts.c_str();
+
+  index_t xlen = t_str[0] == 'n' ? n : m;
+  index_t ylen = t_str[0] == 'n' ? m : n;
+
+  index_t lda = (kl + ku + 1);
+  index_t incX = 1;
+  index_t incY = 1;
+
+  // The counters are double. We convert m and n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double m_d = static_cast<double>(m);
+  double n_d = static_cast<double>(n);
+  double kl_d = static_cast<double>(kl);
+  double ku_d = static_cast<double>(ku);
+
+  state.counters["m"] = m_d;
+  state.counters["n"] = n_d;
+  state.counters["kl"] = kl_d;
+  state.counters["ku"] = ku_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal =
+      (t_str[0] == 'n' ? n_d : m_d) * (kl_d + ku_d + 1.0) -
+      0.5 * (kl_d * (kl_d + 1.0)) - 0.5 * (ku_d * (ku_d + 1.0));
+
+  {
+    double nflops_AtimesX = 2.0 * A_validVal;
+    double nflops_timesAlpha = ylen;
+    double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
+    state.counters["n_fl_ops"] =
+        nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
+  }
+  {
+    double mem_readA = A_validVal;
+    double mem_readX = xlen;
+    double mem_writeY = ylen;
+    double mem_readY = (beta != scalar_t{0}) ? ylen : 0;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_writeY + mem_readY) * sizeof(scalar_t);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_operation transA =
+      t_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+  std::vector<scalar_t> v_y =
+      blas_benchmark::utils::random_data<scalar_t>(ylen);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(lda * n, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(xlen, v_x.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(ylen, v_y.data());
+
+    CHECK_ROCBLAS_STATUS(
+        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference gbmv
+    std::vector<scalar_t> v_y_ref = v_y;
+    reference_blas::gbmv(t_str, m, n, kl, ku, alpha, m_a.data(), lda,
+                         v_x.data(), incX, beta, v_y_ref.data(), incY);
+
+    // Rocblas verification gbmv
+    std::vector<scalar_t> v_y_temp = v_y;
+    {
+      // Temp result on device (copied back to Host upon destruction)
+      blas_benchmark::utils::HIPVector<scalar_t, true> y_temp_gpu(
+          ylen, v_y_temp.data());
+      // rocBLAS function call
+      rocblas_gbmv_f<scalar_t>(rb_handle, transA, m, n, kl, ku, &alpha, m_a_gpu,
+                               lda, v_x_gpu, incX, &beta, y_temp_gpu, incY);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(v_y_temp, v_y_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_gbmv_f<scalar_t>(rb_handle, transA, m, n, kl, ku, &alpha, m_a_gpu,
+                               lda, v_x_gpu, incX, &beta, v_y_gpu, incY);
+      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_gbmv_f<scalar_t>(rb_handle, transA, m, n, kl, ku, &alpha, m_a_gpu,
+                               lda, v_x_gpu, incX, &beta, v_y_gpu, incY);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+  }  // release device memory via utils::DeviceVector destructors
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto gbmv_params = blas_benchmark::utils::get_gbmv_params<scalar_t>(args);
+
+  for (auto p : gbmv_params) {
+    std::string ts;
+    index_t m, n, kl, ku;
+    scalar_t alpha, beta;
+    std::tie(ts, m, n, kl, ku, alpha, beta) = p;
+    int t = static_cast<int>(blas_benchmark::utils::to_transpose_enum(ts));
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle, int t,
+                         index_t m, index_t n, index_t kl, index_t ku,
+                         scalar_t alpha, scalar_t beta, bool* success) {
+      run<scalar_t>(st, rb_handle, t, m, n, kl, ku, alpha, beta, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n, kl, ku).c_str(),
+                                 BM_lambda, rb_handle, t, m, n, kl, ku, alpha,
+                                 beta, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas2/gemv.cpp
+++ b/benchmark/rocblas/blas2/gemv.cpp
@@ -1,0 +1,202 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename gemv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string t, int m, int n) {
+  std::ostringstream str{};
+  str << "BM_Gemv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << t << "/" << m << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_gemv_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_sgemv(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dgemv(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
+         index_t n, scalar_t alpha, scalar_t beta, bool* success) {
+  // Standard test setup.
+  std::string ts = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(ti));
+  const char* t_str = ts.c_str();
+
+  index_t xlen = t_str[0] == 'n' ? n : m;
+  index_t ylen = t_str[0] == 'n' ? m : n;
+
+  index_t lda = m;
+  index_t incX = 1;
+  index_t incY = 1;
+
+  // The counters are double. We convert m and n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double m_d = static_cast<double>(m);
+  double n_d = static_cast<double>(n);
+
+  state.counters["m"] = m_d;
+  state.counters["n"] = n_d;
+
+  {
+    double nflops_AtimesX = 2.0 * m_d * n_d;
+    double nflops_timesAlpha = ylen;
+    double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
+    state.counters["n_fl_ops"] =
+        nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
+  }
+  {
+    double mem_readA = m_d * n_d;
+    double mem_readX = xlen;
+    double mem_writeY = ylen;
+    double mem_readY = (beta != scalar_t{0}) ? ylen : 0;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_writeY + mem_readY) * sizeof(scalar_t);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_operation transA =
+      t_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(m * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+  std::vector<scalar_t> v_y =
+      blas_benchmark::utils::random_data<scalar_t>(ylen);
+
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_a, m * n);
+  auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_x, xlen);
+  auto v_y_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_y, ylen);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m * n, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(xlen, v_x.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(ylen, v_y.data());
+
+    CHECK_ROCBLAS_STATUS(
+        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference gemv
+    std::vector<scalar_t> v_y_ref = v_y;
+    reference_blas::gemv(t_str, m, n, alpha, m_a.data(), m, v_x.data(), incX,
+                         beta, v_y_ref.data(), incY);
+
+    // Rocblas verification gemv
+    std::vector<scalar_t> v_y_temp = v_y;
+    {
+      // Temp result on device (copied back to Host upon destruction)
+      blas_benchmark::utils::HIPVector<scalar_t, true> v_y_temp_gpu(
+          ylen, v_y_temp.data());
+      // rocBLAS function call
+      rocblas_gemv_f<scalar_t>(rb_handle, transA, m, n, &alpha, m_a_gpu, lda,
+                               v_x_gpu, incX, &beta, v_y_temp_gpu, incY);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(v_y_temp, v_y_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_gemv_f<scalar_t>(rb_handle, transA, m, n, &alpha, m_a_gpu, lda,
+                               v_x_gpu, incX, &beta, v_y_gpu, incY);
+      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_gemv_f<scalar_t>(rb_handle, transA, m, n, &alpha, m_a_gpu, lda,
+                               v_x_gpu, incX, &beta, v_y_gpu, incY);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+  }  // release device memory via utils::DeviceVector destructors
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto gemv_params = blas_benchmark::utils::get_blas2_params<scalar_t>(args);
+
+  for (auto p : gemv_params) {
+    std::string ts;
+    index_t m, n;
+    scalar_t alpha, beta;
+    std::tie(ts, m, n, alpha, beta) = p;
+    int t = static_cast<int>(blas_benchmark::utils::to_transpose_enum(ts));
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle, int t,
+                         index_t m, index_t n, scalar_t alpha, scalar_t beta,
+                         bool* success) {
+      run<scalar_t>(st, rb_handle, t, m, n, alpha, beta, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n).c_str(),
+                                 BM_lambda, rb_handle, t, m, n, alpha, beta,
+                                 success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas2/gemv.cpp
+++ b/benchmark/rocblas/blas2/gemv.cpp
@@ -86,23 +86,24 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
   const rocblas_operation transA =
       t_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
 
+  // Data sizes
+  const int m_size = m * n;
+  const int v_x_size = 1 + (xlen - 1) * incX;
+  const int v_y_size = 1 + (ylen - 1) * incY;
+
   // Input matrix/vector, output vector.
   std::vector<scalar_t> m_a =
-      blas_benchmark::utils::random_data<scalar_t>(m * n);
+      blas_benchmark::utils::random_data<scalar_t>(m_size);
   std::vector<scalar_t> v_x =
-      blas_benchmark::utils::random_data<scalar_t>(xlen);
+      blas_benchmark::utils::random_data<scalar_t>(v_x_size);
   std::vector<scalar_t> v_y =
-      blas_benchmark::utils::random_data<scalar_t>(ylen);
-
-  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_a, m * n);
-  auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_x, xlen);
-  auto v_y_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_y, ylen);
+      blas_benchmark::utils::random_data<scalar_t>(v_y_size);
 
   {
     // Device memory allocation & H2D copy
-    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m * n, m_a.data());
-    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(xlen, v_x.data());
-    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(ylen, v_y.data());
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_x_size, v_x.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(v_y_size, v_y.data());
 
     CHECK_ROCBLAS_STATUS(
         rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));

--- a/benchmark/rocblas/blas2/gemv.cpp
+++ b/benchmark/rocblas/blas2/gemv.cpp
@@ -66,13 +66,12 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
   state.counters["m"] = m_d;
   state.counters["n"] = n_d;
 
-  {
-    double nflops_AtimesX = 2.0 * m_d * n_d;
-    double nflops_timesAlpha = ylen;
-    double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
-    state.counters["n_fl_ops"] =
-        nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
-  }
+  double nflops_AtimesX = 2.0 * m_d * n_d;
+  double nflops_timesAlpha = ylen;
+  double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
+  double nflops_tot = nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
+  state.counters["n_fl_ops"] = nflops_tot;
+
   {
     double mem_readA = m_d * n_d;
     double mem_readX = xlen;
@@ -167,6 +166,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas2/gemv.cpp
+++ b/benchmark/rocblas/blas2/gemv.cpp
@@ -168,6 +168,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
     }
 
     blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
   }  // release device memory via utils::DeviceVector destructors
 }
 

--- a/benchmark/rocblas/blas2/gemv.cpp
+++ b/benchmark/rocblas/blas2/gemv.cpp
@@ -136,7 +136,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
     auto blas_warmup = [&]() -> void {
       rocblas_gemv_f<scalar_t>(rb_handle, transA, m, n, &alpha, m_a_gpu, lda,
                                v_x_gpu, incX, &beta, v_y_gpu, incY);
-      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
       return;
     };
 
@@ -155,6 +154,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
 
     // Warmup
     blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);
 

--- a/benchmark/rocblas/blas2/ger.cpp
+++ b/benchmark/rocblas/blas2/ger.cpp
@@ -28,7 +28,7 @@
 template <typename scalar_t>
 std::string get_name(int m, int n) {
   std::ostringstream str{};
-  str << "BM_ger<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+  str << "BM_Ger<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
       << m << "/" << n;
   return str.str();
 }

--- a/benchmark/rocblas/blas2/ger.cpp
+++ b/benchmark/rocblas/blas2/ger.cpp
@@ -103,8 +103,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t m,
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference ger
     std::vector<scalar_t> m_a_ref = m_a;
-    reference_blas::ger(m, n, alpha, m_a_ref.data(), incX, v_x.data(), incY,
-                        v_y.data(), lda);
+    reference_blas::ger(m, n, alpha, v_x.data(), incX, v_y.data(), incY,
+                        m_a_ref.data(), lda);
 
     // Rocblas verification ger
     std::vector<scalar_t> m_a_temp = m_a;

--- a/benchmark/rocblas/blas2/ger.cpp
+++ b/benchmark/rocblas/blas2/ger.cpp
@@ -1,0 +1,194 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename ger.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(int m, int n) {
+  std::ostringstream str{};
+  str << "BM_ger<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << m << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_ger_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_sger(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dger(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, index_t m,
+         index_t n, scalar_t alpha, bool* success) {
+  // Standard test setup.
+  index_t xlen = m;
+  index_t ylen = n;
+
+  index_t lda = m;
+  index_t incX = 1;
+  index_t incY = 1;
+
+  // The counters are double. We convert m and n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double m_d = static_cast<double>(m);
+  double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+  state.counters["m"] = m_d;
+
+  {
+    double nflops_timesAlpha = std::min(xlen, ylen);
+    double nflops_XtimesY = n_d * m_d;
+    double nflops_sum = n_d * m_d;
+    state.counters["n_fl_ops"] =
+        nflops_timesAlpha + nflops_XtimesY + nflops_sum;
+  }
+  {
+    double mem_readA = n_d * m_d;
+    double mem_readX = xlen;
+    double mem_readY = ylen;
+    double mem_writeA = n_d * m_d;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_readY + mem_writeA) * sizeof(scalar_t);
+  }
+
+  // Data sizes
+  const int m_size = lda * n;
+  const int v_x_size = 1 + (xlen - 1) * incX;
+  const int v_y_size = 1 + (ylen - 1) * incY;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(m_size);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(v_x_size);
+  std::vector<scalar_t> v_y =
+      blas_benchmark::utils::random_data<scalar_t>(v_y_size);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_x_size, v_x.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(v_y_size, v_y.data());
+
+    CHECK_ROCBLAS_STATUS(
+        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference ger
+    std::vector<scalar_t> m_a_ref = m_a;
+    reference_blas::ger(m, n, alpha, m_a.data(), incX, v_x.data(), incY,
+                        v_y.data(), lda);
+
+    // Rocblas verification ger
+    std::vector<scalar_t> m_a_temp = m_a;
+    {
+      // Temp result on device (copied back to Host upon destruction)
+      blas_benchmark::utils::HIPVector<scalar_t, true> m_a_temp_gpu(
+          m_size, m_a_temp.data());
+      // rocBLAS function call
+      rocblas_ger_f<scalar_t>(rb_handle, m, n, &alpha, v_x_gpu, incX, v_y_gpu,
+                              incY, m_a_temp_gpu, lda);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(m_a_temp, m_a_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_ger_f<scalar_t>(rb_handle, m, n, &alpha, v_x_gpu, incX, v_y_gpu,
+                              incY, m_a_gpu, lda);
+      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_ger_f<scalar_t>(rb_handle, m, n, &alpha, v_x_gpu, incX, v_y_gpu,
+                              incY, m_a_gpu, lda);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto ger_params = blas_benchmark::utils::get_ger_params<scalar_t>(args);
+
+  for (auto p : ger_params) {
+    index_t m, n;
+    scalar_t alpha;
+    std::tie(m, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         index_t m, index_t n, scalar_t alpha, bool* success) {
+      run<scalar_t>(st, rb_handle, m, n, alpha, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(m, n).c_str(), BM_lambda,
+                                 rb_handle, m, n, alpha, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas2/ger.cpp
+++ b/benchmark/rocblas/blas2/ger.cpp
@@ -103,7 +103,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t m,
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference ger
     std::vector<scalar_t> m_a_ref = m_a;
-    reference_blas::ger(m, n, alpha, m_a.data(), incX, v_x.data(), incY,
+    reference_blas::ger(m, n, alpha, m_a_ref.data(), incX, v_x.data(), incY,
                         v_y.data(), lda);
 
     // Rocblas verification ger
@@ -128,7 +128,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t m,
     auto blas_warmup = [&]() -> void {
       rocblas_ger_f<scalar_t>(rb_handle, m, n, &alpha, v_x_gpu, incX, v_y_gpu,
                               incY, m_a_gpu, lda);
-      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
       return;
     };
 
@@ -147,6 +146,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t m,
 
     // Warmup
     blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);
 

--- a/benchmark/rocblas/blas2/ger.cpp
+++ b/benchmark/rocblas/blas2/ger.cpp
@@ -62,13 +62,12 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t m,
   state.counters["n"] = n_d;
   state.counters["m"] = m_d;
 
-  {
-    double nflops_timesAlpha = std::min(xlen, ylen);
-    double nflops_XtimesY = n_d * m_d;
-    double nflops_sum = n_d * m_d;
-    state.counters["n_fl_ops"] =
-        nflops_timesAlpha + nflops_XtimesY + nflops_sum;
-  }
+  double nflops_timesAlpha = std::min(xlen, ylen);
+  double nflops_XtimesY = n_d * m_d;
+  double nflops_sum = n_d * m_d;
+  double nflops_tot = nflops_timesAlpha + nflops_XtimesY + nflops_sum;
+  state.counters["n_fl_ops"] = nflops_tot;
+
   {
     double mem_readA = n_d * m_d;
     double mem_readX = xlen;
@@ -159,6 +158,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t m,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas2/sbmv.cpp
+++ b/benchmark/rocblas/blas2/sbmv.cpp
@@ -188,8 +188,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     std::tie(uplo, n, k, alpha, beta) = p;
 
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
-                         std::string uplo, index_t n, index_t k,
-                         scalar_t alpha, scalar_t beta, bool* success) {
+                         std::string uplo, index_t n, index_t k, scalar_t alpha,
+                         scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, uplo, n, k, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, k).c_str(),

--- a/benchmark/rocblas/blas2/sbmv.cpp
+++ b/benchmark/rocblas/blas2/sbmv.cpp
@@ -69,7 +69,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
   {
     double nflops_AtimesX = 2.0 * A_validVal;
-    double nflops_timesAlpha = ylen;
+    double nflops_timesAlpha = xlen;
     double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
     state.counters["n_fl_ops"] =
         nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;

--- a/benchmark/rocblas/blas2/sbmv.cpp
+++ b/benchmark/rocblas/blas2/sbmv.cpp
@@ -87,19 +87,24 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   const rocblas_fill uplo_rb =
       uplo_str[0] == 'u' ? rocblas_fill_upper : rocblas_fill_lower;
 
+  // Data sizes
+  const int m_size = lda * n;
+  const int v_x_size = 1 + (xlen - 1) * incX;
+  const int v_y_size = 1 + (ylen - 1) * incY;
+
   // Input matrix/vector, output vector.
   std::vector<scalar_t> m_a =
-      blas_benchmark::utils::random_data<scalar_t>(lda * n);
+      blas_benchmark::utils::random_data<scalar_t>(m_size);
   std::vector<scalar_t> v_x =
-      blas_benchmark::utils::random_data<scalar_t>(xlen);
+      blas_benchmark::utils::random_data<scalar_t>(v_x_size);
   std::vector<scalar_t> v_y =
-      blas_benchmark::utils::random_data<scalar_t>(ylen);
+      blas_benchmark::utils::random_data<scalar_t>(v_y_size);
 
   {
     // Device memory allocation & H2D copy
-    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(lda * n, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
     blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(xlen, v_x.data());
-    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(ylen, v_y.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(v_y_size, v_y.data());
 
     CHECK_ROCBLAS_STATUS(
         rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));

--- a/benchmark/rocblas/blas2/sbmv.cpp
+++ b/benchmark/rocblas/blas2/sbmv.cpp
@@ -137,7 +137,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
     auto blas_warmup = [&]() -> void {
       rocblas_sbmv_f<scalar_t>(rb_handle, uplo_rb, n, k, &alpha, m_a_gpu, lda,
                                v_x_gpu, incX, &beta, v_y_gpu, incY);
-      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
       return;
     };
 
@@ -156,6 +155,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
     // Warmup
     blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);
 

--- a/benchmark/rocblas/blas2/sbmv.cpp
+++ b/benchmark/rocblas/blas2/sbmv.cpp
@@ -165,6 +165,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
     }
 
     blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
   }  // release device memory via utils::DeviceVector destructors
 }
 

--- a/benchmark/rocblas/blas2/sbmv.cpp
+++ b/benchmark/rocblas/blas2/sbmv.cpp
@@ -1,0 +1,198 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename sbmv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, int n, int k) {
+  std::ostringstream str{};
+  str << "BM_Sbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n << "/" << k;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_sbmv_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_ssbmv(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dsbmv(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
+         index_t n, index_t k, scalar_t alpha, scalar_t beta, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+
+  index_t xlen = n;
+  index_t ylen = n;
+
+  index_t lda = (k + 1);
+  index_t incX = 1;
+  index_t incY = 1;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+  double k_d = static_cast<double>(k);
+
+  state.counters["n"] = n_d;
+  state.counters["k"] = k_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = (n_d * (2.0 * k_d + 1.0)) - (k_d * (k_d + 1.0));
+
+  {
+    double nflops_AtimesX = 2.0 * A_validVal;
+    double nflops_timesAlpha = ylen;
+    double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
+    state.counters["n_fl_ops"] =
+        nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
+  }
+  {
+    double mem_readA = A_validVal;
+    double mem_readX = xlen;
+    double mem_writeY = ylen;
+    double mem_readY = (beta != scalar_t{0}) ? ylen : 0;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_writeY + mem_readY) * sizeof(scalar_t);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_fill uplo_rb =
+      uplo_str[0] == 'u' ? rocblas_fill_upper : rocblas_fill_lower;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+  std::vector<scalar_t> v_y =
+      blas_benchmark::utils::random_data<scalar_t>(ylen);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(lda * n, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(xlen, v_x.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(ylen, v_y.data());
+
+    CHECK_ROCBLAS_STATUS(
+        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference sbmv
+    std::vector<scalar_t> v_y_ref = v_y;
+    reference_blas::sbmv(uplo_str, n, k, alpha, m_a.data(), lda, v_x.data(),
+                         incX, beta, v_y_ref.data(), incY);
+
+    // Rocblas verification sbmv
+    std::vector<scalar_t> v_y_temp = v_y;
+    {
+      // Temp result on device (copied back to Host upon destruction)
+      blas_benchmark::utils::HIPVector<scalar_t, true> v_y_temp_gpu(
+          ylen, v_y_temp.data());
+      // rocBLAS function call
+      rocblas_sbmv_f<scalar_t>(rb_handle, uplo_rb, n, k, &alpha, m_a_gpu, lda,
+                               v_x_gpu, incX, &beta, v_y_temp_gpu, incY);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(v_y_temp, v_y_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_sbmv_f<scalar_t>(rb_handle, uplo_rb, n, k, &alpha, m_a_gpu, lda,
+                               v_x_gpu, incX, &beta, v_y_gpu, incY);
+      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_sbmv_f<scalar_t>(rb_handle, uplo_rb, n, k, &alpha, m_a_gpu, lda,
+                               v_x_gpu, incX, &beta, v_y_gpu, incY);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+  }  // release device memory via utils::DeviceVector destructors
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto sbmv_params = blas_benchmark::utils::get_sbmv_params<scalar_t>(args);
+
+  for (auto p : sbmv_params) {
+    std::string uplos;
+    index_t n, k;
+    scalar_t alpha, beta;
+    std::tie(uplos, n, k, alpha, beta) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         std::string uplos, index_t n, index_t k,
+                         scalar_t alpha, scalar_t beta, bool* success) {
+      run<scalar_t>(st, rb_handle, uplos, n, k, alpha, beta, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(uplos, n, k).c_str(),
+                                 BM_lambda, rb_handle, uplos, n, k, alpha, beta,
+                                 success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas2/spmv.cpp
+++ b/benchmark/rocblas/blas2/spmv.cpp
@@ -19,7 +19,7 @@
  *
  *  SYCL-BLAS: BLAS implementation using SYCL
  *
- *  @filename symv.cpp
+ *  @filename spmv.cpp
  *
  **************************************************************************/
 
@@ -28,17 +28,17 @@
 template <typename scalar_t>
 std::string get_name(std::string uplo, int n) {
   std::ostringstream str{};
-  str << "BM_Symv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+  str << "BM_Spmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
       << uplo << "/" << n;
   return str.str();
 }
 
 template <typename scalar_t, typename... args_t>
-static inline void rocblas_symv_f(args_t&&... args) {
+static inline void rocblas_spmv_f(args_t&&... args) {
   if constexpr (std::is_same_v<scalar_t, float>) {
-    CHECK_ROCBLAS_STATUS(rocblas_ssymv(std::forward<args_t>(args)...));
+    CHECK_ROCBLAS_STATUS(rocblas_sspmv(std::forward<args_t>(args)...));
   } else if constexpr (std::is_same_v<scalar_t, double>) {
-    CHECK_ROCBLAS_STATUS(rocblas_dsymv(std::forward<args_t>(args)...));
+    CHECK_ROCBLAS_STATUS(rocblas_dspmv(std::forward<args_t>(args)...));
   }
   return;
 }
@@ -52,25 +52,27 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   index_t xlen = n;
   index_t ylen = n;
 
-  index_t lda = n;
   index_t incX = 1;
   index_t incY = 1;
 
-  // The counters are double. We convert m and n to double to avoid
+  // The counters are double. We convert n to double to avoid
   // integer overflows for n_fl_ops and bytes_processed
   double n_d = static_cast<double>(n);
 
   state.counters["n"] = n_d;
 
+  // Compute the number of A non-zero elements.
+  const double A_validVal = .5 * n_d * (n_d + 1);
+
   {
-    double nflops_AtimesX = 2.0 * n_d * n_d;
-    double nflops_timesAlpha = ylen;
+    double nflops_AtimesX = 2.0 * A_validVal;
+    double nflops_timesAlpha = xlen;
     double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
     state.counters["n_fl_ops"] =
         nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
   }
   {
-    double mem_readA = n_d * (n_d + 1) / 2;
+    double mem_readA = A_validVal;
     double mem_readX = xlen;
     double mem_writeY = ylen;
     double mem_readY = (beta != scalar_t{0}) ? ylen : 0;
@@ -83,7 +85,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       uplo_str[0] == 'u' ? rocblas_fill_upper : rocblas_fill_lower;
 
   // Data sizes
-  const int m_size = lda * n;
+  const int m_size = n * (n + 1) / 2;  // Minimum required size
   const int v_x_size = 1 + (xlen - 1) * incX;
   const int v_y_size = 1 + (ylen - 1) * incY;
 
@@ -98,27 +100,27 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   {
     // Device memory allocation & H2D copy
     blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
-    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_x_size, v_x.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(xlen, v_x.data());
     blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(v_y_size, v_y.data());
 
     CHECK_ROCBLAS_STATUS(
         rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
 
 #ifdef BLAS_VERIFY_BENCHMARK
-    // Reference symv
+    // Reference spmv
     std::vector<scalar_t> v_y_ref = v_y;
-    reference_blas::symv(uplo_str, n, alpha, m_a.data(), lda, v_x.data(), incX,
-                         beta, v_y_ref.data(), incY);
+    reference_blas::spmv(uplo_str, n, alpha, m_a.data(), v_x.data(), incX, beta,
+                         v_y_ref.data(), incY);
 
-    // Rocblas verification symv
+    // Rocblas verification spmv
     std::vector<scalar_t> v_y_temp = v_y;
     {
       // Temp result on device (copied back to Host upon destruction)
       blas_benchmark::utils::HIPVector<scalar_t, true> v_y_temp_gpu(
           ylen, v_y_temp.data());
       // rocBLAS function call
-      rocblas_symv_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, m_a_gpu, lda,
-                               v_x_gpu, incX, &beta, v_y_temp_gpu, incY);
+      rocblas_spmv_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, m_a_gpu, v_x_gpu,
+                               incX, &beta, v_y_temp_gpu, incY);
     }
 
     std::ostringstream err_stream;
@@ -130,8 +132,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 #endif
 
     auto blas_warmup = [&]() -> void {
-      rocblas_symv_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, m_a_gpu, lda,
-                               v_x_gpu, incX, &beta, v_y_gpu, incY);
+      rocblas_spmv_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, m_a_gpu, v_x_gpu,
+                               incX, &beta, v_y_gpu, incY);
       return;
     };
 
@@ -141,8 +143,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
     auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
       CHECK_HIP_ERROR(hipEventRecord(start, NULL));
-      rocblas_symv_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, m_a_gpu, lda,
-                               v_x_gpu, incX, &beta, v_y_gpu, incY);
+      rocblas_spmv_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, m_a_gpu, v_x_gpu,
+                               incX, &beta, v_y_gpu, incY);
       CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
       CHECK_HIP_ERROR(hipEventSynchronize(stop));
       return std::vector{start, stop};
@@ -174,9 +176,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                         bool* success) {
-  auto symv_params = blas_benchmark::utils::get_symv_params<scalar_t>(args);
+  auto spmv_params = blas_benchmark::utils::get_symv_params<scalar_t>(args);
 
-  for (auto p : symv_params) {
+  for (auto p : spmv_params) {
     std::string uplos;
     index_t n;
     scalar_t alpha, beta;

--- a/benchmark/rocblas/blas2/spmv.cpp
+++ b/benchmark/rocblas/blas2/spmv.cpp
@@ -64,13 +64,12 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   // Compute the number of A non-zero elements.
   const double A_validVal = .5 * n_d * (n_d + 1);
 
-  {
-    double nflops_AtimesX = 2.0 * A_validVal;
-    double nflops_timesAlpha = xlen;
-    double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
-    state.counters["n_fl_ops"] =
-        nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
-  }
+  double nflops_AtimesX = 2.0 * A_validVal;
+  double nflops_timesAlpha = n_d;
+  double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * n_d : 0;
+  double nflops_tot = nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
+  state.counters["n_fl_ops"] = nflops_tot;
+
   {
     double mem_readA = A_validVal;
     double mem_readX = xlen;
@@ -165,6 +164,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas2/spmv.cpp
+++ b/benchmark/rocblas/blas2/spmv.cpp
@@ -64,7 +64,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   // Compute the number of A non-zero elements.
   const double A_validVal = .5 * n_d * (n_d + 1);
 
-  double nflops_AtimesX = 2.0 * A_validVal;
+  double nflops_AtimesX = 2.0 * n_d * n_d;
   double nflops_timesAlpha = n_d;
   double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * n_d : 0;
   double nflops_tot = nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;

--- a/benchmark/rocblas/blas2/spr.cpp
+++ b/benchmark/rocblas/blas2/spr.cpp
@@ -116,7 +116,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo, int n,
     auto blas_warmup = [&]() -> void {
       rocblas_spr_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
                               m_a_gpu);
-      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
       return;
     };
 
@@ -135,6 +134,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo, int n,
 
     // Warmup
     blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);
 

--- a/benchmark/rocblas/blas2/spr.cpp
+++ b/benchmark/rocblas/blas2/spr.cpp
@@ -1,0 +1,184 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename spr.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(char uplo, int n, scalar_t alpha, int incX) {
+  std::ostringstream str{};
+  str << "BM_Spr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n << "/" << alpha << "/" << incX;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_spr_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_sspr(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dspr(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo, int n,
+         scalar_t alpha, int incX, bool* success) {
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double size_d = static_cast<double>(n * (n + 1) / 2);
+
+  state.counters["size_d"] = size_d;
+  state.counters["alpha"] = static_cast<double>(alpha);
+  state.counters["incX"] = incX;
+
+  {
+    double nflops_XtimesX = 2.0 * size_d;
+    state.counters["n_fl_ops"] = n + nflops_XtimesX;
+  }
+  {
+    double mem_readA = size_d;
+    double mem_readX = static_cast<double>(n);
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX) * sizeof(scalar_t);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_fill uplo_rb =
+      uplo == 'u' ? rocblas_fill_upper : rocblas_fill_lower;
+
+  // Data sizes
+  const int m_size = n * n;
+  const int v_size = 1 + (n - 1) * std::abs(incX);
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(m_size);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(v_size);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_size, v_x.data());
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference spr
+    std::vector<scalar_t> x_ref = v_x;
+    std::vector<scalar_t> m_a_ref = m_a;
+    reference_blas::spr<scalar_t>(&uplo, n, alpha, x_ref.data(), incX,
+                                  m_a_ref.data());
+
+    // Rocblas verification spr
+    std::vector<scalar_t> m_a_temp = m_a;
+    {
+      // Temp result on device (copied back to Host upon destruction)
+      blas_benchmark::utils::HIPVector<scalar_t, true> m_a_temp_gpu(
+          m_size, m_a_temp.data());
+      // rocBLAS function call
+      rocblas_spr_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
+                              m_a_temp_gpu);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(m_a_temp, m_a_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_spr_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
+                              m_a_gpu);
+      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_spr_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
+                              m_a_gpu);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto spr_params = blas_benchmark::utils::get_spr_params<scalar_t>(args);
+
+  for (auto p : spr_params) {
+    int n, incX;
+    std::string uplo;
+    scalar_t alpha;
+    std::tie(uplo, n, alpha, incX) = p;
+
+    char uplo_str = uplo[0];
+
+    auto BM_lambda_col = [&](benchmark::State& st, rocblas_handle rb_handle,
+                             char uplo, int n, scalar_t alpha, int incX,
+                             bool* success) {
+      run<scalar_t>(st, rb_handle, uplo, n, alpha, incX, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplo_str, n, alpha, incX).c_str(), BM_lambda_col,
+        rb_handle, uplo_str, n, alpha, incX, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas2/spr.cpp
+++ b/benchmark/rocblas/blas2/spr.cpp
@@ -49,18 +49,18 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo, int n,
   // The counters are double. We convert n to double to avoid
   // integer overflows for n_fl_ops and bytes_processed
   double size_d = static_cast<double>(n * (n + 1) / 2);
+  double n_d = static_cast<double>(n);
 
   state.counters["size_d"] = size_d;
   state.counters["alpha"] = static_cast<double>(alpha);
   state.counters["incX"] = incX;
 
-  {
-    double nflops_XtimesX = 2.0 * size_d;
-    state.counters["n_fl_ops"] = n + nflops_XtimesX;
-  }
+  double nflops_tot = 2.0 * size_d + n_d;
+  state.counters["n_fl_ops"] = nflops_tot;
+
   {
     double mem_readA = size_d;
-    double mem_readX = static_cast<double>(n);
+    double mem_readX = n_d;
     state.counters["bytes_processed"] =
         (mem_readA + mem_readX) * sizeof(scalar_t);
   }
@@ -147,6 +147,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo, int n,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas2/spr.cpp
+++ b/benchmark/rocblas/blas2/spr.cpp
@@ -70,7 +70,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo, int n,
       uplo == 'u' ? rocblas_fill_upper : rocblas_fill_lower;
 
   // Data sizes
-  const int m_size = n * n;
+  const int m_size = n * (n + 1) / 2;  // Minimum required size
   const int v_size = 1 + (n - 1) * std::abs(incX);
 
   // Input matrix/vector, output vector.
@@ -83,6 +83,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo, int n,
     // Device memory allocation & H2D copy
     blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
     blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_size, v_x.data());
+
+    CHECK_ROCBLAS_STATUS(
+        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
 
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference spr

--- a/benchmark/rocblas/blas2/spr.cpp
+++ b/benchmark/rocblas/blas2/spr.cpp
@@ -51,9 +51,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo, int n,
   double size_d = static_cast<double>(n * (n + 1) / 2);
   double n_d = static_cast<double>(n);
 
-  state.counters["size_d"] = size_d;
-  state.counters["alpha"] = static_cast<double>(alpha);
-  state.counters["incX"] = incX;
+  state.counters["n"] = n_d;
 
   double nflops_tot = 2.0 * size_d + n_d;
   state.counters["n_fl_ops"] = nflops_tot;

--- a/benchmark/rocblas/blas2/spr.cpp
+++ b/benchmark/rocblas/blas2/spr.cpp
@@ -61,8 +61,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo, int n,
   {
     double mem_readA = size_d;
     double mem_readX = n_d;
+    double mem_writeA = size_d;
     state.counters["bytes_processed"] =
-        (mem_readA + mem_readX) * sizeof(scalar_t);
+        (mem_readA + mem_readX + mem_writeA) * sizeof(scalar_t);
   }
 
   // Matrix options (rocBLAS)

--- a/benchmark/rocblas/blas2/spr2.cpp
+++ b/benchmark/rocblas/blas2/spr2.cpp
@@ -61,14 +61,14 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
   state.counters["n"] = n_d;
 
-  {
-    double nflops_XtimesAlpha = xlen;
-    double nflops_XtimesY = n_d * (n_d + 1) / 2;
-    double nflops_YtimesX = n_d * (n_d + 1) / 2;
-    double nflops_2sum = 2 * n_d * (n_d + 1) / 2;
-    state.counters["n_fl_ops"] =
-        nflops_XtimesAlpha + nflops_XtimesY + nflops_YtimesX + nflops_2sum;
-  }
+  double nflops_XtimesAlpha = xlen;
+  double nflops_XtimesY = n_d * (n_d + 1) / 2;
+  double nflops_YtimesX = n_d * (n_d + 1) / 2;
+  double nflops_2sum = 2 * n_d * (n_d + 1) / 2;
+  double nflops_tot =
+      nflops_XtimesAlpha + nflops_XtimesY + nflops_YtimesX + nflops_2sum;
+  state.counters["n_fl_ops"] = nflops_tot;
+
   {
     double mem_readA = n_d * (n_d + 1) / 2;
     double mem_readX = xlen;
@@ -163,6 +163,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas2/spr2.cpp
+++ b/benchmark/rocblas/blas2/spr2.cpp
@@ -1,0 +1,200 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename spr2.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, int n) {
+  std::ostringstream str{};
+  str << "BM_Spr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_spr2_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_sspr2(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dspr2(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
+         index_t n, scalar_t alpha, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+
+  index_t xlen = n;
+  index_t ylen = n;
+
+  index_t incX = 1;
+  index_t incY = 1;
+
+  // The counters are double. We convert m and n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  {
+    double nflops_XtimesAlpha = xlen;
+    double nflops_XtimesY = n_d * (n_d + 1) / 2;
+    double nflops_YtimesX = n_d * (n_d + 1) / 2;
+    double nflops_2sum = 2 * n_d * (n_d + 1) / 2;
+    state.counters["n_fl_ops"] =
+        nflops_XtimesAlpha + nflops_XtimesY + nflops_YtimesX + nflops_2sum;
+  }
+  {
+    double mem_readA = n_d * (n_d + 1) / 2;
+    double mem_readX = xlen;
+    double mem_readY = ylen;
+    double mem_writeA = n_d * (n_d + 1) / 2;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_readY + mem_writeA) * sizeof(scalar_t);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_fill uplo_rb =
+      uplo_str[0] == 'u' ? rocblas_fill_upper : rocblas_fill_lower;
+
+  // Data sizes
+  const int m_size = n * (n + 1) / 2;  // Minimum required size
+  const int v_x_size = 1 + (xlen - 1) * incX;
+  const int v_y_size = 1 + (ylen - 1) * incY;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(m_size);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(v_x_size);
+  std::vector<scalar_t> v_y =
+      blas_benchmark::utils::random_data<scalar_t>(v_y_size);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_x_size, v_x.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(v_y_size, v_y.data());
+
+    CHECK_ROCBLAS_STATUS(
+        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference spr2
+    std::vector<scalar_t> m_a_ref = m_a;
+    reference_blas::spr2(uplo_str, n, alpha, v_x.data(), incX, v_y.data(), incY,
+                         m_a_ref.data());
+
+    // Rocblas verification spr2
+    std::vector<scalar_t> m_a_temp = m_a;
+    {
+      // Temp result on device (copied back to Host upon destruction)
+      blas_benchmark::utils::HIPVector<scalar_t, true> m_a_temp_gpu(
+          m_size, m_a_temp.data());
+      // rocBLAS function call
+      rocblas_spr2_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
+                               v_y_gpu, incY, m_a_temp_gpu);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(m_a_temp, m_a_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_spr2_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
+                               v_y_gpu, incY, m_a_gpu);
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_spr2_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
+                               v_y_gpu, incY, m_a_gpu);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto spr2_params = blas_benchmark::utils::get_syr_params<scalar_t>(args);
+
+  for (auto p : spr2_params) {
+    std::string uplo;
+    index_t n;
+    scalar_t alpha;
+    std::tie(uplo, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         std::string uplo, index_t n, scalar_t alpha,
+                         bool* success) {
+      run<scalar_t>(st, rb_handle, uplo, n, alpha, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n).c_str(), BM_lambda,
+                                 rb_handle, uplo, n, alpha, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas2/symv.cpp
+++ b/benchmark/rocblas/blas2/symv.cpp
@@ -132,7 +132,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
     auto blas_warmup = [&]() -> void {
       rocblas_symv_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, m_a_gpu, lda,
                                v_x_gpu, incX, &beta, v_y_gpu, incY);
-      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
       return;
     };
 
@@ -151,6 +150,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
     // Warmup
     blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);
 

--- a/benchmark/rocblas/blas2/syr.cpp
+++ b/benchmark/rocblas/blas2/syr.cpp
@@ -60,13 +60,12 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
   state.counters["n"] = n_d;
 
-  {
-    double nflops_XtimesAlpha = xlen;
-    double nflops_XtimesX = n_d * (n_d + 1) / 2;
-    double nflops_addA = n_d * (n_d + 1) / 2;
-    state.counters["n_fl_ops"] =
-        nflops_XtimesAlpha + nflops_XtimesX + nflops_addA;
-  }
+  double nflops_XtimesAlpha = n_d;
+  double nflops_XtimesX = n_d * (n_d + 1) / 2;
+  double nflops_addA = n_d * (n_d + 1) / 2;
+  double nflops_tot = nflops_XtimesAlpha + nflops_XtimesX + nflops_addA;
+  state.counters["n_fl_ops"] = nflops_tot;
+
   {
     double mem_readA = n_d * (n_d + 1) / 2;
     double mem_readX = xlen;
@@ -156,6 +155,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas2/syr.cpp
+++ b/benchmark/rocblas/blas2/syr.cpp
@@ -1,0 +1,192 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename syr.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, int n) {
+  std::ostringstream str{};
+  str << "BM_Syr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_syr_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_ssyr(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dsyr(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
+         index_t n, scalar_t alpha, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+
+  index_t xlen = n;
+
+  index_t lda = n;
+  index_t incX = 1;
+
+  // The counters are double. We convert m and n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  {
+    double nflops_XtimesAlpha = xlen;
+    double nflops_XtimesX = n_d * (n_d + 1) / 2;
+    double nflops_addA = n_d * (n_d + 1) / 2;
+    state.counters["n_fl_ops"] =
+        nflops_XtimesAlpha + nflops_XtimesX + nflops_addA;
+  }
+  {
+    double mem_readA = n_d * (n_d + 1) / 2;
+    double mem_readX = xlen;
+    double mem_writeA = n_d * (n_d + 1) / 2;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_writeA) * sizeof(scalar_t);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_fill uplo_rb =
+      uplo_str[0] == 'u' ? rocblas_fill_upper : rocblas_fill_lower;
+
+  // Data sizes
+  const int m_size = lda * n;
+  const int v_x_size = 1 + (xlen - 1) * incX;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(m_size);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(v_x_size);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_x_size, v_x.data());
+
+    CHECK_ROCBLAS_STATUS(
+        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference syr
+    std::vector<scalar_t> m_a_ref = m_a;
+    reference_blas::syr(uplo_str, n, alpha, v_x.data(), incX, m_a.data(), lda);
+
+    // Rocblas verification syr
+    std::vector<scalar_t> m_a_temp = m_a;
+    {
+      // Temp result on device (copied back to Host upon destruction)
+      blas_benchmark::utils::HIPVector<scalar_t, true> m_a_temp_gpu(
+          m_size, m_a_temp.data());
+      // rocBLAS function call
+      rocblas_syr_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
+                              m_a_temp_gpu, lda);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(m_a_temp, m_a_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_syr_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
+                              m_a_gpu, lda);
+      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_syr_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
+                              m_a_gpu, lda);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto syr_params = blas_benchmark::utils::get_syr_params<scalar_t>(args);
+
+  for (auto p : syr_params) {
+    std::string uplo;
+    index_t n;
+    scalar_t alpha;
+    std::tie(uplo, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         std::string uplo, index_t n, scalar_t alpha,
+                         bool* success) {
+      run<scalar_t>(st, rb_handle, uplo, n, alpha, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n).c_str(), BM_lambda,
+                                 rb_handle, uplo, n, alpha, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas2/syr.cpp
+++ b/benchmark/rocblas/blas2/syr.cpp
@@ -100,7 +100,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference syr
     std::vector<scalar_t> m_a_ref = m_a;
-    reference_blas::syr(uplo_str, n, alpha, v_x.data(), incX, m_a.data(), lda);
+    reference_blas::syr(uplo_str, n, alpha, v_x.data(), incX, m_a_ref.data(),
+                        lda);
 
     // Rocblas verification syr
     std::vector<scalar_t> m_a_temp = m_a;
@@ -124,7 +125,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
     auto blas_warmup = [&]() -> void {
       rocblas_syr_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
                               m_a_gpu, lda);
-      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
       return;
     };
 
@@ -143,6 +143,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
     // Warmup
     blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);
 

--- a/benchmark/rocblas/blas2/syr2.cpp
+++ b/benchmark/rocblas/blas2/syr2.cpp
@@ -28,7 +28,7 @@
 template <typename scalar_t>
 std::string get_name(std::string uplo, int n) {
   std::ostringstream str{};
-  str << "BM_syr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+  str << "BM_Syr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
       << uplo << "/" << n;
   return str.str();
 }

--- a/benchmark/rocblas/blas2/syr2.cpp
+++ b/benchmark/rocblas/blas2/syr2.cpp
@@ -62,14 +62,14 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
   state.counters["n"] = n_d;
 
-  {
-    double nflops_XtimesAlpha = xlen;
-    double nflops_XtimesY = n_d * (n_d + 1) / 2;
-    double nflops_YtimesX = n_d * (n_d + 1) / 2;
-    double nflops_2sum = 2 * n_d * (n_d + 1) / 2;
-    state.counters["n_fl_ops"] =
-        nflops_XtimesAlpha + nflops_XtimesY + nflops_YtimesX + nflops_2sum;
-  }
+  double nflops_XtimesAlpha = n_d;
+  double nflops_XtimesY = n_d * (n_d + 1) / 2;
+  double nflops_YtimesX = n_d * (n_d + 1) / 2;
+  double nflops_2sum = 2 * n_d * (n_d + 1) / 2;
+  double nflops_tot =
+      nflops_XtimesAlpha + nflops_XtimesY + nflops_YtimesX + nflops_2sum;
+  state.counters["n_fl_ops"] = nflops_tot;
+
   {
     double mem_readA = n_d * (n_d + 1) / 2;
     double mem_readX = xlen;
@@ -164,6 +164,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas2/syr2.cpp
+++ b/benchmark/rocblas/blas2/syr2.cpp
@@ -109,7 +109,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
     // Reference syr2
     std::vector<scalar_t> m_a_ref = m_a;
     reference_blas::syr2(uplo_str, n, alpha, v_x.data(), incX, v_y.data(), incY,
-                         m_a.data(), lda);
+                         m_a_ref.data(), lda);
 
     // Rocblas verification syr2
     std::vector<scalar_t> m_a_temp = m_a;
@@ -133,7 +133,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
     auto blas_warmup = [&]() -> void {
       rocblas_syr2_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
                                v_y_gpu, incY, m_a_gpu, lda);
-      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
       return;
     };
 
@@ -152,6 +151,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
     // Warmup
     blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);
 

--- a/benchmark/rocblas/blas2/syr2.cpp
+++ b/benchmark/rocblas/blas2/syr2.cpp
@@ -1,0 +1,201 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename syr2.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, int n) {
+  std::ostringstream str{};
+  str << "BM_syr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_syr2_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_ssyr2(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dsyr2(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
+         index_t n, scalar_t alpha, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+
+  index_t xlen = n;
+  index_t ylen = n;
+
+  index_t lda = n;
+  index_t incX = 1;
+  index_t incY = 1;
+
+  // The counters are double. We convert m and n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  {
+    double nflops_XtimesAlpha = xlen;
+    double nflops_XtimesY = n_d * (n_d + 1) / 2;
+    double nflops_YtimesX = n_d * (n_d + 1) / 2;
+    double nflops_2sum = 2 * n_d * (n_d + 1) / 2;
+    state.counters["n_fl_ops"] =
+        nflops_XtimesAlpha + nflops_XtimesY + nflops_YtimesX + nflops_2sum;
+  }
+  {
+    double mem_readA = n_d * (n_d + 1) / 2;
+    double mem_readX = xlen;
+    double mem_readY = ylen;
+    double mem_writeA = n_d * (n_d + 1) / 2;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_readY + mem_writeA) * sizeof(scalar_t);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_fill uplo_rb =
+      uplo_str[0] == 'u' ? rocblas_fill_upper : rocblas_fill_lower;
+
+  // Data sizes
+  const int m_size = lda * n;
+  const int v_x_size = 1 + (xlen - 1) * incX;
+  const int v_y_size = 1 + (ylen - 1) * incY;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(m_size);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(v_x_size);
+  std::vector<scalar_t> v_y =
+      blas_benchmark::utils::random_data<scalar_t>(v_y_size);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_x_size, v_x.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(v_y_size, v_y.data());
+
+    CHECK_ROCBLAS_STATUS(
+        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference syr2
+    std::vector<scalar_t> m_a_ref = m_a;
+    reference_blas::syr2(uplo_str, n, alpha, v_x.data(), incX, v_y.data(), incY,
+                         m_a.data(), lda);
+
+    // Rocblas verification syr2
+    std::vector<scalar_t> m_a_temp = m_a;
+    {
+      // Temp result on device (copied back to Host upon destruction)
+      blas_benchmark::utils::HIPVector<scalar_t, true> m_a_temp_gpu(
+          m_size, m_a_temp.data());
+      // rocBLAS function call
+      rocblas_syr2_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
+                               v_y_gpu, incY, m_a_temp_gpu, lda);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(m_a_temp, m_a_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_syr2_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
+                               v_y_gpu, incY, m_a_gpu, lda);
+      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_syr2_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, v_x_gpu, incX,
+                               v_y_gpu, incY, m_a_gpu, lda);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto syr2_params = blas_benchmark::utils::get_syr_params<scalar_t>(args);
+
+  for (auto p : syr2_params) {
+    std::string uplo;
+    index_t n;
+    scalar_t alpha;
+    std::tie(uplo, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         std::string uplo, index_t n, scalar_t alpha,
+                         bool* success) {
+      run<scalar_t>(st, rb_handle, uplo, n, alpha, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n).c_str(), BM_lambda,
+                                 rb_handle, uplo, n, alpha, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas2/tbmv.cpp
+++ b/benchmark/rocblas/blas2/tbmv.cpp
@@ -88,16 +88,20 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   const rocblas_operation trans_rb =
       t_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
 
+  // Data sizes
+  const int m_size = lda * n;
+  const int v_size = 1 + (xlen - 1) * incX;
+
   // Input matrix/vector, output vector.
   std::vector<scalar_t> m_a =
-      blas_benchmark::utils::random_data<scalar_t>(lda * n);
+      blas_benchmark::utils::random_data<scalar_t>(m_size);
   std::vector<scalar_t> v_x =
-      blas_benchmark::utils::random_data<scalar_t>(xlen);
+      blas_benchmark::utils::random_data<scalar_t>(v_size);
 
   {
     // Device memory allocation & H2D copy
-    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(lda * n, m_a.data());
-    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(xlen, v_x.data());
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_size, v_x.data());
 
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference tbmv

--- a/benchmark/rocblas/blas2/tbmv.cpp
+++ b/benchmark/rocblas/blas2/tbmv.cpp
@@ -131,7 +131,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
     auto blas_warmup = [&]() -> void {
       rocblas_tbmv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n, k,
                                m_a_gpu, lda, v_x_gpu, incX);
-      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
       return;
     };
 
@@ -150,6 +149,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
     // Warmup
     blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);
 

--- a/benchmark/rocblas/blas2/tbmv.cpp
+++ b/benchmark/rocblas/blas2/tbmv.cpp
@@ -1,0 +1,195 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename tbmv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, std::string t, std::string diag, int n,
+                     int k) {
+  std::ostringstream str{};
+  str << "BM_Tbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_tbmv_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_stbmv(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dtbmv(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
+         std::string t, std::string diag, index_t n, index_t k, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+  const char* t_str = t.c_str();
+  const char* diag_str = diag.c_str();
+
+  index_t xlen = n;
+  index_t lda = (k + 1);
+  index_t incX = 1;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+  double k_d = static_cast<double>(k);
+
+  state.counters["n"] = n_d;
+  state.counters["k"] = k_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = (n_d * (k_d + 1.0)) - (0.5 * (k_d * (k_d + 1.0)));
+
+  {
+    double nflops_AtimesX = 2.0 * A_validVal;
+    state.counters["n_fl_ops"] = nflops_AtimesX;
+  }
+
+  {
+    double mem_readA = A_validVal;
+    double mem_readX = xlen;
+    double mem_writeX = xlen;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_fill uplo_rb =
+      uplo_str[0] == 'u' ? rocblas_fill_upper : rocblas_fill_lower;
+  const rocblas_diagonal diag_rb =
+      diag_str[0] == 'u' ? rocblas_diagonal_unit : rocblas_diagonal_non_unit;
+  const rocblas_operation trans_rb =
+      t_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(lda * n, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(xlen, v_x.data());
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference tbmv
+    std::vector<scalar_t> v_x_ref = v_x;
+    reference_blas::tbmv(uplo_str, t_str, diag_str, n, k, m_a.data(), lda,
+                         v_x_ref.data(), incX);
+
+    // Rocblas verification tbmv
+    std::vector<scalar_t> v_x_temp = v_x;
+    {
+      // Temp result on device (copied back to Host upon destruction)
+      blas_benchmark::utils::HIPVector<scalar_t, true> v_x_temp_gpu(
+          xlen, v_x_temp.data());
+      // rocBLAS function call
+      rocblas_tbmv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n, k,
+                               m_a_gpu, lda, v_x_temp_gpu, incX);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(v_x_temp, v_x_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_tbmv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n, k,
+                               m_a_gpu, lda, v_x_gpu, incX);
+      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_tbmv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n, k,
+                               m_a_gpu, lda, v_x_gpu, incX);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+  }  // release device memory via utils::DeviceVector destructors
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto tbmv_params = blas_benchmark::utils::get_tbmv_params(args);
+
+  for (auto p : tbmv_params) {
+    std::string uplos;
+    std::string ts;
+    std::string diags;
+    index_t n;
+    index_t k;
+    std::tie(uplos, ts, diags, n, k) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         std::string uplos, std::string ts, std::string diags,
+                         index_t n, index_t k, bool* success) {
+      run<scalar_t>(st, rb_handle, uplos, ts, diags, n, k, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
+        rb_handle, uplos, ts, diags, n, k, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas2/tbmv.cpp
+++ b/benchmark/rocblas/blas2/tbmv.cpp
@@ -160,6 +160,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
     }
 
     blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
   }  // release device memory via utils::DeviceVector destructors
 }
 

--- a/benchmark/rocblas/blas2/tbmv.cpp
+++ b/benchmark/rocblas/blas2/tbmv.cpp
@@ -65,17 +65,15 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   state.counters["k"] = k_d;
 
   // Compute the number of A non-zero elements.
-  const double A_validVal = (n_d * (k_d + 1.0)) - (0.5 * (k_d * (k_d + 1.0)));
+  const double A_validVal = n_d * (k_d + 1.0) - 0.5 * (k_d * (k_d + 1.0));
 
-  {
-    double nflops_AtimesX = 2.0 * A_validVal;
-    state.counters["n_fl_ops"] = nflops_AtimesX;
-  }
+  double nflops_tot = 2.0 * A_validVal;
+  state.counters["n_fl_ops"] = nflops_tot;
 
   {
     double mem_readA = A_validVal;
-    double mem_readX = xlen;
-    double mem_writeX = xlen;
+    double mem_readX = n_d;
+    double mem_writeX = n_d;
     state.counters["bytes_processed"] =
         (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
   }
@@ -162,6 +160,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas2/tbsv.cpp
+++ b/benchmark/rocblas/blas2/tbsv.cpp
@@ -97,8 +97,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
   // Populate the main diagonal with larger values.
   const int main_diag = (uplo_str[0] == 'u') ? k : 0;
-  for (index_t j = 0; j < n; ++i)
-    for (index_t i = 0; i < lda; ++j)
+  for (index_t j = 0; j < n; ++j)
+    for (index_t i = 0; i < lda; ++i)
       m_a[i + lda * j] =
           (i == main_diag)
               ? blas_benchmark::utils::random_scalar(scalar_t{9}, scalar_t{11})

--- a/benchmark/rocblas/blas2/tbsv.cpp
+++ b/benchmark/rocblas/blas2/tbsv.cpp
@@ -1,0 +1,202 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename tbsv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, std::string t, std::string diag, int n,
+                     int k) {
+  std::ostringstream str{};
+  str << "BM_Tbsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_tbsv_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_stbsv(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dtbsv(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
+         std::string t, std::string diag, index_t n, index_t k, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+  const char* t_str = t.c_str();
+  const char* diag_str = diag.c_str();
+
+  index_t xlen = n;
+  index_t lda = (k + 1);
+  index_t incX = 1;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+  double k_d = static_cast<double>(k);
+
+  state.counters["n"] = n_d;
+  state.counters["k"] = k_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = n_d * (k_d + 1.0) - 0.5 * (k_d * (k_d + 1.0));
+
+  {
+    double nflops_AtimesX = 2.0 * A_validVal;
+    state.counters["n_fl_ops"] = nflops_AtimesX;
+  }
+
+  {
+    double mem_readA = A_validVal;
+    double mem_readX = xlen;
+    double mem_writeX = xlen;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_fill uplo_rb =
+      uplo_str[0] == 'u' ? rocblas_fill_upper : rocblas_fill_lower;
+  const rocblas_diagonal diag_rb =
+      diag_str[0] == 'u' ? rocblas_diagonal_unit : rocblas_diagonal_non_unit;
+  const rocblas_operation trans_rb =
+      t_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
+
+  // Data sizes
+  const int m_size = lda * n;
+  const int v_size = 1 + (xlen - 1) * incX;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(m_size);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(v_size);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_size, v_x.data());
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference tbmv
+    std::vector<scalar_t> v_x_ref = v_x;
+    reference_blas::tbsv(uplo_str, t_str, diag_str, n, k, m_a.data(), lda,
+                         v_x_ref.data(), incX);
+
+    // Rocblas verification tbmv
+    std::vector<scalar_t> v_x_temp = v_x;
+    {
+      // Temp result on device (copied back to Host upon destruction)
+      blas_benchmark::utils::HIPVector<scalar_t, true> v_x_temp_gpu(
+          xlen * incX, v_x_temp.data());
+      // rocBLAS function call
+      rocblas_tbsv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n, k,
+                               m_a_gpu, lda, v_x_temp_gpu, incX);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(v_x_temp, v_x_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_tbsv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n, k,
+                               m_a_gpu, lda, v_x_gpu, incX);
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_tbsv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n, k,
+                               m_a_gpu, lda, v_x_gpu, incX);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto tbsv_params = blas_benchmark::utils::get_tbmv_params(args);
+
+  for (auto p : tbsv_params) {
+    std::string uplos;
+    std::string ts;
+    std::string diags;
+    index_t n;
+    index_t k;
+    std::tie(uplos, ts, diags, n, k) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         std::string uplos, std::string ts, std::string diags,
+                         index_t n, index_t k, bool* success) {
+      run<scalar_t>(st, rb_handle, uplos, ts, diags, n, k, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
+        rb_handle, uplos, ts, diags, n, k, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas2/tbsv.cpp
+++ b/benchmark/rocblas/blas2/tbsv.cpp
@@ -105,7 +105,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
                                           scalar_t{9}, scalar_t{11})
                                     : blas_benchmark::utils::random_scalar(
                                           scalar_t{-0.1}, scalar_t{0.1});
-
   {
     // Device memory allocation & H2D copy
     blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());

--- a/benchmark/rocblas/blas2/tpmv.cpp
+++ b/benchmark/rocblas/blas2/tpmv.cpp
@@ -63,15 +63,13 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   // Compute the number of A non-zero elements.
   const double A_validVal = .5 * n_d * (n_d + 1);
 
-  {
-    double nflops = 2 * A_validVal;
-    state.counters["n_fl_ops"] = nflops;
-  }
+  double nflops_tot = 2 * A_validVal;
+  state.counters["n_fl_ops"] = nflops_tot;
 
   {
     double mem_readA = A_validVal;
-    double mem_readX = xlen;
-    double mem_writeX = xlen;
+    double mem_readX = n_d;
+    double mem_writeX = n_d;
     state.counters["bytes_processed"] =
         (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
   }
@@ -158,6 +156,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas2/tpmv.cpp
+++ b/benchmark/rocblas/blas2/tpmv.cpp
@@ -169,18 +169,14 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                         bool* success) {
-  auto tpmv_params = blas_benchmark::utils::get_tbmv_params(args);
+  auto tpmv_params = blas_benchmark::utils::get_trsv_params(args);
 
   for (auto p : tpmv_params) {
     std::string uplo;
     std::string ts;
     std::string diags;
     index_t n;
-    index_t k;
-    std::tie(uplo, ts, diags, n, k) = p;
-
-    // Repurpose tbmv parameters.
-    if (k != 1) continue;
+    std::tie(uplo, ts, diags, n) = p;
 
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
                          std::string uplo, std::string ts, std::string diags,

--- a/benchmark/rocblas/blas2/tpmv.cpp
+++ b/benchmark/rocblas/blas2/tpmv.cpp
@@ -64,7 +64,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   const double A_validVal = .5 * n_d * (n_d + 1);
 
   {
-    double nflops = 2 * n_d * (n_d + 1) / 2;
+    double nflops = 2 * A_validVal;
     state.counters["n_fl_ops"] = nflops;
   }
 

--- a/benchmark/rocblas/blas2/tpmv.cpp
+++ b/benchmark/rocblas/blas2/tpmv.cpp
@@ -19,57 +19,53 @@
  *
  *  SYCL-BLAS: BLAS implementation using SYCL
  *
- *  @filename tbsv.cpp
+ *  @filename tpmv.cpp
  *
  **************************************************************************/
 
 #include "../utils.hpp"
 
 template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n,
-                     int k) {
+std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
   std::ostringstream str{};
-  str << "BM_Tbsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
+  str << "BM_Tpmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << t << "/" << diag << "/" << n;
   return str.str();
 }
 
 template <typename scalar_t, typename... args_t>
-static inline void rocblas_tbsv_f(args_t&&... args) {
+static inline void rocblas_tpmv_f(args_t&&... args) {
   if constexpr (std::is_same_v<scalar_t, float>) {
-    CHECK_ROCBLAS_STATUS(rocblas_stbsv(std::forward<args_t>(args)...));
+    CHECK_ROCBLAS_STATUS(rocblas_stpmv(std::forward<args_t>(args)...));
   } else if constexpr (std::is_same_v<scalar_t, double>) {
-    CHECK_ROCBLAS_STATUS(rocblas_dtbsv(std::forward<args_t>(args)...));
+    CHECK_ROCBLAS_STATUS(rocblas_dtpmv(std::forward<args_t>(args)...));
   }
   return;
 }
 
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
-         std::string t, std::string diag, index_t n, index_t k, bool* success) {
+         std::string t, std::string diag, index_t n, bool* success) {
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();
   const char* diag_str = diag.c_str();
 
   index_t xlen = n;
-  index_t lda = (k + 1);
   index_t incX = 1;
 
   // The counters are double. We convert n to double to avoid
   // integer overflows for n_fl_ops and bytes_processed
   double n_d = static_cast<double>(n);
-  double k_d = static_cast<double>(k);
 
   state.counters["n"] = n_d;
-  state.counters["k"] = k_d;
 
   // Compute the number of A non-zero elements.
-  const double A_validVal = n_d * (k_d + 1.0) - 0.5 * (k_d * (k_d + 1.0));
+  const double A_validVal = .5 * n_d * (n_d + 1);
 
   {
-    double nflops_AtimesX = 2.0 * A_validVal;
-    state.counters["n_fl_ops"] = nflops_AtimesX;
+    double nflops = 2 * n_d * (n_d + 1) / 2;
+    state.counters["n_fl_ops"] = nflops;
   }
 
   {
@@ -89,7 +85,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       t_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
 
   // Data sizes
-  const int m_size = lda * n;
+  const int m_size = n * (n + 1) / 2;  // Minimum required size
   const int v_size = 1 + (xlen - 1) * incX;
 
   // Input matrix/vector, output vector.
@@ -97,14 +93,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       blas_benchmark::utils::random_data<scalar_t>(m_size);
   std::vector<scalar_t> v_x =
       blas_benchmark::utils::random_data<scalar_t>(v_size);
-
-  // Populate the main diagonal with larger values.
-  for (index_t i = 0; i < n; ++i)
-    for (index_t j = 0; j < n; ++j)
-      m_a[(i * lda) + i] = (i == j) ? blas_benchmark::utils::random_scalar(
-                                          scalar_t{9}, scalar_t{11})
-                                    : blas_benchmark::utils::random_scalar(
-                                          scalar_t{-0.1}, scalar_t{0.1});
 
   {
     // Device memory allocation & H2D copy
@@ -114,7 +102,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference tbmv
     std::vector<scalar_t> v_x_ref = v_x;
-    reference_blas::tbsv(uplo_str, t_str, diag_str, n, k, m_a.data(), lda,
+    reference_blas::tpmv(uplo_str, t_str, diag_str, n, m_a.data(),
                          v_x_ref.data(), incX);
 
     // Rocblas verification tbmv
@@ -124,8 +112,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       blas_benchmark::utils::HIPVector<scalar_t, true> v_x_temp_gpu(
           xlen * incX, v_x_temp.data());
       // rocBLAS function call
-      rocblas_tbsv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n, k,
-                               m_a_gpu, lda, v_x_temp_gpu, incX);
+      rocblas_tpmv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n,
+                               m_a_gpu, v_x_temp_gpu, incX);
     }
 
     std::ostringstream err_stream;
@@ -137,8 +125,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 #endif
 
     auto blas_warmup = [&]() -> void {
-      rocblas_tbsv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n, k,
-                               m_a_gpu, lda, v_x_gpu, incX);
+      rocblas_tpmv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n,
+                               m_a_gpu, v_x_gpu, incX);
       return;
     };
 
@@ -148,8 +136,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
     auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
       CHECK_HIP_ERROR(hipEventRecord(start, NULL));
-      rocblas_tbsv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n, k,
-                               m_a_gpu, lda, v_x_gpu, incX);
+      rocblas_tpmv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n,
+                               m_a_gpu, v_x_gpu, incX);
       CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
       CHECK_HIP_ERROR(hipEventSynchronize(stop));
       return std::vector{start, stop};
@@ -181,9 +169,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                         bool* success) {
-  auto tbsv_params = blas_benchmark::utils::get_tbmv_params(args);
+  auto tpmv_params = blas_benchmark::utils::get_tbmv_params(args);
 
-  for (auto p : tbsv_params) {
+  for (auto p : tpmv_params) {
     std::string uplo;
     std::string ts;
     std::string diags;
@@ -191,14 +179,17 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     index_t k;
     std::tie(uplo, ts, diags, n, k) = p;
 
+    // Repurpose tbmv parameters.
+    if (k != 1) continue;
+
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
                          std::string uplo, std::string ts, std::string diags,
-                         index_t n, index_t k, bool* success) {
-      run<scalar_t>(st, rb_handle, uplo, ts, diags, n, k, success);
+                         index_t n, bool* success) {
+      run<scalar_t>(st, rb_handle, uplo, ts, diags, n, success);
     };
-    benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo, ts, diags, n, k).c_str(), BM_lambda, rb_handle,
-        uplo, ts, diags, n, k, success);
+    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, ts, diags, n).c_str(),
+                                 BM_lambda, rb_handle, uplo, ts, diags, n,
+                                 success);
   }
 }
 

--- a/benchmark/rocblas/blas2/tpsv.cpp
+++ b/benchmark/rocblas/blas2/tpsv.cpp
@@ -179,18 +179,14 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                         bool* success) {
-  auto tpsv_params = blas_benchmark::utils::get_tbmv_params(args);
+  auto tpsv_params = blas_benchmark::utils::get_trsv_params(args);
 
   for (auto p : tpsv_params) {
     std::string uplo;
     std::string ts;
     std::string diags;
     index_t n;
-    index_t k;
-    std::tie(uplo, ts, diags, n, k) = p;
-
-    // Repurpose tbmv parameters.
-    if (k != 1) continue;
+    std::tie(uplo, ts, diags, n) = p;
 
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
                          std::string uplo, std::string ts, std::string diags,

--- a/benchmark/rocblas/blas2/tpsv.cpp
+++ b/benchmark/rocblas/blas2/tpsv.cpp
@@ -63,15 +63,13 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   // Compute the number of A non-zero elements.
   const double A_validVal = .5 * n_d * (n_d + 1);
 
-  {
-    double nflops = 2 * A_validVal;
-    state.counters["n_fl_ops"] = nflops;
-  }
+  double nflops_tot = 2 * A_validVal;
+  state.counters["n_fl_ops"] = nflops_tot;
 
   {
     double mem_readA = A_validVal;
-    double mem_readX = xlen;
-    double mem_writeX = xlen;
+    double mem_readX = n_d;
+    double mem_writeX = n_d;
     state.counters["bytes_processed"] =
         (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
   }
@@ -168,6 +166,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas2/tpsv.cpp
+++ b/benchmark/rocblas/blas2/tpsv.cpp
@@ -64,7 +64,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   const double A_validVal = .5 * n_d * (n_d + 1);
 
   {
-    double nflops = 2 * n_d * (n_d + 1) / 2;
+    double nflops = 2 * A_validVal;
     state.counters["n_fl_ops"] = nflops;
   }
 

--- a/benchmark/rocblas/blas2/trmv.cpp
+++ b/benchmark/rocblas/blas2/trmv.cpp
@@ -64,15 +64,13 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   // Compute the number of A non-zero elements.
   const double A_validVal = .5 * n_d * (n_d + 1);
 
-  {
-    double nflops_AtimesX = 2.0 * A_validVal;
-    state.counters["n_fl_ops"] = nflops_AtimesX;
-  }
+  double nflops_tot = 2.0 * A_validVal;
+  state.counters["n_fl_ops"] = nflops_tot;
 
   {
     double mem_readA = A_validVal;
-    double mem_readX = xlen;
-    double mem_writeX = xlen;
+    double mem_readX = n_d;
+    double mem_writeX = n_d;
     state.counters["bytes_processed"] =
         (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
   }
@@ -159,6 +157,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas2/trmv.cpp
+++ b/benchmark/rocblas/blas2/trmv.cpp
@@ -19,110 +19,107 @@
  *
  *  SYCL-BLAS: BLAS implementation using SYCL
  *
- *  @filename symv.cpp
+ *  @filename trmv.cpp
  *
  **************************************************************************/
 
 #include "../utils.hpp"
 
 template <typename scalar_t>
-std::string get_name(std::string uplo, int n) {
+std::string get_name(std::string uplo, std::string t, std::string diag, int n,
+                     int k) {
   std::ostringstream str{};
-  str << "BM_Symv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n;
+  str << "BM_Trmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
   return str.str();
 }
 
 template <typename scalar_t, typename... args_t>
-static inline void rocblas_symv_f(args_t&&... args) {
+static inline void rocblas_trmv_f(args_t&&... args) {
   if constexpr (std::is_same_v<scalar_t, float>) {
-    CHECK_ROCBLAS_STATUS(rocblas_ssymv(std::forward<args_t>(args)...));
+    CHECK_ROCBLAS_STATUS(rocblas_strmv(std::forward<args_t>(args)...));
   } else if constexpr (std::is_same_v<scalar_t, double>) {
-    CHECK_ROCBLAS_STATUS(rocblas_dsymv(std::forward<args_t>(args)...));
+    CHECK_ROCBLAS_STATUS(rocblas_dtrmv(std::forward<args_t>(args)...));
   }
   return;
 }
 
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
-         index_t n, scalar_t alpha, scalar_t beta, bool* success) {
+         std::string t, std::string diag, index_t n, index_t k, bool* success) {
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
+  const char* t_str = t.c_str();
+  const char* diag_str = diag.c_str();
 
   index_t xlen = n;
-  index_t ylen = n;
-
   index_t lda = n;
   index_t incX = 1;
-  index_t incY = 1;
 
-  // The counters are double. We convert m and n to double to avoid
+  // The counters are double. We convert n to double to avoid
   // integer overflows for n_fl_ops and bytes_processed
   double n_d = static_cast<double>(n);
 
   state.counters["n"] = n_d;
 
+  // Compute the number of A non-zero elements.
+  const double A_validVal = .5 * n_d * (n_d + 1);
+
   {
-    double nflops_AtimesX = 2.0 * n_d * n_d;
-    double nflops_timesAlpha = ylen;
-    double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
-    state.counters["n_fl_ops"] =
-        nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
+    double nflops_AtimesX = 2.0 * A_validVal;
+    state.counters["n_fl_ops"] = nflops_AtimesX;
   }
+
   {
-    double mem_readA = n_d * (n_d + 1) / 2;
+    double mem_readA = A_validVal;
     double mem_readX = xlen;
-    double mem_writeY = ylen;
-    double mem_readY = (beta != scalar_t{0}) ? ylen : 0;
+    double mem_writeX = xlen;
     state.counters["bytes_processed"] =
-        (mem_readA + mem_readX + mem_writeY + mem_readY) * sizeof(scalar_t);
+        (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
   }
 
   // Matrix options (rocBLAS)
   const rocblas_fill uplo_rb =
       uplo_str[0] == 'u' ? rocblas_fill_upper : rocblas_fill_lower;
+  const rocblas_diagonal diag_rb =
+      diag_str[0] == 'u' ? rocblas_diagonal_unit : rocblas_diagonal_non_unit;
+  const rocblas_operation trans_rb =
+      t_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
 
   // Data sizes
   const int m_size = lda * n;
-  const int v_x_size = 1 + (xlen - 1) * incX;
-  const int v_y_size = 1 + (ylen - 1) * incY;
+  const int v_size = 1 + (xlen - 1) * incX;
 
   // Input matrix/vector, output vector.
   std::vector<scalar_t> m_a =
       blas_benchmark::utils::random_data<scalar_t>(m_size);
   std::vector<scalar_t> v_x =
-      blas_benchmark::utils::random_data<scalar_t>(v_x_size);
-  std::vector<scalar_t> v_y =
-      blas_benchmark::utils::random_data<scalar_t>(v_y_size);
+      blas_benchmark::utils::random_data<scalar_t>(v_size);
 
   {
     // Device memory allocation & H2D copy
     blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
-    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_x_size, v_x.data());
-    blas_benchmark::utils::HIPVector<scalar_t> v_y_gpu(v_y_size, v_y.data());
-
-    CHECK_ROCBLAS_STATUS(
-        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_size, v_x.data());
 
 #ifdef BLAS_VERIFY_BENCHMARK
-    // Reference symv
-    std::vector<scalar_t> v_y_ref = v_y;
-    reference_blas::symv(uplo_str, n, alpha, m_a.data(), lda, v_x.data(), incX,
-                         beta, v_y_ref.data(), incY);
+    // Reference trmv
+    std::vector<scalar_t> v_x_ref = v_x;
+    reference_blas::trmv(uplo_str, t_str, diag_str, n, m_a.data(), lda,
+                         v_x_ref.data(), incX);
 
-    // Rocblas verification symv
-    std::vector<scalar_t> v_y_temp = v_y;
+    // Rocblas verification trmv
+    std::vector<scalar_t> v_x_temp = v_x;
     {
       // Temp result on device (copied back to Host upon destruction)
-      blas_benchmark::utils::HIPVector<scalar_t, true> v_y_temp_gpu(
-          ylen, v_y_temp.data());
+      blas_benchmark::utils::HIPVector<scalar_t, true> v_x_temp_gpu(
+          xlen, v_x_temp.data());
       // rocBLAS function call
-      rocblas_symv_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, m_a_gpu, lda,
-                               v_x_gpu, incX, &beta, v_y_temp_gpu, incY);
+      rocblas_trmv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n,
+                               m_a_gpu, lda, v_x_temp_gpu, incX);
     }
 
     std::ostringstream err_stream;
-    if (!utils::compare_vectors(v_y_temp, v_y_ref, err_stream, "")) {
+    if (!utils::compare_vectors(v_x_temp, v_x_ref, err_stream, "")) {
       const std::string& err_str = err_stream.str();
       state.SkipWithError(err_str.c_str());
       *success = false;
@@ -130,8 +127,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 #endif
 
     auto blas_warmup = [&]() -> void {
-      rocblas_symv_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, m_a_gpu, lda,
-                               v_x_gpu, incX, &beta, v_y_gpu, incY);
+      rocblas_trmv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n,
+                               m_a_gpu, lda, v_x_gpu, incX);
       return;
     };
 
@@ -141,8 +138,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
     auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
       CHECK_HIP_ERROR(hipEventRecord(start, NULL));
-      rocblas_symv_f<scalar_t>(rb_handle, uplo_rb, n, &alpha, m_a_gpu, lda,
-                               v_x_gpu, incX, &beta, v_y_gpu, incY);
+      rocblas_trmv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n,
+                               m_a_gpu, lda, v_x_gpu, incX);
       CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
       CHECK_HIP_ERROR(hipEventSynchronize(stop));
       return std::vector{start, stop};
@@ -174,22 +171,27 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                         bool* success) {
-  auto symv_params = blas_benchmark::utils::get_symv_params<scalar_t>(args);
+  auto trmv_params = blas_benchmark::utils::get_tbmv_params(args);
 
-  for (auto p : symv_params) {
+  for (auto p : trmv_params) {
     std::string uplos;
+    std::string ts;
+    std::string diags;
     index_t n;
-    scalar_t alpha, beta;
-    std::tie(uplos, n, alpha, beta) = p;
+    index_t k;
+    std::tie(uplos, ts, diags, n, k) = p;
+
+    // Repurpose tbmv parameters.
+    if (k != 1) continue;
 
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
-                         std::string uplos, index_t n, scalar_t alpha,
-                         scalar_t beta, bool* success) {
-      run<scalar_t>(st, rb_handle, uplos, n, alpha, beta, success);
+                         std::string uplos, std::string ts, std::string diags,
+                         index_t n, index_t k, bool* success) {
+      run<scalar_t>(st, rb_handle, uplos, ts, diags, n, k, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplos, n).c_str(),
-                                 BM_lambda, rb_handle, uplos, n, alpha, beta,
-                                 success);
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
+        rb_handle, uplos, ts, diags, n, k, success);
   }
 }
 

--- a/benchmark/rocblas/blas2/trmv.cpp
+++ b/benchmark/rocblas/blas2/trmv.cpp
@@ -26,11 +26,10 @@
 #include "../utils.hpp"
 
 template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n,
-                     int k) {
+std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
   std::ostringstream str{};
   str << "BM_Trmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
+      << uplo << "/" << t << "/" << diag << "/" << n;
   return str.str();
 }
 
@@ -46,7 +45,7 @@ static inline void rocblas_trmv_f(args_t&&... args) {
 
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
-         std::string t, std::string diag, index_t n, index_t k, bool* success) {
+         std::string t, std::string diag, index_t n, bool* success) {
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();
@@ -171,27 +170,23 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                         bool* success) {
-  auto trmv_params = blas_benchmark::utils::get_tbmv_params(args);
+  auto trmv_params = blas_benchmark::utils::get_trsv_params(args);
 
   for (auto p : trmv_params) {
     std::string uplos;
     std::string ts;
     std::string diags;
     index_t n;
-    index_t k;
-    std::tie(uplos, ts, diags, n, k) = p;
-
-    // Repurpose tbmv parameters.
-    if (k != 1) continue;
+    std::tie(uplos, ts, diags, n) = p;
 
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
                          std::string uplos, std::string ts, std::string diags,
-                         index_t n, index_t k, bool* success) {
-      run<scalar_t>(st, rb_handle, uplos, ts, diags, n, k, success);
+                         index_t n, bool* success) {
+      run<scalar_t>(st, rb_handle, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
-        rb_handle, uplos, ts, diags, n, k, success);
+        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda, rb_handle,
+        uplos, ts, diags, n, success);
   }
 }
 

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -164,6 +164,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
     }
 
     blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
   }  // release device memory via utils::DeviceVector destructors
 }
 

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -65,7 +65,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   const double A_validVal = .5 * n_d * (n_d + 1);
 
   {
-    double nflops = n_d * n_d;
+    double nflops = 2.0 * A_validVal;
     state.counters["n_fl_ops"] = nflops;
   }
 

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -1,0 +1,202 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trsv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
+  std::ostringstream str{};
+  str << "BM_Trsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << t << "/" << diag << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_trsv_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_strsv(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dtrsv(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
+         std::string t, std::string diag, index_t n, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+  const char* t_str = t.c_str();
+  const char* diag_str = diag.c_str();
+
+  index_t xlen = n;
+  index_t lda = n;
+  index_t incX = 1;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = .5 * n_d * (n_d + 1);
+
+  {
+    double nflops = n_d * n_d;
+    state.counters["n_fl_ops"] = nflops;
+  }
+
+  {
+    double mem_readA = A_validVal;
+    double mem_readX = A_validVal;
+    double mem_writeX = A_validVal;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_fill uplo_rb =
+      uplo_str[0] == 'u' ? rocblas_fill_upper : rocblas_fill_lower;
+  const rocblas_diagonal diag_rb =
+      diag_str[0] == 'u' ? rocblas_diagonal_unit : rocblas_diagonal_non_unit;
+  const rocblas_operation trans_rb =
+      t_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen * incX);
+
+  // Populate the main diagonal with larger values.
+  for (index_t i = 0; i < n; ++i)
+    for (index_t j = 0; j < n; ++j)
+      m_a[(i * lda) + i] = (i == j) ? blas_benchmark::utils::random_scalar(
+                                          scalar_t{9}, scalar_t{11})
+                                    : blas_benchmark::utils::random_scalar(
+                                          scalar_t{-0.1}, scalar_t{0.1});
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(lda * n, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(xlen * incX, v_x.data());
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference tbmv
+    std::vector<scalar_t> v_x_ref = v_x;
+    reference_blas::trsv(uplo_str, t_str, diag_str, n, m_a.data(), lda,
+                         v_x_ref.data(), incX);
+
+    // Rocblas verification tbmv
+    std::vector<scalar_t> v_x_temp = v_x;
+    {
+      // Temp result on device (copied back to Host upon destruction)
+      blas_benchmark::utils::HIPVector<scalar_t, true> v_x_temp_gpu(
+          xlen * incX, v_x_temp.data());
+      // rocBLAS function call
+      rocblas_trsv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n,
+                               m_a_gpu, lda, v_x_temp_gpu, incX);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(v_x_temp, v_x_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_trsv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n,
+                               m_a_gpu, lda, v_x_gpu, incX);
+      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_trsv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n,
+                               m_a_gpu, lda, v_x_gpu, incX);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+  }  // release device memory via utils::DeviceVector destructors
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto trsv_params = blas_benchmark::utils::get_tbmv_params(args);
+
+  for (auto p : trsv_params) {
+    std::string uplos;
+    std::string ts;
+    std::string diags;
+    index_t n;
+    index_t k;
+    std::tie(uplos, ts, diags, n, k) = p;
+
+    // Repurpose tbmv parameters.
+    if (k != 1) continue;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         std::string uplos, std::string ts, std::string diags,
+                         index_t n, bool* success) {
+      run<scalar_t>(st, rb_handle, uplos, ts, diags, n, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda, rb_handle,
+        uplos, ts, diags, n, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -85,10 +85,14 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   const rocblas_operation trans_rb =
       t_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
 
+  // Data sizes
+  const int m_size = lda * n;
+  const int v_size = 1 + (xlen - 1) * incX;
+
   // Input matrix/vector, output vector.
-  std::vector<scalar_t> m_a(lda * n);
+  std::vector<scalar_t> m_a(m_size);
   std::vector<scalar_t> v_x =
-      blas_benchmark::utils::random_data<scalar_t>(xlen * incX);
+      blas_benchmark::utils::random_data<scalar_t>(v_size);
 
   // Populate the main diagonal with larger values.
   for (index_t i = 0; i < n; ++i)
@@ -100,8 +104,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
   {
     // Device memory allocation & H2D copy
-    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(lda * n, m_a.data());
-    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(xlen * incX, v_x.data());
+    blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(m_size, m_a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> v_x_gpu(v_size, v_x.data());
 
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference tbmv

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -177,18 +177,14 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                         bool* success) {
-  auto trsv_params = blas_benchmark::utils::get_tbmv_params(args);
+  auto trsv_params = blas_benchmark::utils::get_trsv_params(args);
 
   for (auto p : trsv_params) {
     std::string uplos;
     std::string ts;
     std::string diags;
     index_t n;
-    index_t k;
-    std::tie(uplos, ts, diags, n, k) = p;
-
-    // Repurpose tbmv parameters.
-    if (k != 1) continue;
+    std::tie(uplos, ts, diags, n) = p;
 
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
                          std::string uplos, std::string ts, std::string diags,

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -95,7 +95,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   // Populate the main diagonal with larger values.
   for (index_t i = 0; i < n; ++i)
     for (index_t j = 0; j < n; ++j)
-      m_a[(i * lda) + i] = (i == j) ? blas_benchmark::utils::random_scalar(
+      m_a[(i * lda) + j] = (i == j) ? blas_benchmark::utils::random_scalar(
                                           scalar_t{9}, scalar_t{11})
                                     : blas_benchmark::utils::random_scalar(
                                           scalar_t{-0.1}, scalar_t{0.1});

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -71,8 +71,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
   {
     double mem_readA = A_validVal;
-    double mem_readX = A_validVal;
-    double mem_writeX = A_validVal;
+    double mem_readX = xlen;
+    double mem_writeX = xlen;
     state.counters["bytes_processed"] =
         (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
   }

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -135,7 +135,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
     auto blas_warmup = [&]() -> void {
       rocblas_trsv_f<scalar_t>(rb_handle, uplo_rb, trans_rb, diag_rb, n,
                                m_a_gpu, lda, v_x_gpu, incX);
-      CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
       return;
     };
 
@@ -154,6 +153,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
 
     // Warmup
     blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);
 

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -64,15 +64,13 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
   // Compute the number of A non-zero elements.
   const double A_validVal = .5 * n_d * (n_d + 1);
 
-  {
-    double nflops = 2.0 * A_validVal;
-    state.counters["n_fl_ops"] = nflops;
-  }
+  double nflops_tot = 2.0 * A_validVal;
+  state.counters["n_fl_ops"] = nflops_tot;
 
   {
     double mem_readA = A_validVal;
-    double mem_readX = xlen;
-    double mem_writeX = xlen;
+    double mem_readX = n_d;
+    double mem_writeX = n_d;
     state.counters["bytes_processed"] =
         (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
   }
@@ -166,6 +164,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/utils.hpp
+++ b/benchmark/rocblas/utils.hpp
@@ -26,7 +26,6 @@
 #ifndef ROCBLAS_UTILS_HPP
 #define ROCBLAS_UTILS_HPP
 
-#include "sycl_blas.h"
 #include <common/common_utils.hpp>
 
 #include <hip/hip_runtime.h>

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -587,7 +587,7 @@ static inline std::vector<symv_param_t<scalar_t>> get_symv_params(Args& args) {
     std::vector<symv_param_t<scalar_t>> symv_default;
     constexpr index_t dmin = 64, dmax = 1024;
     scalar_t alpha = 1;
-    scalar_t beta = 0;
+    scalar_t beta = 1;
     for (std::string uplo : {"u", "l"}) {
       for (index_t n = dmin; n <= dmax; n *= 2) {
         symv_default.push_back(std::make_tuple(uplo, n, alpha, beta));

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -53,6 +53,9 @@ using sbmv_param_t =
     std::tuple<std::string, index_t, index_t, scalar_t, scalar_t>;
 
 template <typename scalar_t>
+using symv_param_t = std::tuple<std::string, index_t, scalar_t, scalar_t>;
+
+template <typename scalar_t>
 using spr_param_t = std::tuple<std::string, index_t, scalar_t, index_t>;
 
 using tbmv_param_t =
@@ -556,6 +559,43 @@ static inline std::vector<sbmv_param_t<scalar_t>> get_sbmv_params(Args& args) {
                                    str_to_int<index_t>(v[2]),
                                    str_to_scalar<scalar_t>(v[3]),
                                    str_to_scalar<scalar_t>(v[4]));
+          } catch (...) {
+            throw std::runtime_error("invalid parameter");
+          }
+        });
+  }
+}
+
+/**
+ * @fn get_symv_params
+ * @brief Returns a vector containing the symv benchmark parameters, either
+ * read from a file according to the command-line args, or the default ones.
+ */
+template <typename scalar_t>
+static inline std::vector<symv_param_t<scalar_t>> get_symv_params(Args& args) {
+  if (args.csv_param.empty()) {
+    warning_no_csv();
+    std::vector<symv_param_t<scalar_t>> symv_default;
+    constexpr index_t dmin = 64, dmax = 1024;
+    scalar_t alpha = 1;
+    scalar_t beta = 0;
+    for (std::string uplo : {"u", "l"}) {
+      for (index_t n = dmin; n <= dmax; n *= 2) {
+        symv_default.push_back(std::make_tuple(uplo, n, alpha, beta));
+      }
+    }
+    return symv_default;
+  } else {
+    return parse_csv_file<symv_param_t<scalar_t>>(
+        args.csv_param, [&](std::vector<std::string>& v) {
+          if (v.size() != 4) {
+            throw std::runtime_error(
+                "invalid number of parameters (4 expected)");
+          }
+          try {
+            return std::make_tuple(v[0].c_str(), str_to_int<index_t>(v[1]),
+                                   str_to_scalar<scalar_t>(v[2]),
+                                   str_to_scalar<scalar_t>(v[3]));
           } catch (...) {
             throw std::runtime_error("invalid parameter");
           }

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -56,6 +56,9 @@ template <typename scalar_t>
 using symv_param_t = std::tuple<std::string, index_t, scalar_t, scalar_t>;
 
 template <typename scalar_t>
+using syr_param_t = std::tuple<std::string, index_t, scalar_t>;
+
+template <typename scalar_t>
 using spr_param_t = std::tuple<std::string, index_t, scalar_t, index_t>;
 
 using tbmv_param_t =
@@ -596,6 +599,42 @@ static inline std::vector<symv_param_t<scalar_t>> get_symv_params(Args& args) {
             return std::make_tuple(v[0].c_str(), str_to_int<index_t>(v[1]),
                                    str_to_scalar<scalar_t>(v[2]),
                                    str_to_scalar<scalar_t>(v[3]));
+          } catch (...) {
+            throw std::runtime_error("invalid parameter");
+          }
+        });
+  }
+}
+
+/**
+ * @fn get_syr_params
+ * @brief Returns a vector containing the syr & syr2 benchmark parameters,
+ * either read from a file according to the command-line args, or the default
+ * ones.
+ */
+template <typename scalar_t>
+static inline std::vector<syr_param_t<scalar_t>> get_syr_params(Args& args) {
+  if (args.csv_param.empty()) {
+    warning_no_csv();
+    std::vector<syr_param_t<scalar_t>> syr_default;
+    constexpr index_t dmin = 64, dmax = 1024;
+    scalar_t alpha = 1;
+    for (std::string uplo : {"u", "l"}) {
+      for (index_t n = dmin; n <= dmax; n *= 2) {
+        syr_default.push_back(std::make_tuple(uplo, n, alpha));
+      }
+    }
+    return syr_default;
+  } else {
+    return parse_csv_file<syr_param_t<scalar_t>>(
+        args.csv_param, [&](std::vector<std::string>& v) {
+          if (v.size() != 3) {
+            throw std::runtime_error(
+                "invalid number of parameters (3 expected)");
+          }
+          try {
+            return std::make_tuple(v[0].c_str(), str_to_int<index_t>(v[1]),
+                                   str_to_scalar<scalar_t>(v[2]));
           } catch (...) {
             throw std::runtime_error("invalid parameter");
           }

--- a/common/include/common/system_reference_blas.hpp
+++ b/common/include/common/system_reference_blas.hpp
@@ -274,6 +274,14 @@ void trmv(const char *uplo, const char *trans, const char *diag, const int n,
 }
 
 template <typename scalar_t>
+void trsv(const char *uplo, const char *trans, const char *diag, const int n,
+          const scalar_t *a, const int lda, scalar_t *x, const int incX) {
+  auto func = blas_system_function<scalar_t>(&cblas_strsv, &cblas_dtrsv);
+  func(CblasColMajor, c_uplo(*uplo), c_trans(*trans), c_diag(*diag), n, a, lda,
+       x, incX);
+}
+
+template <typename scalar_t>
 void sbmv(const char *uplo, int n, int k, scalar_t alpha, const scalar_t a[],
           int lda, const scalar_t x[], int incX, scalar_t beta, scalar_t y[],
           int incY) {

--- a/common/include/common/system_reference_blas.hpp
+++ b/common/include/common/system_reference_blas.hpp
@@ -251,10 +251,10 @@ void gemv(const char *trans, int m, int n, scalar_t alpha, const scalar_t a[],
 }
 
 template <typename scalar_t>
-void ger(int m, int n, scalar_t alpha, const scalar_t a[], int incX,
-         const scalar_t x[], int incY, scalar_t y[], int lda) {
+void ger(int m, int n, scalar_t alpha, const scalar_t x[], int incX,
+         const scalar_t y[], int incY, scalar_t a[], int lda) {
   auto func = blas_system_function<scalar_t>(&cblas_sger, &cblas_dger);
-  func(CblasColMajor, m, n, alpha, a, incX, x, incY, y, lda);
+  func(CblasColMajor, m, n, alpha, x, incX, y, incY, a, lda);
 }
 
 template <typename scalar_t>

--- a/common/include/common/system_reference_blas.hpp
+++ b/common/include/common/system_reference_blas.hpp
@@ -266,6 +266,14 @@ void tbmv(const char *uplo, const char *trans, const char *diag, int n, int k,
 }
 
 template <typename scalar_t>
+void tbsv(const char *uplo, const char *trans, const char *diag, int n, int k,
+          const scalar_t *a, int lda, scalar_t *x, int incX) {
+  auto func = blas_system_function<scalar_t>(&cblas_stbsv, &cblas_dtbsv);
+  func(CblasColMajor, c_uplo(*uplo), c_trans(*trans), c_diag(*diag), n, k, a,
+       lda, x, incX);
+}
+
+template <typename scalar_t>
 void trmv(const char *uplo, const char *trans, const char *diag, const int n,
           const scalar_t *a, const int lda, scalar_t *x, const int incX) {
   auto func = blas_system_function<scalar_t>(&cblas_strmv, &cblas_dtrmv);
@@ -310,6 +318,14 @@ void syr2(const char *uplo, const int n, const scalar_t alpha,
           scalar_t *a, const int lda) {
   auto func = blas_system_function<scalar_t>(&cblas_ssyr2, &cblas_dsyr2);
   func(CblasColMajor, c_uplo(*uplo), n, alpha, x, incX, y, incY, a, lda);
+}
+
+template <typename scalar_t>
+void spr2(const char *uplo, const int n, const scalar_t alpha,
+          const scalar_t *x, const int incX, const scalar_t *y, const int incY,
+          scalar_t *a) {
+  auto func = blas_system_function<scalar_t>(&cblas_sspr2, &cblas_dspr2);
+  func(CblasColMajor, c_uplo(*uplo), n, alpha, x, incX, y, incY, a);
 }
 
 template <typename scalar_t>

--- a/common/include/common/system_reference_blas.hpp
+++ b/common/include/common/system_reference_blas.hpp
@@ -307,11 +307,25 @@ void sbmv(const char *uplo, int n, int k, scalar_t alpha, const scalar_t a[],
 }
 
 template <typename scalar_t>
+void spmv(const char *uplo, int n, scalar_t alpha, const scalar_t a[],
+          const scalar_t x[], int incX, scalar_t beta, scalar_t y[], int incY) {
+  auto func = blas_system_function<scalar_t>(&cblas_sspmv, &cblas_dspmv);
+  func(CblasColMajor, c_uplo(*uplo), n, alpha, a, x, incX, beta, y, incY);
+}
+
+template <typename scalar_t>
 void tpmv(const char *uplo, const char *trans, const char *diag, const int n,
           const scalar_t *a, scalar_t *x, const int incX) {
   auto func = blas_system_function<scalar_t>(&cblas_stpmv, &cblas_dtpmv);
   func(CblasColMajor, c_uplo(*uplo), c_trans(*trans), c_diag(*diag), n, a, x,
        incX);
+}
+
+template <typename scalar_t>
+void trmv(const char *uplo, int n, scalar_t alpha, const scalar_t a[], int lda,
+          const scalar_t x[], int incX, scalar_t beta, scalar_t y[], int incY) {
+  auto func = blas_system_function<scalar_t>(&cblas_strmv, &cblas_dtrmv);
+  func(CblasColMajor, c_uplo(*uplo), n, alpha, a, lda, x, incX, beta, y, incY);
 }
 
 template <typename scalar_t>

--- a/common/include/common/system_reference_blas.hpp
+++ b/common/include/common/system_reference_blas.hpp
@@ -290,12 +290,28 @@ void trsv(const char *uplo, const char *trans, const char *diag, const int n,
 }
 
 template <typename scalar_t>
+void tpsv(const char *uplo, const char *trans, const char *diag, const int n,
+          const scalar_t *a, scalar_t *x, const int incX) {
+  auto func = blas_system_function<scalar_t>(&cblas_stpsv, &cblas_dtpsv);
+  func(CblasColMajor, c_uplo(*uplo), c_trans(*trans), c_diag(*diag), n, a, x,
+       incX);
+}
+
+template <typename scalar_t>
 void sbmv(const char *uplo, int n, int k, scalar_t alpha, const scalar_t a[],
           int lda, const scalar_t x[], int incX, scalar_t beta, scalar_t y[],
           int incY) {
   auto func = blas_system_function<scalar_t>(&cblas_ssbmv, &cblas_dsbmv);
   func(CblasColMajor, c_uplo(*uplo), n, k, alpha, a, lda, x, incX, beta, y,
        incY);
+}
+
+template <typename scalar_t>
+void tpmv(const char *uplo, const char *trans, const char *diag, const int n,
+          const scalar_t *a, scalar_t *x, const int incX) {
+  auto func = blas_system_function<scalar_t>(&cblas_stpmv, &cblas_dtpmv);
+  func(CblasColMajor, c_uplo(*uplo), c_trans(*trans), c_diag(*diag), n, a, x,
+       incX);
 }
 
 template <typename scalar_t>


### PR DESCRIPTION
This PR adds BLAS level 2 operators benchmarks targetting AMD GPUs through rocBLAS routines.

- gemv
- gbmv
- sbmv
- tbmv
- tbsv
- trsv
- spr
- spr2
- symv
- ger
- syr
- syr2
- tpmv
- tpsv
- trmv
- spmv