### PR TITLE
Add cuBLAS benchmarks for level3 operators and relative extensions

### DIFF
--- a/benchmark/cublas/CMakeLists.txt
+++ b/benchmark/cublas/CMakeLists.txt
@@ -59,6 +59,9 @@ set(sources
   blas2/tpsv.cpp
   blas2/trmv.cpp
   blas2/trsv.cpp
+  # Level 3 blas
+  blas3/gemm.cpp
+  blas3/trsm.cpp
 ) 
 
 #if(${BLAS_ENABLE_EXTENSIONS})

--- a/benchmark/cublas/CMakeLists.txt
+++ b/benchmark/cublas/CMakeLists.txt
@@ -62,6 +62,7 @@ set(sources
   # Level 3 blas
   blas3/gemm.cpp
   blas3/trsm.cpp
+  blas3/trmm.cpp
 ) 
 
 #if(${BLAS_ENABLE_EXTENSIONS})

--- a/benchmark/cublas/CMakeLists.txt
+++ b/benchmark/cublas/CMakeLists.txt
@@ -61,10 +61,13 @@ set(sources
   blas2/trsv.cpp
   # Level 3 blas
   blas3/gemm.cpp
+  blas3/gemm_batched.cpp
+  blas3/gemm_batched_strided.cpp
   blas3/symm.cpp
   blas3/syrk.cpp
   blas3/syr2k.cpp
   blas3/trsm.cpp
+  blas3/trsm_batched.cpp
   blas3/trmm.cpp
 ) 
 

--- a/benchmark/cublas/CMakeLists.txt
+++ b/benchmark/cublas/CMakeLists.txt
@@ -61,6 +61,9 @@ set(sources
   blas2/trsv.cpp
   # Level 3 blas
   blas3/gemm.cpp
+  blas3/symm.cpp
+  blas3/syrk.cpp
+  blas3/syr2k.cpp
   blas3/trsm.cpp
   blas3/trmm.cpp
 ) 

--- a/benchmark/cublas/blas3/gemm.cpp
+++ b/benchmark/cublas/blas3/gemm.cpp
@@ -1,0 +1,196 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename gemm.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string t1, std::string t2, int m, int k, int n) {
+  std::ostringstream str{};
+  str << "BM_Gemm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void cublas_routine(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CUBLAS_CHECK(cublasSgemm(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CUBLAS_CHECK(cublasDgemm(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int t1,
+         int t2, index_t m, index_t k, index_t n, scalar_t alpha, scalar_t beta,
+         bool* success) {
+  // Standard test setup.
+  std::string t1s = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(t1));
+  std::string t2s = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(t2));
+  const char* t_a = t1s.c_str();
+  const char* t_b = t2s.c_str();
+
+  index_t lda = t_a[0] == 'n' ? m : k;
+  index_t ldb = t_b[0] == 'n' ? k : n;
+  index_t ldc = m;
+
+  cublasHandle_t& cuda_handle = *cuda_handle_ptr;
+
+  // Matrices
+  std::vector<scalar_t> a = blas_benchmark::utils::random_data<scalar_t>(m * k);
+  std::vector<scalar_t> b = blas_benchmark::utils::random_data<scalar_t>(k * n);
+  std::vector<scalar_t> c =
+      blas_benchmark::utils::const_data<scalar_t>(m * n, 0);
+
+  blas_benchmark::utils::CUDAVector<scalar_t> a_gpu(m * k, a.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> b_gpu(k * n, b.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> c_gpu(n * m, c.data());
+
+  cublasOperation_t c_t_a = (*t_a == 'n') ? CUBLAS_OP_N : CUBLAS_OP_T;
+  cublasOperation_t c_t_b = (*t_b == 'n') ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> c_ref = c;
+  reference_blas::gemm(t_a, t_b, m, n, k, alpha, a.data(), lda, b.data(), ldb,
+                       beta, c_ref.data(), ldc);
+  std::vector<scalar_t> c_temp = c;
+  {
+    blas_benchmark::utils::CUDAVector<scalar_t, true> c_temp_gpu(m * n,
+                                                                 c_temp.data());
+    cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, k, &alpha, a_gpu,
+                             lda, b_gpu, ldb, &beta, c_temp_gpu, ldc);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+  auto blas_warmup = [&]() -> void {
+    cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, k, &alpha, a_gpu,
+                             lda, b_gpu, ldb, &beta, c_gpu, ldc);
+    return;
+  };
+
+  cudaEvent_t start;
+  cudaEvent_t stop;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
+
+  auto blas_method_def = [&]() -> std::vector<cudaEvent_t> {
+    CUDA_CHECK(cudaEventRecord(start));
+    cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, k, &alpha, a_gpu,
+                             lda, b_gpu, ldb, &beta, c_gpu, ldc);
+    CUDA_CHECK(cudaEventRecord(stop));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    return std::vector{start, stop};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_warmup);
+  CUDA_CHECK(cudaStreamSynchronize(NULL));
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef_cuda(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  {
+    // The counters are double. We convert m, n and k to double to avoid
+    // integer overflows for n_fl_ops and bytes_processed
+    double m_d = static_cast<double>(m);
+    double n_d = static_cast<double>(n);
+    double k_d = static_cast<double>(k);
+
+    state.counters["m"] = m_d;
+    state.counters["k"] = k_d;
+    state.counters["n"] = n_d;
+
+    double mem_readA = m_d * k_d;
+    double mem_readB = k_d * n_d;
+    double mem_writeC = m_d * n_d;
+    double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
+    double total_mem =
+        (mem_readA + mem_readB + mem_readC + mem_writeC) * sizeof(scalar_t);
+    state.counters["bytes_processed"] = total_mem;
+    state.SetBytesProcessed(state.iterations() * total_mem);
+
+    double nflops_AtimesB = (2 * k_d - 1) * m_d * n_d;
+    double nflops_timesAlpha = m_d * n_d;
+    double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
+    double nflops = nflops_AtimesB + nflops_timesAlpha + nflops_addBetaC;
+    state.counters["n_fl_ops"] = nflops;
+    state.SetItemsProcessed(state.iterations() * nflops);
+  }
+  blas_benchmark::utils::calc_avg_counters(state);
+
+  CUDA_CHECK(cudaEventDestroy(start));
+  CUDA_CHECK(cudaEventDestroy(stop));
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        cublasHandle_t* cuda_handle_ptr, bool* success) {
+  auto gemm_params = blas_benchmark::utils::get_blas3_params<scalar_t>(args);
+
+  for (auto p : gemm_params) {
+    std::string t1s, t2s;
+    index_t m, n, k;
+    scalar_t alpha, beta;
+    std::tie(t1s, t2s, m, k, n, alpha, beta) = p;
+    int t1 = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t1s));
+    int t2 = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t2s));
+
+    auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
+                         int t1, int t2, index_t m, index_t k, index_t n,
+                         scalar_t alpha, scalar_t beta, bool* success) {
+      run<scalar_t>(st, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(t1s, t2s, m, k, n).c_str(),
+                                 BM_lambda, cuda_handle_ptr, t1, t2, m, k, n,
+                                 alpha, beta, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      cublasHandle_t* cuda_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, cuda_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/cublas/blas3/gemm.cpp
+++ b/benchmark/cublas/blas3/gemm.cpp
@@ -150,10 +150,9 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int t1,
     state.counters["bytes_processed"] = total_mem;
     state.SetBytesProcessed(state.iterations() * total_mem);
 
-    double nflops_AtimesB = (2 * k_d - 1) * m_d * n_d;
-    double nflops_timesAlpha = m_d * n_d;
+    double nflops_AtimesB = (2 * k_d) * m_d * n_d;
     double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
-    double nflops = nflops_AtimesB + nflops_timesAlpha + nflops_addBetaC;
+    double nflops = nflops_AtimesB + nflops_addBetaC;
     state.counters["n_fl_ops"] = nflops;
     state.SetItemsProcessed(state.iterations() * nflops);
   }

--- a/benchmark/cublas/blas3/gemm_batched.cpp
+++ b/benchmark/cublas/blas3/gemm_batched.cpp
@@ -1,0 +1,227 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename gemm_batched.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string t1, std::string t2, int m, int k, int n,
+                     int batch_count, int batch_type) {
+  std::ostringstream str{};
+  str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
+      << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
+      << batch_count << "/"
+      << blas_benchmark::utils::batch_type_to_str(batch_type);
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void cublas_routine(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CUBLAS_CHECK(cublasSgemmBatched(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CUBLAS_CHECK(cublasDgemmBatched(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
+         const char* t_a, const char* t_b, index_t m, index_t k, index_t n,
+         scalar_t alpha, scalar_t beta, index_t batch_count, int batch_type_i,
+         bool* success) {
+  auto batch_type = static_cast<blas::gemm_batch_type_t>(batch_type_i);
+
+  index_t lda = t_a[0] == 'n' ? m : k;
+  index_t ldb = t_b[0] == 'n' ? k : n;
+  index_t ldc = m;
+
+  // The counters are double. We convert m, n, k and batch_count to double to
+  // avoid integer overflows for n_fl_ops and bytes_processed
+  double m_d = static_cast<double>(m);
+  double n_d = static_cast<double>(n);
+  double k_d = static_cast<double>(k);
+  double batch_count_d = static_cast<double>(batch_count);
+
+  state.counters["m"] = m_d;
+  state.counters["k"] = k_d;
+  state.counters["n"] = n_d;
+  state.counters["batch_count"] = batch_count_d;
+
+  const double nflops_AtimesB = (2 * k_d) * m_d * n_d;
+  const double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
+  const double nflops_tot = (nflops_AtimesB + nflops_addBetaC) * batch_count_d;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  {
+    double mem_readA = m_d * k_d;
+    double mem_readB = k_d * n_d;
+    double mem_writeC = m_d * n_d;
+    double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readB + mem_readC + mem_writeC) * batch_count_d *
+        sizeof(scalar_t);
+  }
+
+  cublasHandle_t& cuda_handle = *cuda_handle_ptr;
+
+  // Matrices
+  std::vector<scalar_t> a =
+      blas_benchmark::utils::random_data<scalar_t>(m * k * batch_count);
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(k * n * batch_count);
+  std::vector<scalar_t> c =
+      blas_benchmark::utils::const_data<scalar_t>(m * n * batch_count, 0);
+
+  blas_benchmark::utils::CUDAVectorBatched<scalar_t> d_A_array(m * k,
+                                                               batch_count, a);
+  blas_benchmark::utils::CUDAVectorBatched<scalar_t> d_B_array(k * n,
+                                                               batch_count, b);
+  blas_benchmark::utils::CUDAVectorBatched<scalar_t> d_C_array(m * n,
+                                                               batch_count);
+
+  cublasOperation_t c_t_a = (*t_a == 'n') ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+  cublasOperation_t c_t_b = (*t_b == 'n') ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  {
+    std::vector<scalar_t> c_ref = c;
+    auto _base = [=](index_t dim0, index_t dim1, index_t idx) {
+      return dim0 * dim1 * idx;
+    };
+    for (int batch_idx = 0; batch_idx < batch_count; batch_idx++) {
+      reference_blas::gemm(t_a, t_b, m, n, k, alpha,
+                           a.data() + _base(m, k, batch_idx), lda,
+                           b.data() + _base(k, n, batch_idx), ldb, beta,
+                           c_ref.data() + _base(m, n, batch_idx), ldc);
+    }
+
+    std::vector<scalar_t> c_temp(m * n * batch_count);
+
+    {
+      blas_benchmark::utils::CUDAVectorBatched<scalar_t, true> c_temp_gpu(
+          n * m, batch_count, c_temp);
+      cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, k, &alpha,
+                               d_A_array.get_batch_array(), lda,
+                               d_B_array.get_batch_array(), ldb, &beta,
+                               c_temp_gpu.get_batch_array(), ldc, batch_count);
+    }
+
+    std::ostringstream err_stream;
+    for (int i = 0; i < batch_count; ++i) {
+      if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+        const std::string& err_str = err_stream.str();
+        state.SkipWithError(err_str.c_str());
+        *success = false;
+      };
+    }
+
+  }  // close scope for verify benchmark
+#endif
+
+  auto blas_warmup = [&]() -> void {
+    cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, k, &alpha,
+                             d_A_array.get_batch_array(), lda,
+                             d_B_array.get_batch_array(), ldb, &beta,
+                             d_C_array.get_batch_array(), ldc, batch_count);
+    return;
+  };
+
+  cudaEvent_t start, stop;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
+
+  auto blas_method_def = [&]() -> std::vector<cudaEvent_t> {
+    CUDA_CHECK(cudaEventRecord(start));
+    cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, k, &alpha,
+                             d_A_array.get_batch_array(), lda,
+                             d_B_array.get_batch_array(), ldb, &beta,
+                             d_C_array.get_batch_array(), ldc, batch_count);
+    CUDA_CHECK(cudaEventRecord(stop));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    return std::vector{start, stop};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+  CUDA_CHECK(cudaStreamSynchronize(NULL));
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef_cuda(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        cublasHandle_t* cuda_handle_ptr, bool* success) {
+  auto gemm_params =
+      blas_benchmark::utils::get_gemm_batched_params<scalar_t>(args);
+
+  for (auto p : gemm_params) {
+    std::string t1s, t2s;
+    index_t m, n, k, batch_count;
+    scalar_t alpha, beta;
+    int batch_type;
+    std::tie(t1s, t2s, m, k, n, alpha, beta, batch_count, batch_type) = p;
+
+    if (batch_type == 1) {
+      std::cerr << "interleaved memory for gemm_batched operator is not "
+                   "supported by cuBLAS\n";
+      continue;
+    }
+
+    auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
+                         std::string t1, std::string t2, index_t m, index_t k,
+                         index_t n, scalar_t alpha, scalar_t beta,
+                         index_t batch_count, int batch_type, bool* success) {
+      run<scalar_t>(st, cuda_handle_ptr, t1.c_str(), t2.c_str(), m, k, n, alpha,
+                    beta, batch_count, batch_type, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(t1s, t2s, m, k, n, batch_count, batch_type).c_str(),
+        BM_lambda, cuda_handle_ptr, t1s.c_str(), t2s.c_str(), m, k, n, alpha,
+        beta, batch_count, batch_type, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      cublasHandle_t* cuda_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, cuda_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/cublas/blas3/gemm_batched.cpp
+++ b/benchmark/cublas/blas3/gemm_batched.cpp
@@ -189,10 +189,10 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         cublasHandle_t* cuda_handle_ptr, bool* success) {
-  auto gemm_params =
+  auto gemm_batched_params =
       blas_benchmark::utils::get_gemm_batched_params<scalar_t>(args);
 
-  for (auto p : gemm_params) {
+  for (auto p : gemm_batched_params) {
     std::string t1s, t2s;
     index_t m, n, k, batch_count;
     scalar_t alpha, beta;

--- a/benchmark/cublas/blas3/gemm_batched.cpp
+++ b/benchmark/cublas/blas3/gemm_batched.cpp
@@ -214,7 +214,8 @@ void register_benchmark(blas_benchmark::Args& args,
     benchmark::RegisterBenchmark(
         get_name<scalar_t>(t1s, t2s, m, k, n, batch_count, batch_type).c_str(),
         BM_lambda, cuda_handle_ptr, t1s.c_str(), t2s.c_str(), m, k, n, alpha,
-        beta, batch_count, batch_type, success);
+        beta, batch_count, batch_type, success)
+        ->UseRealTime();
   }
 }
 

--- a/benchmark/cublas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/cublas/blas3/gemm_batched_strided.cpp
@@ -89,15 +89,13 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int t1,
   const double nflops_tot = (nflops_AtimesB + nflops_addBetaC) * batch_size_d;
   state.counters["n_fl_ops"] = nflops_tot;
 
-  {
-    double mem_readA = m_d * k_d;
-    double mem_readB = k_d * n_d;
-    double mem_writeC = m_d * n_d;
-    double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
-    state.counters["bytes_processed"] =
-        (mem_readA + mem_readB + mem_readC + mem_writeC) * batch_size_d *
-        sizeof(scalar_t);
-  }
+  const double mem_readA = m_d * k_d;
+  const double mem_readB = k_d * n_d;
+  const double mem_writeC = m_d * n_d;
+  const double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
+  const double total_mem = (mem_readA + mem_readB + mem_readC + mem_writeC) *
+                           batch_size_d * sizeof(scalar_t);
+  state.counters["bytes_processed"] = total_mem;
 
   cublasHandle_t& cuda_handle = *cuda_handle_ptr;
 
@@ -193,6 +191,7 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int t1,
     blas_benchmark::utils::update_counters(state, times);
   }
 
+  state.SetBytesProcessed(state.iterations() * total_mem);
   state.SetItemsProcessed(state.iterations() * nflops_tot);
 
   blas_benchmark::utils::calc_avg_counters(state);

--- a/benchmark/cublas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/cublas/blas3/gemm_batched_strided.cpp
@@ -1,0 +1,240 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename gemm_batched_strided.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string t1, std::string t2, int m, int k, int n,
+                     int batch_size) {
+  std::ostringstream str{};
+  str << "BM_GemmBatchedStrided<"
+      << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
+      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/";
+
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void cublas_routine(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CUBLAS_CHECK(cublasSgemmStridedBatched(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CUBLAS_CHECK(cublasDgemmStridedBatched(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int t1,
+         int t2, index_t m, index_t k, index_t n, scalar_t alpha, scalar_t beta,
+         index_t batch_size, bool* success) {
+  // Standard test setup.
+  std::string t1s = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(t1));
+  std::string t2s = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(t2));
+  const char* t_a = t1s.c_str();
+  const char* t_b = t2s.c_str();
+
+  const bool trA = t_a[0] == 'n';
+  const bool trB = t_b[0] == 'n';
+
+  index_t lda = trA ? m : k;
+  index_t ldb = trB ? k : n;
+  index_t ldc = m;
+
+  // Stride parameters are computed automatically inside the run function
+  // instead of passing them as function argument. It makes more readable and do
+  // not affect perfomance measurment.
+  const long long int stride_a = trA ? (lda * k) : (lda * m);
+  const long long int stride_b = trB ? (ldb * n) : (ldb * k);
+  const long long int stride_c = m * n;
+
+  // The counters are double. We convert m, n, k and batch_size to double to
+  // avoid integer overflows for n_fl_ops and bytes_processed
+  double m_d = static_cast<double>(m);
+  double n_d = static_cast<double>(n);
+  double k_d = static_cast<double>(k);
+  double batch_size_d = static_cast<double>(batch_size);
+
+  state.counters["m"] = m_d;
+  state.counters["k"] = k_d;
+  state.counters["n"] = n_d;
+  state.counters["batch_size"] = batch_size_d;
+
+  const double nflops_AtimesB = (2 * k_d) * m_d * n_d;
+  const double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
+  const double nflops_tot = (nflops_AtimesB + nflops_addBetaC) * batch_size_d;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  {
+    double mem_readA = m_d * k_d;
+    double mem_readB = k_d * n_d;
+    double mem_writeC = m_d * n_d;
+    double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
+    state.counters["bytes_processed"] =
+        (mem_readA + mem_readB + mem_readC + mem_writeC) * batch_size_d *
+        sizeof(scalar_t);
+  }
+
+  cublasHandle_t& cuda_handle = *cuda_handle_ptr;
+
+  // Matrices sizes
+  const index_t a_size = m * k;
+  const index_t b_size = k * n;
+  const index_t c_size = m * n;
+
+  // Matrices (Total size is equal to matrix size x batch_size since we're using
+  // default striding values)
+  std::vector<scalar_t> a =
+      blas_benchmark::utils::random_data<scalar_t>(a_size * batch_size);
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(b_size * batch_size);
+  std::vector<scalar_t> c =
+      blas_benchmark::utils::const_data<scalar_t>(c_size * batch_size, 0);
+
+  blas_benchmark::utils::CUDAVector<scalar_t> a_gpu(a_size * batch_size,
+                                                    a.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> b_gpu(b_size * batch_size,
+                                                    b.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> c_gpu(c_size * batch_size,
+                                                    c.data());
+
+  cublasOperation_t c_t_a = trA ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+  cublasOperation_t c_t_b = trB ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> c_ref = c;
+  auto _base = [=](index_t dim0, index_t dim1, index_t idx) {
+    return dim0 * dim1 * idx;
+  };
+  for (int batch_idx = 0; batch_idx < batch_size; batch_idx++) {
+    reference_blas::gemm(t_a, t_b, m, n, k, alpha,
+                         a.data() + _base(m, k, batch_idx), lda,
+                         b.data() + _base(k, n, batch_idx), ldb, beta,
+                         c_ref.data() + _base(m, n, batch_idx), ldc);
+  }
+
+  std::vector<scalar_t> c_temp = c;
+  {
+    blas_benchmark::utils::CUDAVector<scalar_t, true> c_temp_gpu(
+        c_size * batch_size, c_temp.data());
+    cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, k, &alpha, a_gpu,
+                             lda, stride_a, b_gpu, ldb, stride_b, &beta,
+                             c_temp_gpu, ldc, stride_c, batch_size);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+
+  auto blas_warmup = [&]() -> void {
+    cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, k, &alpha, a_gpu,
+                             lda, stride_a, b_gpu, ldb, stride_b, &beta, c_gpu,
+                             ldc, stride_c, batch_size);
+    return;
+  };
+
+  cudaEvent_t start, stop;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
+
+  auto blas_method_def = [&]() -> std::vector<cudaEvent_t> {
+    CUDA_CHECK(cudaEventRecord(start));
+    cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, k, &alpha, a_gpu,
+                             lda, stride_a, b_gpu, ldb, stride_b, &beta, c_gpu,
+                             ldc, stride_c, batch_size);
+    CUDA_CHECK(cudaEventRecord(stop));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    return std::vector{start, stop};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_warmup);
+  CUDA_CHECK(cudaStreamSynchronize(NULL));
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef_cuda(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        cublasHandle_t* cuda_handle_ptr, bool* success) {
+  auto gemm_params =
+      blas_benchmark::utils::get_gemm_batched_params<scalar_t>(args);
+
+  for (auto p : gemm_params) {
+    std::string t1s, t2s;
+    index_t m, n, k, batch_size;
+    scalar_t alpha, beta;
+    int batch_type;
+    std::tie(t1s, t2s, m, k, n, alpha, beta, batch_size, batch_type) = p;
+    int t1 = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t1s));
+    int t2 = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t2s));
+
+    if (batch_type == 1) {
+      std::cerr << "computing gemm_strided_batched batch type interleaved "
+                   "cannot be used in cuBLAS\n";
+      continue;
+    }
+
+    auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
+                         int t1, int t2, index_t m, index_t k, index_t n,
+                         scalar_t alpha, scalar_t beta, index_t batch_size,
+                         bool* success) {
+      run<scalar_t>(st, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta,
+                    batch_size, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size).c_str(), BM_lambda,
+        cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      cublasHandle_t* cuda_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, cuda_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/cublas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/cublas/blas3/gemm_batched_strided.cpp
@@ -227,7 +227,8 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         get_name<scalar_t>(t1s, t2s, m, k, n, batch_size).c_str(), BM_lambda,
-        cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size, success);
+        cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size, success)
+        ->UseRealTime();
   }
 }
 

--- a/benchmark/cublas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/cublas/blas3/gemm_batched_strided.cpp
@@ -201,10 +201,10 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int t1,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         cublasHandle_t* cuda_handle_ptr, bool* success) {
-  auto gemm_params =
+  auto gemm_batched_strided_params =
       blas_benchmark::utils::get_gemm_batched_params<scalar_t>(args);
 
-  for (auto p : gemm_params) {
+  for (auto p : gemm_batched_strided_params) {
     std::string t1s, t2s;
     index_t m, n, k, batch_size;
     scalar_t alpha, beta;

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -68,7 +68,7 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
   const double mem_writeC = m_d * n_d;
   const double mem_readA =
       (side == 'l') ? (m_d * (m_d + 1) / 2) : (n_d * (n_d + 1) / 2);
-  double total_mem =
+  const double total_mem =
       (mem_readBreadC + mem_writeC + mem_readA) * sizeof(scalar_t);
   state.counters["bytes_processed"] = total_mem;
 
@@ -167,7 +167,6 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         cublasHandle_t* cuda_handle_ptr, bool* success) {
-
   auto symm_params = blas_benchmark::utils::get_symm_params<scalar_t>(args);
 
   for (auto p : symm_params) {

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -1,0 +1,192 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename symm.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(char side, char uplo, int m, int n, scalar_t alpha,
+                     scalar_t beta) {
+  std::ostringstream str{};
+  str << "BM_Symm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << side << "/" << uplo << "/" << m << "/" << n << "/" << alpha << "/"
+      << beta;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void cublas_routine(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CUBLAS_CHECK(cublasSsymm(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CUBLAS_CHECK(cublasDsymm(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
+         char uplo, index_t m, index_t n, scalar_t alpha, scalar_t beta,
+         bool* success) {
+  index_t lda = side == 'l' ? m : n;
+  index_t ldb = m;
+  index_t ldc = ldb;
+
+  cublasHandle_t& cuda_handle = *cuda_handle_ptr;
+
+  // The counters are double. We convert m, n and k to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double m_d = static_cast<double>(m);
+  double n_d = static_cast<double>(n);
+
+  state.counters["m"] = m_d;
+  state.counters["n"] = n_d;
+
+  double mem_readAreadB = 2 * m_d * n_d;
+  double mem_writeB = m_d * n_d;
+  double total_mem = (mem_readAreadB + mem_writeB) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = total_mem;
+
+  const double nflops_AtimesB = 2 * m_d * n_d;
+  const double nflops_timesAlpha = m_d * n_d;
+  const double nflops = nflops_AtimesB + nflops_timesAlpha;
+  state.counters["n_fl_ops"] = nflops;
+
+  const auto a_other_dim = (lda == m) ? m : n;
+  // Matrices
+  std::vector<scalar_t> a(lda * lda);
+  // blas_benchmark::utils::random_data<scalar_t>(lda * a_other_dim);
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(ldb * n);
+  std::vector<scalar_t> c =
+      blas_benchmark::utils::random_data<scalar_t>(ldc * n);
+
+  blas_benchmark::utils::fill_sym_matrix(a, lda);
+
+  blas_benchmark::utils::CUDAVector<scalar_t> a_gpu(lda * lda, a.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> b_gpu(ldb * n, b.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> c_gpu(ldc * n, c.data());
+
+  cublasSideMode_t c_side =
+      (side == 'l') ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
+
+  cublasFillMode_t c_uplo =
+      (uplo == 'u') ? CUBLAS_FILL_MODE_UPPER : CUBLAS_FILL_MODE_LOWER;
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> c_ref = c;
+  reference_blas::symm(&side, &uplo, m, n, alpha, a.data(), lda, b.data(), ldb,
+                       beta, c_ref.data(), ldc);
+  std::vector<scalar_t> c_temp = c;
+  {
+    blas_benchmark::utils::CUDAVector<scalar_t, true> c_temp_gpu(ldc * n,
+                                                                 c_temp.data());
+    cublas_routine<scalar_t>(cuda_handle, c_side, c_uplo, m, n, &alpha, a_gpu,
+                             lda, b_gpu, ldb, &beta, c_temp_gpu, ldc);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+  auto blas_warmup = [&]() -> void {
+    cublas_routine<scalar_t>(cuda_handle, c_side, c_uplo, m, n, &alpha, a_gpu,
+                             lda, b_gpu, ldb, &beta, c_gpu, ldc);
+    return;
+  };
+
+  cudaEvent_t start;
+  cudaEvent_t stop;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
+
+  auto blas_method_def = [&]() -> std::vector<cudaEvent_t> {
+    CUDA_CHECK(cudaEventRecord(start));
+    cublas_routine<scalar_t>(cuda_handle, c_side, c_uplo, m, n, &alpha, a_gpu,
+                             lda, b_gpu, ldb, &beta, c_gpu, ldc);
+    CUDA_CHECK(cudaEventRecord(stop));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    return std::vector{start, stop};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_warmup);
+  CUDA_CHECK(cudaStreamSynchronize(NULL));
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef_cuda(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetBytesProcessed(state.iterations() * total_mem);
+  state.SetItemsProcessed(state.iterations() * nflops);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+
+  CUDA_CHECK(cudaEventDestroy(start));
+  CUDA_CHECK(cudaEventDestroy(stop));
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        cublasHandle_t* cuda_handle_ptr, bool* success) {
+  // Get params from trsm since they are the same
+  auto symm_params = blas_benchmark::utils::get_symm_params<scalar_t>(args);
+
+  for (auto p : symm_params) {
+    char s_side, s_uplo;
+    index_t m, n;
+    scalar_t alpha, beta;
+    std::tie(s_side, s_uplo, m, n, alpha, beta) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
+                         char side, char uplo, index_t m, index_t n,
+                         scalar_t alpha, scalar_t beta, bool* success) {
+      run<scalar_t>(st, cuda_handle_ptr, side, uplo, m, n, alpha, beta,
+                    success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(s_side, s_uplo, m, n, alpha, beta).c_str(),
+        BM_lambda, cuda_handle_ptr, s_side, s_uplo, m, n, alpha, beta, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      cublasHandle_t* cuda_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, cuda_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -167,7 +167,7 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         cublasHandle_t* cuda_handle_ptr, bool* success) {
-  // Get params from trsm since they are the same
+
   auto symm_params = blas_benchmark::utils::get_symm_params<scalar_t>(args);
 
   for (auto p : symm_params) {

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -78,16 +78,13 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
   const double nflops = nflops_AtimesB + nflops_addBetaC;
   state.counters["n_fl_ops"] = nflops;
 
-  const auto a_other_dim = (lda == m) ? m : n;
   // Matrices
-  std::vector<scalar_t> a(lda * lda);
-  // blas_benchmark::utils::random_data<scalar_t>(lda * a_other_dim);
+  std::vector<scalar_t> a =
+      blas_benchmark::utils::random_data<scalar_t>(lda * lda);
   std::vector<scalar_t> b =
       blas_benchmark::utils::random_data<scalar_t>(ldb * n);
   std::vector<scalar_t> c =
       blas_benchmark::utils::random_data<scalar_t>(ldc * n);
-
-  blas_benchmark::utils::fill_sym_matrix(a, lda);
 
   blas_benchmark::utils::CUDAVector<scalar_t> a_gpu(lda * lda, a.data());
   blas_benchmark::utils::CUDAVector<scalar_t> b_gpu(ldb * n, b.data());

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -63,14 +63,19 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
   state.counters["m"] = m_d;
   state.counters["n"] = n_d;
 
-  double mem_readAreadB = 2 * m_d * n_d;
-  double mem_writeB = m_d * n_d;
-  double total_mem = (mem_readAreadB + mem_writeB) * sizeof(scalar_t);
+  const double mem_readBreadC =
+      (beta != scalar_t{0}) ? 2 * m_d * n_d : m_d * n_d;
+  const double mem_writeC = m_d * n_d;
+  const double mem_readA =
+      (side == 'l') ? (m_d * (m_d + 1) / 2) : (n_d * (n_d + 1) / 2);
+  double total_mem =
+      (mem_readBreadC + mem_writeC + mem_readA) * sizeof(scalar_t);
   state.counters["bytes_processed"] = total_mem;
 
-  const double nflops_AtimesB = 2 * m_d * n_d;
-  const double nflops_timesAlpha = m_d * n_d;
-  const double nflops = nflops_AtimesB + nflops_timesAlpha;
+  const double nflops_AtimesB =
+      (side == 'l') ? (2 * m_d * m_d) * n_d : 2 * n_d * n_d * n_d;
+  const double nflops_addBetaC = 2 * m_d * n_d;
+  const double nflops = nflops_AtimesB + nflops_addBetaC;
   state.counters["n_fl_ops"] = nflops;
 
   const auto a_other_dim = (lda == m) ? m : n;

--- a/benchmark/cublas/blas3/syr2k.cpp
+++ b/benchmark/cublas/blas3/syr2k.cpp
@@ -69,10 +69,11 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
   state.counters["bytes_processed"] = total_mem;
 
   const double nflops_AtimesBtwice = 2 * n_d * (n_d + 1) * k_d;
-  const double nflops_timesAlpha = n_d * (n_d+1)/2.;
+  const double nflops_timesAlpha = n_d * (n_d + 1) / 2.;
   const double nflops_addBetaC =
       (beta != scalar_t{0}) ? (2 * n_d * (n_d + 1) / 2.) : 0;
-  const double nflops = nflops_AtimesBtwice + nflops_timesAlpha + nflops_addBetaC;
+  const double nflops =
+      nflops_AtimesBtwice + nflops_timesAlpha + nflops_addBetaC;
 
   state.counters["n_fl_ops"] = nflops;
 
@@ -164,7 +165,6 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         cublasHandle_t* cuda_handle_ptr, bool* success) {
-  // Get params from trsm since they are the same
   auto syr2k_params = blas_benchmark::utils::get_syrk_params<scalar_t>(args);
 
   for (auto p : syr2k_params) {

--- a/benchmark/cublas/blas3/syr2k.cpp
+++ b/benchmark/cublas/blas3/syr2k.cpp
@@ -1,0 +1,194 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename syr2k.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
+                     scalar_t beta) {
+  std::ostringstream str{};
+  str << "BM_Syr2k<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
+      << beta;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void cublas_routine(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CUBLAS_CHECK(cublasSsyr2k(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CUBLAS_CHECK(cublasDsyr2k(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
+         char trans, index_t n, index_t k, scalar_t alpha, scalar_t beta,
+         bool* success) {
+  const index_t lda = (trans == 'n') ? n : k;
+  const index_t ldc = n;
+
+  cublasHandle_t& cuda_handle = *cuda_handle_ptr;
+
+  // The counters are double. We convert m, n and k to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  const double n_d = static_cast<double>(n);
+  const double k_d = static_cast<double>(k);
+
+  state.counters["k"] = k_d;
+  state.counters["n"] = n_d;
+
+  const double mem_readAreadB = 2 * n_d * k_d;
+  const double mem_readWriteC = 2 * n_d * (n_d + 1) / 2.;
+  const double total_mem = (mem_readAreadB + mem_readWriteC) * sizeof(scalar_t);
+
+  state.counters["bytes_processed"] = total_mem;
+
+  const double nflops_AtimesBtwice = 2 * n_d * (n_d + 1) * k_d;
+  const double nflops_timesAlpha = n_d * (n_d+1)/2.;
+  const double nflops_addBetaC =
+      (beta != scalar_t{0}) ? (2 * n_d * (n_d + 1) / 2.) : 0;
+  const double nflops = nflops_AtimesBtwice + nflops_timesAlpha + nflops_addBetaC;
+
+  state.counters["n_fl_ops"] = nflops;
+
+  const auto m_a_dim = (trans == 'n') ? (lda * k) : (lda * n);
+
+  // Matrices
+  std::vector<scalar_t> a =
+      blas_benchmark::utils::random_data<scalar_t>(m_a_dim);
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(m_a_dim);
+  std::vector<scalar_t> c(ldc * n);
+
+  blas_benchmark::utils::fill_sym_matrix(c, ldc);
+
+  blas_benchmark::utils::CUDAVector<scalar_t> a_gpu(m_a_dim, a.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> b_gpu(m_a_dim, b.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> c_gpu(ldc * n, c.data());
+
+  cublasFillMode_t c_uplo =
+      (uplo == 'u') ? CUBLAS_FILL_MODE_UPPER : CUBLAS_FILL_MODE_LOWER;
+
+  cublasOperation_t c_t = (trans == 'n') ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> c_ref = c;
+  reference_blas::syr2k(&uplo, &trans, n, k, alpha, a.data(), lda, b.data(),
+                        lda, beta, c_ref.data(), ldc);
+  std::vector<scalar_t> c_temp = c;
+  {
+    blas_benchmark::utils::CUDAVector<scalar_t, true> c_temp_gpu(ldc * n,
+                                                                 c_temp.data());
+    cublas_routine<scalar_t>(cuda_handle, c_uplo, c_t, n, k, &alpha, a_gpu, lda,
+                             b_gpu, lda, &beta, c_temp_gpu, ldc);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+  auto blas_warmup = [&]() -> void {
+    cublas_routine<scalar_t>(cuda_handle, c_uplo, c_t, n, k, &alpha, a_gpu, lda,
+                             b_gpu, lda, &beta, c_gpu, ldc);
+    return;
+  };
+
+  cudaEvent_t start;
+  cudaEvent_t stop;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
+
+  auto blas_method_def = [&]() -> std::vector<cudaEvent_t> {
+    CUDA_CHECK(cudaEventRecord(start));
+    cublas_routine<scalar_t>(cuda_handle, c_uplo, c_t, n, k, &alpha, a_gpu, lda,
+                             b_gpu, lda, &beta, c_gpu, ldc);
+    CUDA_CHECK(cudaEventRecord(stop));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    return std::vector{start, stop};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_warmup);
+  CUDA_CHECK(cudaStreamSynchronize(NULL));
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef_cuda(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetBytesProcessed(state.iterations() * total_mem);
+  state.SetItemsProcessed(state.iterations() * nflops);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+
+  CUDA_CHECK(cudaEventDestroy(start));
+  CUDA_CHECK(cudaEventDestroy(stop));
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        cublasHandle_t* cuda_handle_ptr, bool* success) {
+  // Get params from trsm since they are the same
+  auto syr2k_params = blas_benchmark::utils::get_syrk_params<scalar_t>(args);
+
+  for (auto p : syr2k_params) {
+    char s_uplo, s_trans;
+    index_t n, k;
+    scalar_t alpha, beta;
+    std::tie(s_uplo, s_trans, n, k, alpha, beta) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
+                         char uplo, char trans, index_t n, index_t k,
+                         scalar_t alpha, scalar_t beta, bool* success) {
+      run<scalar_t>(st, cuda_handle_ptr, uplo, trans, n, k, alpha, beta,
+                    success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(s_uplo, s_trans, n, k, alpha, beta).c_str(),
+        BM_lambda, cuda_handle_ptr, s_uplo, s_trans, n, k, alpha, beta, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      cublasHandle_t* cuda_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, cuda_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/cublas/blas3/syr2k.cpp
+++ b/benchmark/cublas/blas3/syr2k.cpp
@@ -84,9 +84,8 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
       blas_benchmark::utils::random_data<scalar_t>(m_a_dim);
   std::vector<scalar_t> b =
       blas_benchmark::utils::random_data<scalar_t>(m_a_dim);
-  std::vector<scalar_t> c(ldc * n);
-
-  blas_benchmark::utils::fill_sym_matrix(c, ldc);
+  std::vector<scalar_t> c =
+      blas_benchmark::utils::random_data<scalar_t>(ldc * n);
 
   blas_benchmark::utils::CUDAVector<scalar_t> a_gpu(m_a_dim, a.data());
   blas_benchmark::utils::CUDAVector<scalar_t> b_gpu(m_a_dim, b.data());

--- a/benchmark/cublas/blas3/syrk.cpp
+++ b/benchmark/cublas/blas3/syrk.cpp
@@ -1,0 +1,188 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename syrk.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
+                     scalar_t beta) {
+  std::ostringstream str{};
+  str << "BM_Syrk<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
+      << beta;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void cublas_routine(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CUBLAS_CHECK(cublasSsyrk(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CUBLAS_CHECK(cublasDsyrk(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
+         char trans, index_t n, index_t k, scalar_t alpha, scalar_t beta,
+         bool* success) {
+  index_t lda = (trans == 'n') ? n : k;
+  index_t ldc = n;
+
+  cublasHandle_t& cuda_handle = *cuda_handle_ptr;
+
+  // The counters are double. We convert m, n and k to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  const double n_d = static_cast<double>(n);
+  const double k_d = static_cast<double>(k);
+
+  state.counters["k"] = k_d;
+  state.counters["n"] = n_d;
+
+  const double mem_readA = n_d * k_d;
+  const double mem_readWriteC = 2 * n_d * (n_d + 1) / 2.;
+  const double total_mem = (mem_readA + mem_readWriteC) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = total_mem;
+
+  const double nflops_AtimesA = n_d * (n_d + 1) * k;
+  const double nflops_timesAlpha = n_d * k_d;
+  const double nflops_addBetaC =
+      (beta != scalar_t{0}) ? (2 * n_d * (n_d + 1) / 2.) : 0;
+  const double nflops = nflops_AtimesA + nflops_timesAlpha + nflops_addBetaC;
+  state.counters["n_fl_ops"] = nflops;
+
+  const auto m_a_dim = (trans == 'n') ? (lda * k) : (lda * n);
+  // Matrices
+  std::vector<scalar_t> a =
+      blas_benchmark::utils::random_data<scalar_t>(m_a_dim);
+  std::vector<scalar_t> c(ldc * n);
+
+  blas_benchmark::utils::fill_sym_matrix(c, ldc);
+
+  blas_benchmark::utils::CUDAVector<scalar_t> a_gpu(m_a_dim, a.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> c_gpu(ldc * n, c.data());
+
+  cublasFillMode_t c_uplo =
+      (uplo == 'u') ? CUBLAS_FILL_MODE_UPPER : CUBLAS_FILL_MODE_LOWER;
+
+  cublasOperation_t c_t = (trans == 'n') ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> c_ref = c;
+  reference_blas::syrk(&uplo, &trans, n, k, alpha, a.data(), lda, beta,
+                       c_ref.data(), ldc);
+  std::vector<scalar_t> c_temp = c;
+  {
+    blas_benchmark::utils::CUDAVector<scalar_t, true> c_temp_gpu(ldc * n,
+                                                                 c_temp.data());
+    cublas_routine<scalar_t>(cuda_handle, c_uplo, c_t, n, k, &alpha, a_gpu, lda,
+                             &beta, c_temp_gpu, ldc);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+  auto blas_warmup = [&]() -> void {
+    cublas_routine<scalar_t>(cuda_handle, c_uplo, c_t, n, k, &alpha, a_gpu, lda,
+                             &beta, c_gpu, ldc);
+    return;
+  };
+
+  cudaEvent_t start;
+  cudaEvent_t stop;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
+
+  auto blas_method_def = [&]() -> std::vector<cudaEvent_t> {
+    CUDA_CHECK(cudaEventRecord(start));
+    cublas_routine<scalar_t>(cuda_handle, c_uplo, c_t, n, k, &alpha, a_gpu, lda,
+                             &beta, c_gpu, ldc);
+    CUDA_CHECK(cudaEventRecord(stop));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    return std::vector{start, stop};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_warmup);
+  CUDA_CHECK(cudaStreamSynchronize(NULL));
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef_cuda(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetBytesProcessed(state.iterations() * total_mem);
+  state.SetItemsProcessed(state.iterations() * nflops);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+
+  CUDA_CHECK(cudaEventDestroy(start));
+  CUDA_CHECK(cudaEventDestroy(stop));
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        cublasHandle_t* cuda_handle_ptr, bool* success) {
+  // Get params from trsm since they are the same
+  auto syrk_params = blas_benchmark::utils::get_syrk_params<scalar_t>(args);
+
+  for (auto p : syrk_params) {
+    char s_uplo, s_trans;
+    index_t n, k;
+    scalar_t alpha, beta;
+    std::tie(s_uplo, s_trans, n, k, alpha, beta) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
+                         char uplo, char trans, index_t n, index_t k,
+                         scalar_t alpha, scalar_t beta, bool* success) {
+      run<scalar_t>(st, cuda_handle_ptr, uplo, trans, n, k, alpha, beta,
+                    success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(s_uplo, s_trans, n, k, alpha, beta).c_str(),
+        BM_lambda, cuda_handle_ptr, s_uplo, s_trans, n, k, alpha, beta, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      cublasHandle_t* cuda_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, cuda_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/cublas/blas3/syrk.cpp
+++ b/benchmark/cublas/blas3/syrk.cpp
@@ -76,9 +76,8 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
   // Matrices
   std::vector<scalar_t> a =
       blas_benchmark::utils::random_data<scalar_t>(m_a_dim);
-  std::vector<scalar_t> c(ldc * n);
-
-  blas_benchmark::utils::fill_sym_matrix(c, ldc);
+  std::vector<scalar_t> c =
+      blas_benchmark::utils::random_data<scalar_t>(ldc * n);
 
   blas_benchmark::utils::CUDAVector<scalar_t> a_gpu(m_a_dim, a.data());
   blas_benchmark::utils::CUDAVector<scalar_t> c_gpu(ldc * n, c.data());
@@ -156,7 +155,6 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         cublasHandle_t* cuda_handle_ptr, bool* success) {
-
   auto syrk_params = blas_benchmark::utils::get_syrk_params<scalar_t>(args);
 
   for (auto p : syrk_params) {

--- a/benchmark/cublas/blas3/syrk.cpp
+++ b/benchmark/cublas/blas3/syrk.cpp
@@ -156,7 +156,7 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         cublasHandle_t* cuda_handle_ptr, bool* success) {
-  // Get params from trsm since they are the same
+
   auto syrk_params = blas_benchmark::utils::get_syrk_params<scalar_t>(args);
 
   for (auto p : syrk_params) {

--- a/benchmark/cublas/blas3/syrk.cpp
+++ b/benchmark/cublas/blas3/syrk.cpp
@@ -67,11 +67,9 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
   const double total_mem = (mem_readA + mem_readWriteC) * sizeof(scalar_t);
   state.counters["bytes_processed"] = total_mem;
 
-  const double nflops_AtimesA = n_d * (n_d + 1) * k;
-  const double nflops_timesAlpha = n_d * k_d;
-  const double nflops_addBetaC =
-      (beta != scalar_t{0}) ? (2 * n_d * (n_d + 1) / 2.) : 0;
-  const double nflops = nflops_AtimesA + nflops_timesAlpha + nflops_addBetaC;
+  const double nflops_AtimesA = n_d * (n_d + 1) * k_d;
+  const double nflops_addBetaC = (beta != scalar_t{0}) ? (n_d * (n_d + 1)) : 0;
+  const double nflops = nflops_AtimesA + nflops_addBetaC;
   state.counters["n_fl_ops"] = nflops;
 
   const auto m_a_dim = (trans == 'n') ? (lda * k) : (lda * n);

--- a/benchmark/cublas/blas3/trmm.cpp
+++ b/benchmark/cublas/blas3/trmm.cpp
@@ -77,7 +77,6 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
 
   // Matrices
   std::vector<scalar_t> a(tr_m_size);
-  //= blas_benchmark::utils::random_data<scalar_t>(tr_m_size);
   std::vector<scalar_t> b =
       blas_benchmark::utils::random_data<scalar_t>(ldb * n);
 

--- a/benchmark/cublas/blas3/trmm.cpp
+++ b/benchmark/cublas/blas3/trmm.cpp
@@ -1,0 +1,203 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trmm.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(char side, char uplo, char t, char diag, int m, int n) {
+  std::ostringstream str{};
+  str << "BM_Trmm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << side << "/" << uplo << "/" << t << "/" << diag << "/" << m << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void cublas_routine(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CUBLAS_CHECK(cublasStrmm(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CUBLAS_CHECK(cublasDtrmm(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
+         char uplo, char t, char diag, index_t m, index_t n, scalar_t alpha,
+         bool* success) {
+  index_t lda = side == 'l' ? m : n;
+  index_t ldb = m;
+  index_t ldc = ldb;
+
+  cublasHandle_t& cuda_handle = *cuda_handle_ptr;
+
+  const index_t tr_m_size = (side == 'l') ? lda * m : lda * n;
+
+  // The counters are double. We convert m, n and k to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double m_d = static_cast<double>(m);
+  double n_d = static_cast<double>(n);
+
+  state.counters["m"] = m_d;
+  state.counters["n"] = n_d;
+
+  double mem_readAreadB = 2 * m_d * n_d;
+  double mem_writeB = m_d * n_d;
+  double total_mem = (mem_readAreadB + mem_writeB) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = total_mem;
+
+  const double nflops_AtimesB = 2 * m_d * n_d;
+  const double nflops_timesAlpha = m_d * n_d;
+  const double nflops = nflops_AtimesB + nflops_timesAlpha;
+  state.counters["n_fl_ops"] = nflops;
+
+  // Matrices
+  std::vector<scalar_t> a(tr_m_size);
+  //= blas_benchmark::utils::random_data<scalar_t>(tr_m_size);
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(ldb * n);
+
+  const scalar_t diagValue =
+      (diag == 'u') ? scalar_t{1}
+                    : blas_benchmark::utils::random_scalar<scalar_t>(
+                          scalar_t{1}, scalar_t{10});
+
+  
+  const auto a_other_dim{tr_m_size/lda};
+  blas_benchmark::utils::fill_trsm_matrix(a, a_other_dim, lda, uplo,
+                                          diagValue, scalar_t{0});
+
+  blas_benchmark::utils::CUDAVector<scalar_t> a_gpu(tr_m_size, a.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> b_gpu(ldb * n, b.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> c_gpu(ldc * n);
+
+  cublasSideMode_t c_side =
+      (side == 'l') ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
+
+  cublasFillMode_t c_uplo =
+      (uplo == 'u') ? CUBLAS_FILL_MODE_UPPER : CUBLAS_FILL_MODE_LOWER;
+
+  cublasOperation_t c_t = (t == 'n') ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+  cublasDiagType_t c_diag =
+      (diag == 'u') ? CUBLAS_DIAG_UNIT : CUBLAS_DIAG_NON_UNIT;
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> b_ref = b;
+  reference_blas::trmm(&side, &uplo, &t, &diag, m, n, alpha, a.data(), lda,
+                       b_ref.data(), ldb);
+  std::vector<scalar_t> c_temp(ldb * n);
+  {
+    blas_benchmark::utils::CUDAVector<scalar_t, true> c_temp_gpu(m * n,
+                                                                 c_temp.data());
+    cublas_routine<scalar_t>(cuda_handle, c_side, c_uplo, c_t, c_diag, m, n,
+                             &alpha, a_gpu, lda, b_gpu, ldb, c_temp_gpu, ldc);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(c_temp, b_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+  auto blas_warmup = [&]() -> void {
+    cublas_routine<scalar_t>(cuda_handle, c_side, c_uplo, c_t, c_diag, m, n,
+                             &alpha, a_gpu, lda, b_gpu, ldb, c_gpu, ldc);
+    return;
+  };
+
+  cudaEvent_t start;
+  cudaEvent_t stop;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
+
+  auto blas_method_def = [&]() -> std::vector<cudaEvent_t> {
+    CUDA_CHECK(cudaEventRecord(start));
+    cublas_routine<scalar_t>(cuda_handle, c_side, c_uplo, c_t, c_diag, m, n,
+                             &alpha, a_gpu, lda, b_gpu, ldb, c_gpu, ldc);
+    CUDA_CHECK(cudaEventRecord(stop));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    return std::vector{start, stop};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_warmup);
+  CUDA_CHECK(cudaStreamSynchronize(NULL));
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef_cuda(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetBytesProcessed(state.iterations() * total_mem);
+  state.SetItemsProcessed(state.iterations() * nflops);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+
+  CUDA_CHECK(cudaEventDestroy(start));
+  CUDA_CHECK(cudaEventDestroy(stop));
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        cublasHandle_t* cuda_handle_ptr, bool* success) {
+  // Get params from trsm since they are the same
+  auto trmm_params = blas_benchmark::utils::get_trsm_params<scalar_t>(args);
+
+  for (auto p : trmm_params) {
+    char s_side, s_uplo, s_t, s_diag;
+    index_t m, n;
+    scalar_t alpha;
+    std::tie(s_side, s_uplo, s_t, s_diag, m, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
+                         char side, char uplo, char t, char diag, index_t m,
+                         index_t n, scalar_t alpha, bool* success) {
+      run<scalar_t>(st, cuda_handle_ptr, side, uplo, t, diag, m, n, alpha,
+                    success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(s_side, s_uplo, s_t, s_diag, m, n).c_str(),
+        BM_lambda, cuda_handle_ptr, s_side, s_uplo, s_t, s_diag, m, n, alpha,
+        success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      cublasHandle_t* cuda_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, cuda_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/cublas/blas3/trsm.cpp
+++ b/benchmark/cublas/blas3/trsm.cpp
@@ -68,13 +68,11 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
   const double k_d = static_cast<double>(k);
 
   state.counters["m"] = m_d;
-  state.counters["k"] = k_d;
   state.counters["n"] = n_d;
 
-  const double mem_read = k_d * (k_d + 1) / 2;
-  const double mem_write = m_d * n_d;
-
-  const double total_mem = (mem_read * mem_write) * sizeof(scalar_t);
+  const double mem_readA = k_d * (k_d + 1) / 2;
+  const double mem_readBwriteB = 2 * m_d * n_d;
+  const double total_mem = (mem_readA * mem_readBwriteB) * sizeof(scalar_t);
   state.counters["bytes_processed"] = total_mem;
 
   const double nflops_AtimesB =

--- a/benchmark/cublas/blas3/trsm.cpp
+++ b/benchmark/cublas/blas3/trsm.cpp
@@ -1,0 +1,205 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trsm.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(char side, char uplo, char trans, char diag, index_t m,
+                     index_t n) {
+  std::ostringstream str{};
+  str << "BM_Trsm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << side << "/" << uplo << "/" << trans << "/" << diag << "/" << m << "/"
+      << n;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void cublas_routine(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CUBLAS_CHECK(cublasStrsm(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CUBLAS_CHECK(cublasDtrsm(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
+         char uplo, char trans, char diag, index_t m, index_t n, scalar_t alpha,
+         bool* success) {
+  // Standard test setup.
+  index_t lda = side == 'l' ? m : n;
+  index_t ldb = m;
+  index_t k = side == 'l' ? m : n;
+
+  cublasHandle_t& cuda_handle = *cuda_handle_ptr;
+
+  const int sizeA = k * lda;
+  const int sizeB = n * ldb;
+
+  // Init counters for benchmark
+
+  // The counters are double. We convert m, n and k to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  const double m_d = static_cast<double>(m);
+  const double n_d = static_cast<double>(n);
+  const double k_d = static_cast<double>(k);
+
+  state.counters["m"] = m_d;
+  state.counters["k"] = k_d;
+  state.counters["n"] = n_d;
+
+  const double mem_read = k_d * (k_d + 1) / 2;
+  const double mem_write = m_d * n_d;
+
+  const double total_mem = (mem_read * mem_write) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = total_mem;
+
+  const double nflops_AtimesB =
+      2 * k_d * (k_d + 1) / 2 * (side == 'l' ? n_d : m_d);
+  const double nflops_timesAlpha = m_d * n_d;
+  const double nflops = nflops_AtimesB + nflops_timesAlpha;
+  state.counters["n_fl_ops"] = nflops;
+
+  // Matrices
+  std::vector<scalar_t> a(sizeA);
+  std::vector<scalar_t> b = blas_benchmark::utils::random_data<scalar_t>(sizeB);
+
+  const scalar_t diagValue =
+      diag == 'u' ? scalar_t{1}
+                  : blas_benchmark::utils::random_scalar<scalar_t>(
+                        scalar_t{1}, scalar_t{10});
+
+  blas_benchmark::utils::fill_trsm_matrix(a, k, lda, uplo, diagValue,
+                                          scalar_t{0});
+
+  blas_benchmark::utils::CUDAVector<scalar_t> a_gpu(sizeA, a.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> b_gpu(sizeB, b.data());
+
+  cublasSideMode_t c_side =
+      (side == 'l') ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
+
+  cublasFillMode_t c_uplo =
+      (uplo == 'u') ? CUBLAS_FILL_MODE_UPPER : CUBLAS_FILL_MODE_LOWER;
+
+  cublasOperation_t c_t = (trans == 'n') ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+  cublasDiagType_t c_diag =
+      (diag == 'u') ? CUBLAS_DIAG_UNIT : CUBLAS_DIAG_NON_UNIT;
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run once verifying the results against the reference blas implementation.
+  std::vector<scalar_t> x_ref = b;
+  std::vector<scalar_t> b_temp = b;
+
+  reference_blas::trsm(&side, &uplo, &trans, &diag, m, n,
+                       static_cast<scalar_t>(alpha), a.data(), lda,
+                       x_ref.data(), ldb);
+
+  {
+    blas_benchmark::utils::CUDAVector<scalar_t, true> b_temp_gpu(sizeB,
+                                                                 b_temp.data());
+    cublas_routine<scalar_t>(cuda_handle, c_side, c_uplo, c_t, c_diag, m, n,
+                             &alpha, a_gpu, lda, b_temp_gpu, ldb);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(b_temp, x_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+  auto blas_warmup = [&]() -> void {
+    cublas_routine<scalar_t>(cuda_handle, c_side, c_uplo, c_t, c_diag, m, n,
+                             &alpha, a_gpu, lda, b_gpu, ldb);
+    return;
+  };
+
+  cudaEvent_t start, stop;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
+
+  auto blas_method_def = [&]() -> std::vector<cudaEvent_t> {
+    CUDA_CHECK(cudaEventRecord(start, NULL));
+    cublas_routine<scalar_t>(cuda_handle, c_side, c_uplo, c_t, c_diag, m, n,
+                             &alpha, a_gpu, lda, b_gpu, ldb);
+    CUDA_CHECK(cudaEventRecord(stop, NULL));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    return std::vector{start, stop};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_warmup);
+  CUDA_CHECK(cudaStreamSynchronize(NULL));
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef_cuda(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetBytesProcessed(state.iterations() * total_mem);
+  state.SetItemsProcessed(state.iterations() * nflops);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        cublasHandle_t* cuda_handle_ptr, bool* success) {
+  auto trsm_params = blas_benchmark::utils::get_trsm_params<scalar_t>(args);
+
+  for (auto p : trsm_params) {
+    char side, uplo, trans, diag;
+    index_t m, n;
+    scalar_t alpha;
+    std::tie(side, uplo, trans, diag, m, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
+                         char side, char uplo, char trans, char diag, index_t m,
+                         index_t n, scalar_t alpha, bool* success) {
+      run<scalar_t>(st, cuda_handle_ptr, side, uplo, trans, diag, m, n, alpha,
+                    success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
+        cuda_handle_ptr, side, uplo, trans, diag, m, n, alpha, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      cublasHandle_t* cuda_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, cuda_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/cublas/blas3/trsm_batched.cpp
+++ b/benchmark/cublas/blas3/trsm_batched.cpp
@@ -104,13 +104,11 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
   state.counters["n"] = n_d;
   state.counters["batch_count"] = batch_count_d;
 
-  {
-    const double mem_readA = k_d * (k_d + 1) / 2;
-    const double mem_readBwriteB = 2 * m_d * n_d;
-    const double total_mem =
-        ((mem_readA + mem_readBwriteB) * sizeof(scalar_t)) * batch_count;
-    state.counters["bytes_processed"] = total_mem;
-  }
+  const double mem_readA = k_d * (k_d + 1) / 2;
+  const double mem_readBwriteB = 2 * m_d * n_d;
+  const double total_mem =
+      ((mem_readA + mem_readBwriteB) * sizeof(scalar_t)) * batch_count;
+  state.counters["bytes_processed"] = total_mem;
 
   const double nflops_AtimesB =
       2 * k_d * (k_d + 1) / 2 * (side == 'l' ? n_d : m_d);
@@ -249,6 +247,7 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
     blas_benchmark::utils::update_counters(state, times);
   }
 
+  state.SetBytesProcessed(state.iterations() * total_mem);
   state.SetItemsProcessed(state.iterations() * nflops_tot);
 
   blas_benchmark::utils::calc_avg_counters(state);

--- a/benchmark/cublas/blas3/trsm_batched.cpp
+++ b/benchmark/cublas/blas3/trsm_batched.cpp
@@ -257,10 +257,10 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         cublasHandle_t* cuda_handle_ptr, bool* success) {
-  auto trsm_params =
+  auto trsm_batched_params =
       blas_benchmark::utils::get_trsm_batched_params<scalar_t>(args);
 
-  for (auto p : trsm_params) {
+  for (auto p : trsm_batched_params) {
     char s_side, s_uplo, s_t, s_diag;
     index_t m, n, batch_count;
     scalar_t alpha;

--- a/benchmark/cublas/blas3/trsm_batched.cpp
+++ b/benchmark/cublas/blas3/trsm_batched.cpp
@@ -1,0 +1,293 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trsm_batched.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+// Convert batch_type=strided to interleaved on the host
+template <typename scalar_t>
+std::vector<scalar_t> strided_to_interleaved(const std::vector<scalar_t>& input,
+                                             int offset, int ld_rows,
+                                             int ld_cols, int batchs) {
+  std::vector<scalar_t> output(input.size());
+  for (int c = 0; c < ld_cols; ++c) {
+    for (int r = 0; r < ld_rows; ++r) {
+      for (int b = 0; b < batchs; ++b) {
+        output[c * ld_rows * batchs + r * batchs + b + offset] =
+            input[b * ld_cols * ld_rows + c * ld_rows + r + offset];
+      }
+    }
+  }
+  return output;
+}
+
+// Convert batch_type=interleaved to strided on the host
+template <typename scalar_t>
+std::vector<scalar_t> interleaved_to_strided(const std::vector<scalar_t>& input,
+                                             int offset, int ld_rows,
+                                             int ld_cols, int batchs) {
+  std::vector<scalar_t> output(input.size());
+  for (int b = 0; b < batchs; ++b) {
+    for (int c = 0; c < ld_cols; ++c) {
+      for (int r = 0; r < ld_rows; ++r) {
+        output[b * ld_cols * ld_rows + c * ld_rows + r + offset] =
+            input[c * ld_rows * batchs + r * batchs + b + offset];
+      }
+    }
+  }
+  return output;
+}
+
+template <typename scalar_t>
+std::string get_name(const char side, const char uplo, const char t,
+                     const char diag, int m, int n, int batch_count,
+                     int batch_type) {
+  std::ostringstream str{};
+  str << "BM_TrsmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
+      << ">/" << side << "/" << uplo << "/" << t << "/" << diag << "/" << m
+      << "/" << n << "/" << batch_count << "/"
+      << blas_benchmark::utils::batch_type_to_str(batch_type);
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void cublas_routine(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CUBLAS_CHECK(cublasStrsmBatched(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CUBLAS_CHECK(cublasDtrsmBatched(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
+         const char side, const char uplo, const char t, const char diag,
+         index_t m, index_t n, scalar_t alpha, index_t batch_count,
+         int batch_type_i, bool* success) {
+  // Standard test setup.
+  index_t lda = side == 'l' ? m : n;
+  index_t ldb = m;
+  index_t k = side == 'l' ? m : n;
+
+  auto batch_type = static_cast<blas::gemm_batch_type_t>(batch_type_i);
+
+  // The counters are double. We convert m, n, k and batch_count to double to
+  // avoid integer overflows for n_fl_ops and bytes_processed
+  const double m_d = static_cast<double>(m);
+  const double n_d = static_cast<double>(n);
+  const double batch_count_d = static_cast<double>(batch_count);
+  const double k_d = static_cast<double>(k);
+
+  state.counters["m"] = m_d;
+  state.counters["n"] = n_d;
+  state.counters["batch_count"] = batch_count_d;
+
+  {
+    const double mem_readA = k_d * (k_d + 1) / 2;
+    const double mem_readBwriteB = 2 * m_d * n_d;
+    const double total_mem =
+        ((mem_readA + mem_readBwriteB) * sizeof(scalar_t)) * batch_count;
+    state.counters["bytes_processed"] = total_mem;
+  }
+
+  const double nflops_AtimesB =
+      2 * k_d * (k_d + 1) / 2 * (side == 'l' ? n_d : m_d);
+  const double nflops_timesAlpha = m_d * n_d;
+  const double nflops_tot = (nflops_AtimesB + nflops_timesAlpha) * batch_count;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  cublasHandle_t& cuda_handle = *cuda_handle_ptr;
+
+  const int a_m_size = (side == 'l') ? lda * m : lda * n;
+
+  // Matrices
+  std::vector<scalar_t> a(a_m_size * batch_count);
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(ldb * n * batch_count);
+
+  {
+    auto copy_vector = [&a, a_m_size](std::vector<scalar_t>& v,
+                                      const int curr_batch) -> void {
+      for (int i = 0; i < a_m_size; ++i) {
+        a[curr_batch * a_m_size + i] = v[i];
+      }
+      return;
+    };
+
+    std::vector<scalar_t> temp_a(a_m_size);
+    for (int i = 0; i < batch_count; ++i) {
+      const scalar_t diagValue =
+          diag == 'u' ? scalar_t{1}
+                      : blas_benchmark::utils::random_scalar<scalar_t>(
+                            scalar_t{1}, scalar_t{10});
+
+      blas_benchmark::utils::fill_trsm_matrix(temp_a, (a_m_size / lda), lda,
+                                              uplo, diagValue, scalar_t{0});
+
+      copy_vector(temp_a, i);
+      temp_a.clear();
+    }
+  }
+
+  blas_benchmark::utils::CUDAVectorBatched<scalar_t> d_A_array(a_m_size,
+                                                               batch_count, a);
+  blas_benchmark::utils::CUDAVectorBatched<scalar_t> d_B_array(ldb * n,
+                                                               batch_count, b);
+
+  cublasSideMode_t c_side =
+      (side == 'l') ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
+
+  cublasOperation_t c_t = (t == 'n') ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+  cublasFillMode_t c_uplo =
+      (uplo == 'u') ? CUBLAS_FILL_MODE_UPPER : CUBLAS_FILL_MODE_LOWER;
+
+  cublasDiagType_t c_diag =
+      (diag == 'n') ? CUBLAS_DIAG_NON_UNIT : CUBLAS_DIAG_UNIT;
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run once verifying the results against the reference blas implementation.
+  {
+    std::vector<scalar_t> x_ref = b;
+    std::vector<scalar_t> b_temp = b;
+    auto _base = [=](index_t dim0, index_t dim1, index_t idx) {
+      return dim0 * dim1 * idx;
+    };
+    for (int batch_idx = 0; batch_idx < batch_count; batch_idx++) {
+      reference_blas::trsm(&side, &uplo, &t, &diag, m, n,
+                           static_cast<scalar_t>(alpha),
+                           a.data() + _base(lda, a_m_size / lda, batch_idx),
+                           lda, x_ref.data() + _base(m, n, batch_idx), ldb);
+    }
+
+    if (batch_type == blas::gemm_batch_type_t::interleaved) {
+      constexpr int offset = 0;
+      a = strided_to_interleaved(a, offset, lda, t == 't' ? m : n, batch_count);
+      b = strided_to_interleaved(b, offset, ldb, n, batch_count);
+    }
+
+    {
+      blas_benchmark::utils::CUDAVectorBatched<scalar_t, true> b_temp_gpu(
+          n * m, batch_count, b_temp);
+      cublas_routine<scalar_t>(cuda_handle, c_side, c_uplo, c_t, c_diag, m, n,
+                               &alpha, d_A_array.get_batch_array(), lda,
+                               b_temp_gpu.get_batch_array(), ldb, batch_count);
+    }
+
+    if (batch_type == blas::gemm_batch_type_t::interleaved) {
+      constexpr int offset = 0;
+      b_temp = interleaved_to_strided(b_temp, offset, ldb, n, batch_count);
+    }
+    std::ostringstream err_stream;
+    for (int i = 0; i < batch_count; ++i) {
+      if (!utils::compare_vectors(b_temp, x_ref, err_stream, "")) {
+        const std::string& err_str = err_stream.str();
+        state.SkipWithError(err_str.c_str());
+        *success = false;
+      };
+    }
+
+  }  // close scope for verify benchmark
+#endif
+
+  auto blas_warmup = [&]() -> void {
+    cublas_routine<scalar_t>(cuda_handle, c_side, c_uplo, c_t, c_diag, m, n,
+                             &alpha, d_A_array.get_batch_array(), lda,
+                             d_B_array.get_batch_array(), ldb, batch_count);
+    return;
+  };
+
+  cudaEvent_t start, stop;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
+
+  auto blas_method_def = [&]() -> std::vector<cudaEvent_t> {
+    CUDA_CHECK(cudaEventRecord(start));
+    cublas_routine<scalar_t>(cuda_handle, c_side, c_uplo, c_t, c_diag, m, n,
+                             &alpha, d_A_array.get_batch_array(), lda,
+                             d_B_array.get_batch_array(), ldb, batch_count);
+    CUDA_CHECK(cudaEventRecord(stop));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    return std::vector{start, stop};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+  CUDA_CHECK(cudaStreamSynchronize(NULL));
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef_cuda(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        cublasHandle_t* cuda_handle_ptr, bool* success) {
+  auto trsm_params =
+      blas_benchmark::utils::get_trsm_batched_params<scalar_t>(args);
+
+  for (auto p : trsm_params) {
+    char s_side, s_uplo, s_t, s_diag;
+    index_t m, n, batch_count;
+    scalar_t alpha;
+    int batch_type;
+    std::tie(s_side, s_uplo, s_t, s_diag, m, n, alpha, batch_count,
+             batch_type) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
+                         char side, char uplo, char t, char diag, index_t m,
+                         index_t n, scalar_t alpha, index_t batch_count,
+                         int batch_type, bool* success) {
+      run<scalar_t>(st, cuda_handle_ptr, side, uplo, t, diag, m, n, alpha,
+                    batch_count, batch_type, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(s_side, s_uplo, s_t, s_diag, m, n, batch_count,
+                           batch_type)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, s_side, s_uplo, s_t, s_diag, m, n, alpha,
+        batch_count, batch_type, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      cublasHandle_t* cuda_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, cuda_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/cublas/utils.hpp
+++ b/benchmark/cublas/utils.hpp
@@ -1,7 +1,3 @@
-#include "blas_meta.h"
-#include <cstddef>
-#include <numeric>
-#include <vector>
 #/***************************************************************************
 # *
 # *  @license

--- a/benchmark/cublas/utils.hpp
+++ b/benchmark/cublas/utils.hpp
@@ -1,3 +1,7 @@
+#include "blas_meta.h"
+#include <cstddef>
+#include <numeric>
+#include <vector>
 #/***************************************************************************
 # *
 # *  @license
@@ -161,6 +165,62 @@ class CUDAVector : private CUDADeviceMemory<T> {
  private:
   T* d_data_;
   T* h_data_ = nullptr;
+};
+
+template <typename T, bool CopyToHost = false>
+class CUDAVectorBatched : private CUDADeviceMemory<T> {
+ public:
+  explicit CUDAVectorBatched(size_t matrix_size, size_t batch_count)
+      : CUDADeviceMemory<T>(matrix_size),
+        c_batch_count(batch_count),
+        c_matrix_size(matrix_size) {
+    d_data = std::vector<T*>(batch_count, nullptr);
+    for (int i = 0; i < batch_count; ++i) {
+      CUDA_CHECK(cudaMalloc(&d_data[i], sizeof(T) * matrix_size));
+    }
+    CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&batch_Array),
+                          sizeof(T*) * batch_count));
+    CUDA_CHECK(cudaMemcpy(batch_Array, d_data.data(), sizeof(T*) * batch_count,
+                          cudaMemcpyHostToDevice));
+  }
+
+  CUDAVectorBatched(size_t matrix_size, size_t batch_count, std::vector<T>& h_v)
+      : CUDAVectorBatched<T, CopyToHost>(matrix_size, batch_count) {
+    if constexpr (CopyToHost) h_data = h_v.data();
+    for (int i = 0; i < batch_count; ++i) {
+      CUDA_CHECK(cudaMemcpy(d_data[i], &h_v[matrix_size * i],
+                            sizeof(T) * c_matrix_size, cudaMemcpyHostToDevice));
+    }
+  }
+
+  ~CUDAVectorBatched() {
+    if constexpr (CopyToHost) {
+      for (int i = 0; i < c_batch_count; ++i) {
+        this->copyD2H(d_data[i], (h_data + c_matrix_size * i));
+      }
+    }
+    for (int i = 0; i < c_batch_count; ++i) {
+      this->free(d_data[i]);
+    }
+    free_batch_dpointer(batch_Array);
+  }
+
+  T** get_batch_array() const { return batch_Array; }
+
+  // Disallow copying or assigning
+  CUDAVectorBatched(const CUDAVectorBatched&) = delete;
+  CUDAVectorBatched& operator=(const CUDAVectorBatched&) = delete;
+
+ private:
+  const int c_matrix_size;
+  const int c_batch_count;
+  T** batch_Array;
+  std::vector<T*> d_data;
+  T* h_data = nullptr;
+
+  void free_batch_dpointer(T** batch_pointer) {
+    if (batch_pointer != nullptr) CUDA_CHECK(cudaFree(batch_pointer));
+  }
 };
 
 // Pseudo-scalar subclass which uses device memory

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -521,8 +521,8 @@ static inline std::vector<symm_param_t<scalar_t>> get_symm_params(Args& args) {
       for (char uplo : {'u', 'l'}) {
         for (index_t m = dmin; m <= dmax; m *= 2) {
           for (index_t n = dmin; n <= dmax; n *= 2) {
-              symm_default.push_back(
-                  std::make_tuple(side, uplo, m, n, alpha, beta));
+            symm_default.push_back(
+                std::make_tuple(side, uplo, m, n, alpha, beta));
           }
         }
       }
@@ -1006,24 +1006,6 @@ static inline void fill_trsm_matrix(std::vector<scalar_t>& A, size_t k,
       A[i + j * lda] = value;
     }
   }
-}
-
-/**
- * @breif Fills fully a symmetrical matrix suitable for testing
- * @param M The matrix to fill. Size must be at least lda * lda
- * @param lda The leading dimension of matrix @p M
- */
-template <typename scalar_t>
-static inline void fill_sym_matrix(std::vector<scalar_t>& m, const int n) {
-  const int lda = n;
-  for (int col = 0; col < n; ++col) {
-    for (int row = 0; row < n; ++row) {
-      // arbitrary number to have a variety of number
-      m[col * lda + row] = random_scalar(scalar_t{-5}, scalar_t{5});
-      m[row * lda + col] = random_scalar(scalar_t{-5}, scalar_t{5});
-    }
-  }
-  return;
 }
 
 /**

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -533,7 +533,7 @@ static inline std::vector<symm_param_t<scalar_t>> get_symm_params(Args& args) {
         args.csv_param, [&](std::vector<std::string>& v) {
           if (v.size() != 6) {
             throw std::runtime_error(
-                "invalid number of parameters (7 expected)");
+                "invalid number of parameters (6 expected)");
           }
           try {
             return std::make_tuple(v[0][0], v[1][0], str_to_int<index_t>(v[2]),

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -577,7 +577,7 @@ static inline std::vector<syrk_param_t<scalar_t>> get_syrk_params(Args& args) {
         args.csv_param, [&](std::vector<std::string>& v) {
           if (v.size() != 6) {
             throw std::runtime_error(
-                "invalid number of parameters (7 expected)");
+                "invalid number of parameters (6 expected)");
           }
           try {
             return std::make_tuple(v[0][0], v[1][0], str_to_int<index_t>(v[2]),

--- a/common/include/common/system_reference_blas.hpp
+++ b/common/include/common/system_reference_blas.hpp
@@ -396,6 +396,32 @@ void trmm(const char *side, const char *uplo, const char *trans,
        c_diag(*diag), m, n, alpha, A, lda, B, ldb);
 }
 
+template <typename scalar_t>
+void symm(const char *side, const char *uplo, int m, int n, scalar_t alpha,
+          const scalar_t a[], int lda, const scalar_t b[], int ldb,
+          scalar_t beta, scalar_t c[], int ldc) {
+  auto func = blas_system_function<scalar_t>(&cblas_ssymm, &cblas_dsymm);
+  func(CblasColMajor, c_side(*side), c_uplo(*uplo), m, n, alpha, a, lda, b, ldb,
+       beta, c, ldc);
+}
+
+template <typename scalar_t>
+void syrk(const char *uplo, const char *trans, int n, int k, scalar_t alpha,
+          const scalar_t a[], int lda, scalar_t beta, scalar_t c[], int ldc) {
+  auto func = blas_system_function<scalar_t>(&cblas_ssyrk, &cblas_dsyrk);
+  func(CblasColMajor, c_uplo(*uplo), c_trans(*trans), n, k, alpha, a, lda, beta,
+       c, ldc);
+}
+
+template <typename scalar_t>
+void syr2k(const char *uplo, const char *trans, int n, int k, scalar_t alpha,
+           const scalar_t a[], int lda, const scalar_t b[], int ldb,
+           scalar_t beta, scalar_t c[], int ldc) {
+  auto func = blas_system_function<scalar_t>(&cblas_ssyr2k, &cblas_dsyr2k);
+  func(CblasColMajor, c_uplo(*uplo), c_trans(*trans), n, k, alpha, a, lda, b,
+       ldb, beta, c, ldc);
+}
+
 }  // namespace reference_blas
 
 #endif /* end of include guard: SYSTEM_REFERENCE_BLAS_HPP */

--- a/common/include/common/system_reference_blas.hpp
+++ b/common/include/common/system_reference_blas.hpp
@@ -387,6 +387,15 @@ void trsm(const char *side, const char *uplo, const char *trans,
        c_diag(*diag), m, n, alpha, A, lda, B, ldb);
 }
 
+template <typename scalar_t>
+void trmm(const char *side, const char *uplo, const char *trans,
+          const char *diag, int m, int n, scalar_t alpha, const scalar_t A[],
+          int lda, scalar_t B[], int ldb) {
+  auto func = blas_system_function<scalar_t>(&cblas_strmm, &cblas_dtrmm);
+  func(CblasColMajor, c_side(*side), c_uplo(*uplo), c_trans(*trans),
+       c_diag(*diag), m, n, alpha, A, lda, B, ldb);
+}
+
 }  // namespace reference_blas
 
 #endif /* end of include guard: SYSTEM_REFERENCE_BLAS_HPP */


### PR DESCRIPTION
This PR adds all the cuBLAS benchmarks for the available level 3 operators.

List of operators added:

- gemm
- gemm_batched
- gemm_batched_strided
- symm
- syrk
- syr2k
- trmm
- trsm
- trsm_batched
