### PR TITLE
Adding USM support for Level 3 operators in SYCL-BLAS

### DIFF
--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -54,11 +54,11 @@ set(sources
   blas2/trsv.cpp
   blas2/tbsv.cpp
   # Level 3 blas
-  # blas3/gemm.cpp
-  # blas3/gemm_batched.cpp
-  # blas3/gemm_batched_strided.cpp
-  # blas3/trsm.cpp
-  # blas3/symm.cpp
+  blas3/gemm.cpp
+  blas3/gemm_batched.cpp
+  blas3/gemm_batched_strided.cpp
+  blas3/trsm.cpp
+  blas3/symm.cpp
 )
 
 if(${BLAS_ENABLE_EXTENSIONS})

--- a/benchmark/syclblas/blas3/gemm_batched.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched.cpp
@@ -61,16 +61,17 @@ std::vector<scalar_t> interleaved_to_strided(const std::vector<scalar_t>& input,
 
 template <typename scalar_t>
 std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int batch_type) {
+                     int batch_size, int batch_type, std::string mem_type) {
   std::ostringstream str{};
   str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
       << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
       << batch_size << "/"
       << blas_benchmark::utils::batch_type_to_str(batch_type);
+  str << "/" << mem_type;
   return str.str();
 }
 
-template <typename scalar_t>
+template <typename scalar_t, blas::helper::AllocType mem_alloc>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
          int t2, index_t m, index_t k, index_t n, scalar_t alpha, scalar_t beta,
          index_t batch_size, int batch_type_i, bool* success) {
@@ -92,6 +93,7 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
       state, beta, m, n, k, batch_size);
 
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
+  auto q = sb_handle.get_queue();
 
   // Matrices
   std::vector<scalar_t> a =
@@ -124,19 +126,39 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
   }
 #endif
 
-  auto a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(a, m * k * batch_size);
-  auto b_gpu = blas::make_sycl_iterator_buffer<scalar_t>(b, k * n * batch_size);
-  auto c_gpu = blas::make_sycl_iterator_buffer<scalar_t>(c, m * n * batch_size);
+  auto a_gpu =
+      blas::helper::allocate<mem_alloc, scalar_t>(m * k * batch_size, q);
+  auto b_gpu =
+      blas::helper::allocate<mem_alloc, scalar_t>(k * n * batch_size, q);
+  auto c_gpu =
+      blas::helper::allocate<mem_alloc, scalar_t>(m * n * batch_size, q);
+
+  auto copy_a = blas::helper::copy_to_device<scalar_t>(q, a.data(), a_gpu,
+                                                       m * k * batch_size);
+  auto copy_b = blas::helper::copy_to_device<scalar_t>(q, b.data(), b_gpu,
+                                                       n * k * batch_size);
+  auto copy_c = blas::helper::copy_to_device<scalar_t>(q, c.data(), c_gpu,
+                                                       m * n * batch_size);
+
+  sb_handle.wait({copy_a, copy_b, copy_c});
 
 #ifdef BLAS_VERIFY_BENCHMARK
   std::vector<scalar_t> c_temp = c;
   {
     auto c_temp_gpu =
-        blas::make_sycl_iterator_buffer<scalar_t>(c_temp, m * n * batch_size);
-    auto event =
+        blas::helper::allocate<mem_alloc, scalar_t>(m * n * batch_size, q);
+    auto copy_temp = blas::helper::copy_to_device<scalar_t>(
+        q, c_temp.data(), c_temp_gpu, m * n * batch_size);
+    sb_handle.wait(copy_temp);
+    auto gemm_batched_event =
         _gemm_batched(sb_handle, *t_a, *t_b, m, n, k, alpha, a_gpu, lda, b_gpu,
                       ldb, beta, c_temp_gpu, ldc, batch_size, batch_type);
-    sb_handle.wait(event);
+    sb_handle.wait(gemm_batched_event);
+    auto copy_out = blas::helper::copy_to_host<scalar_t>(
+        q, c_temp_gpu, c_temp.data(), m * n * batch_size);
+    sb_handle.wait(copy_out);
+
+    blas::helper::deallocate<mem_alloc>(c_temp_gpu, q);
   }
   if (batch_type == blas::gemm_batch_type_t::interleaved) {
     constexpr int offset = 0;
@@ -180,15 +202,17 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
                           state.counters["bytes_processed"]);
 
   blas_benchmark::utils::calc_avg_counters(state);
+
+  blas::helper::deallocate<mem_alloc>(a_gpu, q);
+  blas::helper::deallocate<mem_alloc>(b_gpu, q);
+  blas::helper::deallocate<mem_alloc>(c_gpu, q);
 };
 
-template <typename scalar_t>
-void register_benchmark(blas_benchmark::Args& args,
-                        blas::SB_Handle* sb_handle_ptr, bool* success) {
-  auto gemm_params =
-      blas_benchmark::utils::get_gemm_batched_params<scalar_t>(args);
-
-  for (auto p : gemm_params) {
+template <typename scalar_t, blas::helper::AllocType mem_alloc>
+void register_benchmark(blas::SB_Handle* sb_handle_ptr, bool* success,
+                        std::string mem_type,
+                        std::vector<gemm_batched_param_t<scalar_t>> params) {
+  for (auto p : params) {
     std::string t1s, t2s;
     index_t m, n, k, batch_size;
     scalar_t alpha, beta;
@@ -201,15 +225,29 @@ void register_benchmark(blas_benchmark::Args& args,
                          int t1, int t2, index_t m, index_t k, index_t n,
                          scalar_t alpha, scalar_t beta, index_t batch_size,
                          int batch_type, bool* success) {
-      run<scalar_t>(st, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
-                    batch_type, success);
+      run<scalar_t, mem_alloc>(st, sb_handle_ptr, t1, t2, m, k, n, alpha, beta,
+                               batch_size, batch_type, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, batch_type).c_str(),
+        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, batch_type, mem_type)
+            .c_str(),
         BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         batch_type, success)
         ->UseRealTime();
   }
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        blas::SB_Handle* sb_handle_ptr, bool* success) {
+  auto gemm_batched_params =
+      blas_benchmark::utils::get_gemm_batched_params<scalar_t>(args);
+  register_benchmark<scalar_t, blas::helper::AllocType::buffer>(
+      sb_handle_ptr, success, "buffer", gemm_batched_params);
+#ifdef SB_ENABLE_USM
+  register_benchmark<scalar_t, blas::helper::AllocType::usm>(
+      sb_handle_ptr, success, "usm", gemm_batched_params);
+#endif
 }
 
 namespace blas_benchmark {

--- a/benchmark/syclblas/blas3/symm.cpp
+++ b/benchmark/syclblas/blas3/symm.cpp
@@ -26,14 +26,15 @@
 #include "../utils.hpp"
 
 template <typename scalar_t>
-std::string get_name(char side, char uplo, int m, int n) {
+std::string get_name(char side, char uplo, int m, int n, std::string mem_type) {
   std::ostringstream str{};
   str << "BM_Symm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
       << side << "/" << uplo << "/" << m << "/" << n;
+  str << "/" << mem_type;
   return str.str();
 }
 
-template <typename scalar_t>
+template <typename scalar_t, blas::helper::AllocType mem_alloc>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char side,
          char uplo, index_t m, index_t n, scalar_t alpha, scalar_t beta,
          bool* success) {
@@ -48,6 +49,7 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char side,
                                                        side);
 
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
+  auto q = sb_handle.get_queue();
 
   // Matrices
   std::vector<scalar_t> a = blas_benchmark::utils::random_data<scalar_t>(k * k);
@@ -55,9 +57,18 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char side,
   std::vector<scalar_t> c =
       blas_benchmark::utils::const_data<scalar_t>(m * n, 0);
 
-  auto a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(a, k * k);
-  auto b_gpu = blas::make_sycl_iterator_buffer<scalar_t>(b, m * n);
-  auto c_gpu = blas::make_sycl_iterator_buffer<scalar_t>(c, m * n);
+  auto a_gpu = blas::helper::allocate<mem_alloc, scalar_t>(k * k, q);
+  auto b_gpu = blas::helper::allocate<mem_alloc, scalar_t>(m * n, q);
+  auto c_gpu = blas::helper::allocate<mem_alloc, scalar_t>(m * n, q);
+
+  auto copy_a =
+      blas::helper::copy_to_device<scalar_t>(q, a.data(), a_gpu, k * k);
+  auto copy_b =
+      blas::helper::copy_to_device<scalar_t>(q, b.data(), b_gpu, n * m);
+  auto copy_c =
+      blas::helper::copy_to_device<scalar_t>(q, c.data(), c_gpu, m * n);
+
+  sb_handle.wait({copy_a, copy_b, copy_c});
 
 #ifdef BLAS_VERIFY_BENCHMARK
   // Run a first time with a verification of the results
@@ -68,10 +79,18 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char side,
                        ldb, beta, c_ref.data(), ldc);
   std::vector<scalar_t> c_temp = c;
   {
-    auto c_temp_gpu = blas::make_sycl_iterator_buffer<scalar_t>(c_temp, m * n);
-    auto event = _symm(sb_handle, side, uplo, m, n, alpha, a_gpu, lda, b_gpu,
-                       ldb, beta, c_temp_gpu, ldc);
-    sb_handle.wait(event);
+    auto c_temp_gpu = blas::helper::allocate<mem_alloc, scalar_t>(m * n, q);
+    auto copy_temp = blas::helper::copy_to_device<scalar_t>(q, c_temp.data(),
+                                                            c_temp_gpu, m * n);
+    sb_handle.wait(copy_temp);
+    auto symm_event = _symm(sb_handle, side, uplo, m, n, alpha, a_gpu, lda,
+                            b_gpu, ldb, beta, c_temp_gpu, ldc);
+    sb_handle.wait(symm_event);
+    auto copy_out = blas::helper::copy_to_host<scalar_t>(q, c_temp_gpu,
+                                                         c_temp.data(), m * n);
+    sb_handle.wait(copy_out);
+
+    blas::helper::deallocate<mem_alloc>(c_temp_gpu, q);
   }
 
   std::ostringstream err_stream;
@@ -110,14 +129,17 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char side,
                           state.counters["bytes_processed"]);
 
   blas_benchmark::utils::calc_avg_counters(state);
+
+  blas::helper::deallocate<mem_alloc>(a_gpu, q);
+  blas::helper::deallocate<mem_alloc>(b_gpu, q);
+  blas::helper::deallocate<mem_alloc>(c_gpu, q);
 };
 
-template <typename scalar_t>
-void register_benchmark(blas_benchmark::Args& args,
-                        blas::SB_Handle* sb_handle_ptr, bool* success) {
-  auto symm_params = blas_benchmark::utils::get_symm_params<scalar_t>(args);
-
-  for (auto p : symm_params) {
+template <typename scalar_t, blas::helper::AllocType mem_alloc>
+void register_benchmark(blas::SB_Handle* sb_handle_ptr, bool* success,
+                        std::string mem_type,
+                        std::vector<symm_param_t<scalar_t>> params) {
+  for (auto p : params) {
     char side, uplo;
     index_t m, n;
     scalar_t alpha, beta;
@@ -126,13 +148,27 @@ void register_benchmark(blas_benchmark::Args& args,
     auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
                          char side, char uplo, index_t m, index_t n,
                          scalar_t alpha, scalar_t beta, bool* success) {
-      run<scalar_t>(st, sb_handle_ptr, side, uplo, m, n, alpha, beta, success);
+      run<scalar_t, mem_alloc>(st, sb_handle_ptr, side, uplo, m, n, alpha, beta,
+                               success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(side, uplo, m, n).c_str(),
-                                 BM_lambda, sb_handle_ptr, side, uplo, m, n,
-                                 alpha, beta, success)
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(side, uplo, m, n, mem_type).c_str(), BM_lambda,
+        sb_handle_ptr, side, uplo, m, n, alpha, beta, success)
         ->UseRealTime();
   }
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        blas::SB_Handle* sb_handle_ptr, bool* success) {
+  auto symm_params = blas_benchmark::utils::get_symm_params<scalar_t>(args);
+
+  register_benchmark<scalar_t, blas::helper::AllocType::buffer>(
+      sb_handle_ptr, success, "buffer", symm_params);
+#ifdef SB_ENABLE_USM
+  register_benchmark<scalar_t, blas::helper::AllocType::usm>(
+      sb_handle_ptr, success, "usm", symm_params);
+#endif
 }
 
 namespace blas_benchmark {

--- a/include/interface/blas3_interface.h
+++ b/include/interface/blas3_interface.h
@@ -40,13 +40,11 @@ namespace internal {
  */
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename container_2_t, typename element_t, typename index_t>
-typename sb_handle_t::event_t _gemm(sb_handle_t& sb_handle, char _TransA,
-                                    char _TransB, index_t _M, index_t _N,
-                                    index_t _K, element_t _alpha,
-                                    container_0_t a_, index_t _lda,
-                                    container_1_t b_, index_t _ldb,
-                                    element_t _beta, container_2_t _C,
-                                    index_t _ldc);
+typename sb_handle_t::event_t _gemm(
+    sb_handle_t& sb_handle, char _TransA, char _TransB, index_t _M, index_t _N,
+    index_t _K, element_t _alpha, container_0_t a_, index_t _lda,
+    container_1_t b_, index_t _ldb, element_t _beta, container_2_t _C,
+    index_t _ldc, const typename sb_handle_t::event_t& _dependencies);
 
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename container_2_t, typename element_t, typename index_t>
@@ -55,7 +53,8 @@ typename sb_handle_t::event_t _gemm_batched(
     index_t _K, element_t _alpha, container_0_t a_, index_t _lda,
     container_1_t b_, index_t _ldb, element_t _beta, container_2_t _C,
     index_t _ldc, index_t batch_size,
-    gemm_batch_type_t batch_type = gemm_batch_type_t::strided);
+    gemm_batch_type_t batch_type = gemm_batch_type_t::strided,
+    const typename sb_handle_t::event_t& _dependencies = {});
 
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename container_2_t, typename element_t, typename index_t>
@@ -64,37 +63,35 @@ typename sb_handle_t::event_t _gemm_strided_batched(
     index_t _K, element_t _alpha, container_0_t a_, index_t _lda,
     index_t _stridea, container_1_t b_, index_t _ldb, index_t _strideb,
     element_t _beta, container_2_t _C, index_t _ldc, index_t _stridec,
-    index_t batch_size);
+    index_t batch_size, const typename sb_handle_t::event_t& _dependencies);
 
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename element_t, typename index_t>
-typename sb_handle_t::event_t _trsm(sb_handle_t& sb_handle, char side,
-                                    char uplo, char trans, char diag, index_t M,
-                                    index_t N, element_t alpha, container_0_t A,
-                                    index_t lda, container_1_t B, index_t ldb);
+typename sb_handle_t::event_t _trsm(
+    sb_handle_t& sb_handle, char side, char uplo, char trans, char diag,
+    index_t M, index_t N, element_t alpha, container_0_t A, index_t lda,
+    container_1_t B, index_t ldb,
+    const typename sb_handle_t::event_t& _dependencies);
 
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename container_2_t, typename element_t, typename index_t>
-typename sb_handle_t::event_t _symm(sb_handle_t& sb_handle, char _side,
-                                    char _uplo, index_t _M, index_t _N,
-                                    element_t _alpha, container_0_t a_,
-                                    index_t _lda, container_1_t b_,
-                                    index_t _ldb, element_t _beta,
-                                    container_2_t _C, index_t _ldc);
+typename sb_handle_t::event_t _symm(
+    sb_handle_t& sb_handle, char _side, char _uplo, index_t _M, index_t _N,
+    element_t _alpha, container_0_t a_, index_t _lda, container_1_t b_,
+    index_t _ldb, element_t _beta, container_2_t _C, index_t _ldc,
+    const typename sb_handle_t::event_t& _dependencies);
 
 }  // namespace internal
 
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename container_2_t, typename element_t, typename index_t>
-typename sb_handle_t::event_t _gemm(sb_handle_t& sb_handle, char _TransA,
-                                    char _TransB, index_t _M, index_t _N,
-                                    index_t _K, element_t _alpha,
-                                    container_0_t a_, index_t _lda,
-                                    container_1_t b_, index_t _ldb,
-                                    element_t _beta, container_2_t _C,
-                                    index_t _ldc) {
+typename sb_handle_t::event_t _gemm(
+    sb_handle_t& sb_handle, char _TransA, char _TransB, index_t _M, index_t _N,
+    index_t _K, element_t _alpha, container_0_t a_, index_t _lda,
+    container_1_t b_, index_t _ldb, element_t _beta, container_2_t _C,
+    index_t _ldc, const typename sb_handle_t::event_t& _dependencies = {}) {
   return internal::_gemm(sb_handle, _TransA, _TransB, _M, _N, _K, _alpha, a_,
-                         _lda, b_, _ldb, _beta, _C, _ldc);
+                         _lda, b_, _ldb, _beta, _C, _ldc, _dependencies);
 }
 
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
@@ -104,10 +101,11 @@ typename sb_handle_t::event_t _gemm_batched(
     index_t _K, element_t _alpha, container_0_t a_, index_t _lda,
     container_1_t b_, index_t _ldb, element_t _beta, container_2_t _C,
     index_t _ldc, index_t batch_size,
-    gemm_batch_type_t batch_type = gemm_batch_type_t::strided) {
+    gemm_batch_type_t batch_type = gemm_batch_type_t::strided,
+    const typename sb_handle_t::event_t& _dependencies = {}) {
   return internal::_gemm_batched(sb_handle, _TransA, _TransB, _M, _N, _K,
                                  _alpha, a_, _lda, b_, _ldb, _beta, _C, _ldc,
-                                 batch_size, batch_type);
+                                 batch_size, batch_type, _dependencies);
 }
 
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
@@ -117,34 +115,33 @@ typename sb_handle_t::event_t _gemm_strided_batched(
     index_t _K, element_t _alpha, container_0_t a_, index_t _lda,
     index_t _stridea, container_1_t b_, index_t _ldb, index_t _strideb,
     element_t _beta, container_2_t _C, index_t _ldc, index_t _stridec,
-    index_t batch_size) {
+    index_t batch_size,
+    const typename sb_handle_t::event_t& _dependencies = {}) {
   return internal::_gemm_strided_batched(
       sb_handle, _TransA, _TransB, _M, _N, _K, _alpha, a_, _lda, _stridea, b_,
-      _ldb, _strideb, _beta, _C, _ldc, _stridec, batch_size);
+      _ldb, _strideb, _beta, _C, _ldc, _stridec, batch_size, _dependencies);
 }
 
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename element_t, typename index_t>
-typename sb_handle_t::event_t inline _trsm(sb_handle_t& sb_handle, char side,
-                                           char uplo, char trans, char diag,
-                                           index_t M, index_t N,
-                                           element_t alpha, container_0_t A,
-                                           index_t lda, container_1_t B,
-                                           index_t ldb) {
+typename sb_handle_t::event_t inline _trsm(
+    sb_handle_t& sb_handle, char side, char uplo, char trans, char diag,
+    index_t M, index_t N, element_t alpha, container_0_t A, index_t lda,
+    container_1_t B, index_t ldb,
+    const typename sb_handle_t::event_t& _dependencies = {}) {
   return internal::_trsm(sb_handle, side, uplo, trans, diag, M, N, alpha, A,
-                         lda, B, ldb);
+                         lda, B, ldb, _dependencies);
 }
 
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename container_2_t, typename element_t, typename index_t>
-typename sb_handle_t::event_t _symm(sb_handle_t& sb_handle, char _side,
-                                    char _uplo, index_t _M, index_t _N,
-                                    element_t _alpha, container_0_t a_,
-                                    index_t _lda, container_1_t b_,
-                                    index_t _ldb, element_t _beta,
-                                    container_2_t _C, index_t _ldc) {
+typename sb_handle_t::event_t _symm(
+    sb_handle_t& sb_handle, char _side, char _uplo, index_t _M, index_t _N,
+    element_t _alpha, container_0_t a_, index_t _lda, container_1_t b_,
+    index_t _ldb, element_t _beta, container_2_t _C, index_t _ldc,
+    const typename sb_handle_t::event_t& _dependencies = {}) {
   return internal::_symm(sb_handle, _side, _uplo, _M, _N, _alpha, a_, _lda, b_,
-                         _ldb, _beta, _C, _ldc);
+                         _ldb, _beta, _C, _ldc, _dependencies);
 }
 
 }  // namespace blas

--- a/include/interface/gemm_launcher.h
+++ b/include/interface/gemm_launcher.h
@@ -34,21 +34,21 @@ namespace blas {
 /*!
  * @brief Wrapper around Gemm. Creates the views, then makes and launches Gemm
  */
-template <int WgSize, bool DoubleBuffer, bool ConflictA, bool ConflictB,
-          int ClSize, typename TileT, bool TransA, bool TransB, bool SymmA,
-          bool SymmB, int GemmMemoryType, int GemmAlgorithm,
+template <typename container_0_t, typename container_1_t,
+          typename container_2_t, int WgSize, bool DoubleBuffer, bool ConflictA,
+          bool ConflictB, int ClSize, typename TileT, bool TransA, bool TransB,
+          bool SymmA, bool SymmB, int GemmMemoryType, int GemmAlgorithm,
           int GemmVectorization, bool is_beta_zero, int VectorSize,
           int BatchType = static_cast<int>(gemm_batch_type_t::strided),
           bool UseJointMatrix = false>
 struct Gemm_Launcher {
-  template <typename sb_handle_t, typename container_0_t,
-            typename container_1_t, typename container_2_t, typename element_t,
-            typename index_t>
+  template <typename sb_handle_t, typename element_t, typename index_t>
   static typename sb_handle_t::event_t _select_gemm(
       sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
       element_t _alpha, container_0_t a_, index_t _lda, index_t _stridea,
       container_1_t b_, index_t _ldb, index_t _strideb, element_t _beta,
-      container_2_t _C, index_t _ldc, index_t _stridec, index_t batch_size);
+      container_2_t _C, index_t _ldc, index_t _stridec, index_t batch_size,
+      const typename sb_handle_t::event_t& _dependencies = {});
 };
 
 }  // namespace blas

--- a/python_generator/py_gen_blas_gemm_launcher.py
+++ b/python_generator/py_gen_blas_gemm_launcher.py
@@ -72,6 +72,9 @@ if __name__ == '__main__':
     use_joint_matrix = sys.argv[37]
     symm_a = sys.argv[38]
     symm_b = sys.argv[39]
+    container0 = sys.argv[40]
+    container1 = sys.argv[41]
+    container2 = sys.argv[42]
     source = 'generated_src/' + blas_level_name + '/' + blas_function_name + '/'
     try:
         os.makedirs(source)
@@ -245,6 +248,21 @@ if __name__ == '__main__':
         Iterable(
             key='SYMM_B',
             vals=[symm_b],
+            itermode=Itermode.combinations,
+            iter_modifier=1),
+        Iterable(
+            key='container_t0',
+            vals=[container0],
+            itermode=Itermode.combinations,
+            iter_modifier=1),
+        Iterable(
+            key='container_t1',
+            vals=[container1],
+            itermode=Itermode.combinations,
+            iter_modifier=1),
+        Iterable(
+            key='container_t2',
+            vals=[container2],
             itermode=Itermode.combinations,
             iter_modifier=1)
     ]

--- a/src/interface/blas3/CMakeLists.txt
+++ b/src/interface/blas3/CMakeLists.txt
@@ -23,11 +23,11 @@
 # *
 # **************************************************************************/
 #blas3
-# generate_blas_gemm_objects(blas3 gemm_launcher)
-# generate_blas_ternary_objects(blas3 gemm)
-# generate_blas_ternary_objects(blas3 symm)
-# generate_blas_binary_objects(blas3 trsm)
+generate_blas_gemm_objects(blas3 gemm_launcher)
+generate_blas_ternary_objects(blas3 gemm)
+generate_blas_ternary_objects(blas3 symm)
+generate_blas_binary_objects(blas3 trsm)
 
-# if(BLAS_ENABLE_CONST_INPUT)
-#     generate_blas_ternary_objects(blas3 gemm_const)
-# endif()
+if(BLAS_ENABLE_CONST_INPUT)
+    generate_blas_ternary_objects(blas3 gemm_const)
+endif()

--- a/src/interface/blas3/backend/amd_gpu.hpp
+++ b/src/interface/blas3/backend/amd_gpu.hpp
@@ -38,19 +38,21 @@ typename sb_handle_t::event_t _gemm(
     element_t _alpha, container_0_t _a, index_t _lda, index_t _stridea,
     container_1_t _b, index_t _ldb, index_t _strideb, element_t _beta,
     container_2_t _c, index_t _ldc, index_t _stridec, index_t batch_size,
-    gemm_batch_type_t batch_type) {
+    gemm_batch_type_t batch_type,
+    const typename sb_handle_t::event_t& _dependencies) {
   static constexpr int ClSize = 64;
   static constexpr int tileWgSize = ClSize / sizeof(element_t);
   if (batch_type == gemm_batch_type_t::interleaved) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<4, 4, 4, 4, 1, 1, 1, 1, 4, 4>, _t_a,
-        _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::no_local),
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<4, 4, 4, 4, 1, 1, 1, 1, 4, 4>, _t_a, _t_b, s_a, s_b,
+        static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
         static_cast<int>(gemm_batch_type_t::interleaved)>::
         template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
                               _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size);
+                              batch_size, _dependencies);
   }
 /* Tall & Skinny matrices. */
 #ifdef GEMM_TALL_SKINNY_SUPPORT
@@ -58,83 +60,84 @@ typename sb_handle_t::event_t _gemm(
                           (_K > 1024 && _M <= 256 && _N <= 256))) {
     if (_M <= 16 && _N > 32) {
       return blas::Gemm_Launcher<
-          256, true, true, true, ClSize, Tile<1, 4, tileWgSize, tileWgSize>,
-          _t_a, _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
+          container_0_t, container_1_t, container_2_t, 256, true, true, true,
+          ClSize, Tile<1, 4, tileWgSize, tileWgSize>, _t_a, _t_b, s_a, s_b,
+          static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 2,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if (_M > 64 && _N <= 32) {
       return blas::Gemm_Launcher<
-          256, true, true, true, ClSize, Tile<4, 1, tileWgSize, tileWgSize>,
-          _t_a, _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
+          container_0_t, container_1_t, container_2_t, 256, true, true, true,
+          ClSize, Tile<4, 1, tileWgSize, tileWgSize>, _t_a, _t_b, s_a, s_b,
+          static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 2,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if (_M <= 16 || _N <= 16) {
       return blas::Gemm_Launcher<
-          256, true, true, true, ClSize, Tile<1, 1, tileWgSize, tileWgSize>,
-          _t_a, _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
+          container_0_t, container_1_t, container_2_t, 256, true, true, true,
+          ClSize, Tile<1, 1, tileWgSize, tileWgSize>, _t_a, _t_b, s_a, s_b,
+          static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 2,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if (_M <= 32 || _N <= 32) {
       return blas::Gemm_Launcher<
-          256, true, true, true, ClSize, Tile<2, 2, tileWgSize, tileWgSize>,
-          _t_a, _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
+          container_0_t, container_1_t, container_2_t, 256, true, true, true,
+          ClSize, Tile<2, 2, tileWgSize, tileWgSize>, _t_a, _t_b, s_a, s_b,
+          static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 2,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else {
       return blas::Gemm_Launcher<
-          256, true, true, true, ClSize, Tile<4, 4, tileWgSize, tileWgSize>,
-          _t_a, _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
+          container_0_t, container_1_t, container_2_t, 256, true, true, true,
+          ClSize, Tile<4, 4, tileWgSize, tileWgSize>, _t_a, _t_b, s_a, s_b,
+          static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 2,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     }
   } else
 #endif  // GEMM_TALL_SKINNY_SUPPORT
       if (_M * _N <= 65536) {
-        return blas::Gemm_Launcher<
-            256, false, false, false, ClSize,
-            Tile<1, 1, tileWgSize, tileWgSize>, _t_a, _t_b, s_a, s_b,
-            static_cast<int>(gemm_memory_t::local),
-            static_cast<int>(gemm_algorithm_t::standard),
-            static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-            static_cast<int>(gemm_batch_type_t::strided)>::
-            template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                  _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size);
+    return blas::Gemm_Launcher<
+        container_0_t, container_1_t, container_2_t, 256, false, false, false,
+        ClSize, Tile<1, 1, tileWgSize, tileWgSize>, _t_a, _t_b, s_a, s_b,
+        static_cast<int>(gemm_memory_t::local),
+        static_cast<int>(gemm_algorithm_t::standard),
+        static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                              batch_size, _dependencies);
   } else {
     return blas::Gemm_Launcher<
-        256, false, false, false, ClSize, Tile<4, 4, tileWgSize, tileWgSize>,
-        _t_a, _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
+        container_0_t, container_1_t, container_2_t, 256, false, false, false,
+        ClSize, Tile<4, 4, tileWgSize, tileWgSize>, _t_a, _t_b, s_a, s_b,
+        static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 2,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                _a, _lda,
-                                                                _stridea, _b,
-                                                                _ldb, _strideb,
-                                                                _beta, _c, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                              batch_size, _dependencies);
   }
 }
 }  // namespace backend

--- a/src/interface/blas3/backend/arm_gpu.hpp
+++ b/src/interface/blas3/backend/arm_gpu.hpp
@@ -37,302 +37,330 @@ typename sb_handle_t::event_t _gemm(
     element_t _alpha, container_0_t _a, index_t _lda, index_t _stridea,
     container_1_t _b, index_t _ldb, index_t _strideb, element_t _beta,
     container_2_t _c, index_t _ldc, index_t _stridec, index_t batch_size,
-    gemm_batch_type_t batch_type) {
+    gemm_batch_type_t batch_type,
+    const typename sb_handle_t::event_t& _dependencies) {
   if (batch_type == gemm_batch_type_t::interleaved) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<2, 2, 4, 4, 1, 1, 1, 1, 4, 4>, _t_a,
-        _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::no_local),
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<2, 2, 4, 4, 1, 1, 1, 1, 4, 4>, _t_a, _t_b, s_a, s_b,
+        static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 2,
         static_cast<int>(gemm_batch_type_t::interleaved)>::
         template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
                               _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size);
+                              batch_size, _dependencies);
   } else {
 #if defined MODEL_RESNET_50
     if (batch_size == 36 && _M == 128 && _K == 128 && _N == 784) {
       if (!_t_b) {
         return blas::Gemm_Launcher<
-            64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+            container_0_t, container_1_t, container_2_t, 64, false, false,
+            false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
             static_cast<int>(gemm_memory_t::no_local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 2,
             static_cast<int>(gemm_batch_type_t::strided)>::
             template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                   _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size);
+                                  _stridec, batch_size, _dependencies);
       } else {
         return blas::Gemm_Launcher<
-            32, false, false, false, 64, Tile<4, 8, 8, 4>, _t_a, _t_b, s_a, s_b,
+            container_0_t, container_1_t, container_2_t, 32, false, false,
+            false, 64, Tile<4, 8, 8, 4>, _t_a, _t_b, s_a, s_b,
             static_cast<int>(gemm_memory_t::no_local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
             static_cast<int>(gemm_batch_type_t::strided)>::
             template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                   _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size);
+                                  _stridec, batch_size, _dependencies);
       }
     } else if (batch_size == 36 && _M == 128 && _K == 128 && _N == 49) {
       if (!_t_b) {
         return blas::Gemm_Launcher<
-            32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
+            container_0_t, container_1_t, container_2_t, 32, false, false,
+            false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
             static_cast<int>(gemm_memory_t::no_local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
             static_cast<int>(gemm_batch_type_t::strided)>::
             template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                   _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size);
+                                  _stridec, batch_size, _dependencies);
       } else {
         return blas::Gemm_Launcher<
-            32, false, false, false, 64, Tile<4, 8, 8, 4>, _t_a, _t_b, s_a, s_b,
+            container_0_t, container_1_t, container_2_t, 32, false, false,
+            false, 64, Tile<4, 8, 8, 4>, _t_a, _t_b, s_a, s_b,
             static_cast<int>(gemm_memory_t::no_local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
             static_cast<int>(gemm_batch_type_t::strided)>::
             template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                   _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size);
+                                  _stridec, batch_size, _dependencies);
       }
     } else if (batch_size == 36 && _M == 64 && _K == 64 && _N == 196) {
       if (!_t_b) {
         return blas::Gemm_Launcher<
-            64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+            container_0_t, container_1_t, container_2_t, 64, false, false,
+            false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
             static_cast<int>(gemm_memory_t::no_local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
             static_cast<int>(gemm_batch_type_t::strided)>::
             template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                   _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size);
+                                  _stridec, batch_size, _dependencies);
         return blas::Gemm_Launcher<
-            32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
+            container_0_t, container_1_t, container_2_t, 32, false, false,
+            false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
             static_cast<int>(gemm_memory_t::no_local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 1,
             static_cast<int>(gemm_batch_type_t::strided)>::
             template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                   _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size);
+                                  _stridec, batch_size, _dependencies);
       }
     } else if (batch_size == 16 && _M == 256 && _K == 256 && _N == 49) {
       if (!_t_b) {
         return blas::Gemm_Launcher<
-            16, false, false, false, 64, Tile<4, 4, 4, 4>, _t_a, _t_b, s_a, s_b,
+            container_0_t, container_1_t, container_2_t, 16, false, false,
+            false, 64, Tile<4, 4, 4, 4>, _t_a, _t_b, s_a, s_b,
             static_cast<int>(gemm_memory_t::no_local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 1,
             static_cast<int>(gemm_batch_type_t::strided)>::
             template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                   _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size);
+                                  _stridec, batch_size, _dependencies);
       } else {
         return blas::Gemm_Launcher<
-            16, false, false, false, 64, Tile<4, 4, 4, 4>, _t_a, _t_b, s_a, s_b,
+            container_0_t, container_1_t, container_2_t, 16, false, false,
+            false, 64, Tile<4, 4, 4, 4>, _t_a, _t_b, s_a, s_b,
             static_cast<int>(gemm_memory_t::no_local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
             static_cast<int>(gemm_batch_type_t::strided)>::
             template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                   _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size);
+                                  _stridec, batch_size, _dependencies);
       }
     }
     /* Tends to perform well for Winograd sizes (i.e. batched) */
     else if (batch_size > 1 && !_t_a) {
       return blas::Gemm_Launcher<
-          64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 64, false, false, false,
+          64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 2,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if ((_M == 64 && _K == 576 && _N == 12544)) {
       return blas::Gemm_Launcher<
-          64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 64, false, false, false,
+          64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if ((_M == 1024 && _K == 512 && _N == 3136) ||
                (_M == 256 && _K == 2304 && _N == 784)) {
       return blas::Gemm_Launcher<
-          32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 32, false, false, false,
+          64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if ((_M == 2048 && _K == 1024 && _N == 784) ||
                (_M == 512 && _K == 1024 && _N == 784) ||
                (_M == 2048 && _K == 512 && _N == 784)) {
       return blas::Gemm_Launcher<
-          32, false, false, false, 64, Tile<4, 8, 8, 4>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 32, false, false, false,
+          64, Tile<4, 8, 8, 4>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if ((_M == 512 && _K == 2048 && _N == 784)) {
       return blas::Gemm_Launcher<
-          64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 64, false, false, false,
+          64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if ((_M == 64 && _K == 576 && _N == 784) ||
                (_M == 2048 && _K == 512 && _N == 49)) {
       return blas::Gemm_Launcher<
-          16, false, false, false, 64, Tile<4, 4, 4, 4>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 16, false, false, false,
+          64, Tile<4, 4, 4, 4>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if ((_M == 512 && _K == 256 && _N == 784) ||
                (_M == 512 && _K == 128 && _N == 196) ||
                (_M == 512 && _K == 2048 && _N == 49)) {
       return blas::Gemm_Launcher<
-          32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 32, false, false, false,
+          64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 1,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if ((_M == 256 && _K == 512 && _N == 196) ||
                (_M == 512 && _K == 4608 && _N == 49)) {
       return blas::Gemm_Launcher<
-          64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 64, false, false, false,
+          64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 2,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if ((_M == 1024 && _K == 256 && _N == 49) ||
                (_M == 2048 && _K == 1024 && _N == 49)) {
       return blas::Gemm_Launcher<
-          32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 32, false, false, false,
+          64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 2,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if ((_M == 512 && _K == 4608 && _N == 49)) {
       return blas::Gemm_Launcher<
-          16, false, false, false, 64, Tile<4, 4, 4, 4>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 16, false, false, false,
+          64, Tile<4, 4, 4, 4>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 2,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if (!_t_a) {
       /* Does well on most im2col or 1x1 convolutions, or is within 10% of
        * best kernel. */
       return blas::Gemm_Launcher<
-          32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 32, false, false, false,
+          64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else {
       return blas::Gemm_Launcher<
-          128, false, false, false, 64, Tile<4, 8, 16, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 128, false, false, false,
+          64, Tile<4, 8, 16, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     }
 #elif defined MODEL_VGG_16
     /* Tends to perform well for Winograd sizes (i.e. batched) */
     if (batch_size > 1 && !_t_a) {
       return blas::Gemm_Launcher<
-          64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 64, false, false, false,
+          64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 2,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if (!_t_a) {
       /* Does well on most im2col or 1x1 convolutions, or is within 10% of
        * best kernel. */
       return blas::Gemm_Launcher<
-          64, false, false, false, 64, Tile<4, 4, 4, 4>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 64, false, false, false,
+          64, Tile<4, 4, 4, 4>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 2,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else {
       return blas::Gemm_Launcher<
-          128, false, false, false, 64, Tile<4, 8, 16, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 128, false, false, false,
+          64, Tile<4, 8, 16, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     }
 #else
     if (_M == 512 && _N == 49 && _K == 512) {
       return blas::Gemm_Launcher<
-          64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 64, false, false, false,
+          64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero,
           4>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                     _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size);
+                                    _ldc, _stridec, batch_size, _dependencies);
     } else if (_t_a) {
       return blas::Gemm_Launcher<
-          128, false, false, false, 64, Tile<4, 8, 16, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 128, false, false, false,
+          64, Tile<4, 8, 16, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero,
           4>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                     _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size);
+                                    _ldc, _stridec, batch_size, _dependencies);
     } else {
       return blas::Gemm_Launcher<
-          32, false, false, false, 64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 32, false, false, false,
+          64, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero,
           4>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                     _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size);
+                                    _ldc, _stridec, batch_size, _dependencies);
     }
 #endif
   }

--- a/src/interface/blas3/backend/default_cpu.hpp
+++ b/src/interface/blas3/backend/default_cpu.hpp
@@ -38,79 +38,65 @@ typename sb_handle_t::event_t _gemm(
     element_t _alpha, container_0_t _a, index_t _lda, index_t _stridea,
     container_1_t _b, index_t _ldb, index_t _strideb, element_t _beta,
     container_2_t _c, index_t _ldc, index_t _stridec, index_t batch_size,
-    gemm_batch_type_t batch_type) {
+    gemm_batch_type_t batch_type,
+    const typename sb_handle_t::event_t& _dependencies) {
   if (batch_type == gemm_batch_type_t::interleaved) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<2, 2, 4, 4, 1, 1, 1, 1, 4, 4>, _t_a,
-        _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::no_local),
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<2, 2, 4, 4, 1, 1, 1, 1, 4, 4>, _t_a, _t_b, s_a, s_b,
+        static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
         static_cast<int>(gemm_batch_type_t::interleaved)>::
         template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
                               _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size);
+                              batch_size, _dependencies);
   }
 #if defined(NAIVE_GEMM)
   return blas::Gemm_Launcher<
-      64, false, false, false, 64, Tile<8, 8, 8, 8>, _t_a, _t_b, s_a, s_b,
+      container_0_t, container_1_t, container_2_t, 64, false, false, false, 64,
+      Tile<8, 8, 8, 8>, _t_a, _t_b, s_a, s_b,
       static_cast<int>(gemm_memory_t::no_local),
       static_cast<int>(gemm_algorithm_t::naive),
       static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 1,
-      static_cast<int>(
-          gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M, _N,
-                                                              _K, _alpha, _a,
-                                                              _lda, _stridea,
-                                                              _b, _ldb,
-                                                              _strideb, _beta,
-                                                              _c, _ldc,
-                                                              _stridec,
-                                                              batch_size);
+      static_cast<int>(gemm_batch_type_t::strided)>::
+      template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                            _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                            batch_size, _dependencies);
 #else
   if (_M <= 128 && _N <= 128 && _K <= 128 && !s_a && !s_b) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<2, 2, 8, 8>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<2, 2, 8, 8>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 2,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                _a, _lda,
-                                                                _stridea, _b,
-                                                                _ldb, _strideb,
-                                                                _beta, _c, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                              batch_size, _dependencies);
   } else if (!s_a && !s_b) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<8, 8, 8, 8>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<8, 8, 8, 8>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 1,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                _a, _lda,
-                                                                _stridea, _b,
-                                                                _ldb, _strideb,
-                                                                _beta, _c, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                              batch_size, _dependencies);
   } else {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<2, 2, 8, 8>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<2, 2, 8, 8>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 2,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                _a, _lda,
-                                                                _stridea, _b,
-                                                                _ldb, _strideb,
-                                                                _beta, _c, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                              batch_size, _dependencies);
   }
 
 #endif

--- a/src/interface/blas3/backend/intel_gpu.hpp
+++ b/src/interface/blas3/backend/intel_gpu.hpp
@@ -37,17 +37,19 @@ typename sb_handle_t::event_t _gemm(
     element_t _alpha, container_0_t _a, index_t _lda, index_t _stridea,
     container_1_t _b, index_t _ldb, index_t _strideb, element_t _beta,
     container_2_t _c, index_t _ldc, index_t _stridec, index_t batch_size,
-    gemm_batch_type_t batch_type) {
+    gemm_batch_type_t batch_type,
+    const typename sb_handle_t::event_t& _dependencies) {
   if (batch_type == gemm_batch_type_t::interleaved) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<4, 4, 4, 4, 1, 1, 1, 1, 4, 4>, _t_a,
-        _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::no_local),
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<4, 4, 4, 4, 1, 1, 1, 1, 4, 4>, _t_a, _t_b, s_a, s_b,
+        static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
         static_cast<int>(gemm_batch_type_t::interleaved)>::
         template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
                               _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size);
+                              batch_size, _dependencies);
   }
 #ifdef GEMM_TALL_SKINNY_SUPPORT
   /* Tall & Skinny matrices. */
@@ -55,154 +57,151 @@ typename sb_handle_t::event_t _gemm(
       ((_K >= 4096 && _M * _N <= 16384) || (_K >= 1024 && _M * _N <= 4096))) {
     if (_M >= 16 && _N <= 4) {
       return blas::Gemm_Launcher<
-          32, true, true, true, 64, Tile<2, 1, 8, 4>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 32, true, true, true, 64,
+          Tile<2, 1, 8, 4>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if (_M <= 4 || _N <= 4) {
       // Need to increase the work group size for cl::sycl::half for the
       // launcher to be instancianted
       constexpr int wg_size = sizeof(element_t) == 2 ? 8 : 4;
       return blas::Gemm_Launcher<
-          16, true, false, false, 64, Tile<1, 1, wg_size, wg_size>, _t_a, _t_b,
-          s_a, s_b, static_cast<int>(gemm_memory_t::local),
-          static_cast<int>(gemm_algorithm_t::tall_skinny),
-          static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
-          static_cast<int>(gemm_batch_type_t::strided)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
-    } else if (_M >= 16 && _N <= 8) {
-      return blas::Gemm_Launcher<
-          32, true, true, true, 64, Tile<2, 2, 8, 4>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 16, true, false, false,
+          64, Tile<1, 1, wg_size, wg_size>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
+    } else if (_M >= 16 && _N <= 8) {
+      return blas::Gemm_Launcher<
+          container_0_t, container_1_t, container_2_t, 32, true, true, true, 64,
+          Tile<2, 2, 8, 4>, _t_a, _t_b, s_a, s_b,
+          static_cast<int>(gemm_memory_t::local),
+          static_cast<int>(gemm_algorithm_t::tall_skinny),
+          static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
+          static_cast<int>(gemm_batch_type_t::strided)>::
+          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
+                                _stridec, batch_size, _dependencies);
     } else if (_M <= 8 || _N <= 8) {
       // Need to increase the work group size for cl::sycl::half for the
       // launcher to be instancianted
       constexpr int wg_size = sizeof(element_t) == 2 ? 8 : 4;
       return blas::Gemm_Launcher<
-          16, true, false, false, 64, Tile<2, 2, wg_size, wg_size>, _t_a, _t_b,
-          s_a, s_b, static_cast<int>(gemm_memory_t::local),
+          container_0_t, container_1_t, container_2_t, 16, true, false, false,
+          64, Tile<2, 2, wg_size, wg_size>, _t_a, _t_b, s_a, s_b,
+          static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if (_M <= 16 || _N <= 16) {
       return blas::Gemm_Launcher<
-          64, true, true, true, 64, Tile<2, 2, 8, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 64, true, true, true, 64,
+          Tile<2, 2, 8, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else if (_M <= 32 || _N <= 32) {
       return blas::Gemm_Launcher<
-          64, true, true, true, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 64, true, true, true, 64,
+          Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else {
       constexpr int wg_size = sizeof(element_t) == 8 ? 8 : 16;
       return blas::Gemm_Launcher<
-          256, true, true, true, 64, Tile<4, 4, wg_size, wg_size>, _t_a, _t_b,
-          s_a, s_b, static_cast<int>(gemm_memory_t::local),
+          container_0_t, container_1_t, container_2_t, 256, true, true, true,
+          64, Tile<4, 4, wg_size, wg_size>, _t_a, _t_b, s_a, s_b,
+          static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     }
   } else if (batch_size == 1 && (_t_a || (_t_b && _M * _N > 1048576))) {
     if (_M <= 64 || _N <= 64) {
       return blas::Gemm_Launcher<
-          64, true, true, true, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+          container_0_t, container_1_t, container_2_t, 64, true, true, true, 64,
+          Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     } else {
       // Need to increase the work group size for double for the
       // launcher to be instancianted
       constexpr int wg_size = sizeof(element_t) == 8 ? 8 : 16;
       return blas::Gemm_Launcher<
-          256, true, true, true, 64, Tile<4, 4, wg_size, wg_size>, _t_a, _t_b,
-          s_a, s_b, static_cast<int>(gemm_memory_t::local),
+          container_0_t, container_1_t, container_2_t, 256, true, true, true,
+          64, Tile<4, 4, wg_size, wg_size>, _t_a, _t_b, s_a, s_b,
+          static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::tall_skinny),
           static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
           static_cast<int>(gemm_batch_type_t::strided)>::
           template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size);
+                                _stridec, batch_size, _dependencies);
     }
   }
 #endif
   if (_M <= 128 && _N <= 128) {
     return blas::Gemm_Launcher<
-        64, true, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 64, true, false, false, 64,
+        Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                _a, _lda,
-                                                                _stridea, _b,
-                                                                _ldb, _strideb,
-                                                                _beta, _c, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                              batch_size, _dependencies);
   } else if (_t_b && !_t_a && !s_a && !s_b) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<8, 8, 8, 8>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<8, 8, 8, 8>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                _a, _lda,
-                                                                _stridea, _b,
-                                                                _ldb, _strideb,
-                                                                _beta, _c, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                              batch_size, _dependencies);
   } else {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<4, 8, 16, 8>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<4, 8, 16, 8>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                _a, _lda,
-                                                                _stridea, _b,
-                                                                _ldb, _strideb,
-                                                                _beta, _c, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                              batch_size, _dependencies);
   }
 }
 }  // namespace backend

--- a/src/interface/blas3/backend/nvidia_gpu.hpp
+++ b/src/interface/blas3/backend/nvidia_gpu.hpp
@@ -38,18 +38,19 @@ typename sb_handle_t::event_t _gemm(
     element_t _alpha, container_0_t _a, index_t _lda, index_t _stridea,
     container_1_t _b, index_t _ldb, index_t _strideb, element_t _beta,
     container_2_t _c, index_t _ldc, index_t _stridec, index_t batch_size,
-    gemm_batch_type_t batch_type) {
+    gemm_batch_type_t batch_type,
+    const typename sb_handle_t::event_t& _dependencies) {
   if (batch_type == gemm_batch_type_t::interleaved) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64,
-        Tile<2, 2, 4, 4, 1, 1, 1, 1, 4, 4, 1, 1, 1, float, float>, _t_a, _t_b,
-        s_a, s_b, static_cast<int>(gemm_memory_t::no_local),
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<2, 2, 4, 4, 1, 1, 1, 1, 4, 4, 1, 1, 1, float, float>, _t_a,
+        _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
         static_cast<int>(gemm_batch_type_t::interleaved)>::
         template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
                               _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size);
+                              batch_size, _dependencies);
   }
 
 #ifdef SB_ENABLE_JOINT_MATRIX
@@ -57,7 +58,8 @@ typename sb_handle_t::event_t _gemm(
   if (en_joint_matrix != NULL && *en_joint_matrix == '1') {
     if (_M > 1024 && _N > 1024) {
       return blas::Gemm_Launcher<
-          256, false, true, true, 128,
+          container_0_t, container_1_t, container_2_t, 256, false, true, true,
+          128,
           Tile<8, 8, 16, 16, 16, 2, 1, 1, 1, 1, 16, 16, 16, cl::sycl::half,
                float>,
           _t_a, _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
@@ -66,10 +68,12 @@ typename sb_handle_t::event_t _gemm(
           static_cast<int>(gemm_batch_type_t::strided),
           true>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                        _stridea, _b, _ldb, _strideb, _beta, _c,
-                                       _ldc, _stridec, batch_size);
+                                       _ldc, _stridec, batch_size,
+                                       _dependencies);
     } else if (_M > 64 && _N > 64) {
       return blas::Gemm_Launcher<
-          128, false, true, true, 128,
+          container_0_t, container_1_t, container_2_t, 128, false, true, true,
+          128,
           Tile<4, 8, 16, 8, 16, 2, 1, 1, 1, 1, 16, 16, 16, cl::sycl::half,
                float>,
           _t_a, _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
@@ -78,11 +82,13 @@ typename sb_handle_t::event_t _gemm(
           static_cast<int>(gemm_batch_type_t::strided),
           true>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                        _stridea, _b, _ldb, _strideb, _beta, _c,
-                                       _ldc, _stridec, batch_size);
+                                       _ldc, _stridec, batch_size,
+                                       _dependencies);
 
     } else {
       return blas::Gemm_Launcher<
-          128, false, true, true, 128,
+          container_0_t, container_1_t, container_2_t, 128, false, true, true,
+          128,
           Tile<2, 4, 16, 8, 16, 2, 1, 1, 1, 1, 16, 16, 16, cl::sycl::half,
                float>,
           _t_a, _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
@@ -91,11 +97,12 @@ typename sb_handle_t::event_t _gemm(
           static_cast<int>(gemm_batch_type_t::strided),
           true>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                        _stridea, _b, _ldb, _strideb, _beta, _c,
-                                       _ldc, _stridec, batch_size);
+                                       _ldc, _stridec, batch_size,
+                                       _dependencies);
     }
   } else {
     return blas::Gemm_Launcher<
-        64, false, false, true, 64,
+        container_0_t, container_1_t, container_2_t, 64, false, false, true, 64,
         Tile<8, 8, 8, 8, 1, 1, 2, 2, 1, 1, 1, 1, 1, float, float>, _t_a, _t_b,
         s_a, s_b, static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
@@ -103,13 +110,14 @@ typename sb_handle_t::event_t _gemm(
         static_cast<int>(gemm_batch_type_t::strided),
         false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                       _stridea, _b, _ldb, _strideb, _beta, _c,
-                                      _ldc, _stridec, batch_size);
+                                      _ldc, _stridec, batch_size,
+                                      _dependencies);
   }
 
 #else  // SB_ENABLE_JOINT_MATRIX
   else {
     return blas::Gemm_Launcher<
-        64, false, false, true, 64,
+        container_0_t, container_1_t, container_2_t, 64, false, false, true, 64,
         Tile<8, 8, 8, 8, 1, 1, 2, 2, 1, 1, 1, 1, 1, float, float>, _t_a, _t_b,
         s_a, s_b, static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
@@ -117,7 +125,8 @@ typename sb_handle_t::event_t _gemm(
         static_cast<int>(gemm_batch_type_t::strided),
         false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
                                       _stridea, _b, _ldb, _strideb, _beta, _c,
-                                      _ldc, _stridec, batch_size);
+                                      _ldc, _stridec, batch_size,
+                                      _dependencies);
   }
 #endif
 }

--- a/src/interface/blas3/backend/power_vr.hpp
+++ b/src/interface/blas3/backend/power_vr.hpp
@@ -51,7 +51,8 @@ struct Gemm_Launcher {
   static inline typename sb_handle_t::event_t _select_gemm(
       sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
       value_t _alpha, container_0_t _A, container_1_t _B, value_t _beta,
-      container_2_t _C, index_t batch_size) {
+      container_2_t _C, index_t batch_size,
+      const typename sb_handle_t::event_t& _dependencies) {
     auto m = static_cast<size_t>(_M);
     auto n = static_cast<size_t>(_N);
     auto k = static_cast<size_t>(_K);
@@ -306,18 +307,19 @@ typename sb_handle_t::event_t _gemm(
   }
   return blas::gemm::backend::sycl_imagination_nn_api::Gemm_Launcher<
       _t_a, _t_b>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _b,
-                                         _beta, _c, batch_size);
+                                         _beta, _c, batch_size, _dependencies);
 #else
   if (batch_type == gemm_batch_type_t::interleaved) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<4, 4, 4, 4, 1, 1, 1, 1, 4, 4>, _t_a,
-        _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::no_local),
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<4, 4, 4, 4, 1, 1, 1, 1, 4, 4>, _t_a, _t_b, s_a, s_b,
+        static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
         static_cast<int>(gemm_batch_type_t::interleaved)>::
         template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
                               _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size);
+                              batch_size, _dependencies);
   }
   // The following _M, _N ,and _K is used for SSD + Mobilenet v2 (TF version)
   // We computed the best tile combination for each sizes -(4-March-2018)
@@ -326,7 +328,8 @@ typename sb_handle_t::event_t _gemm(
       (_M == 273 && _K == 576 && _N == 100) ||
       (_M == 384 && _K == 64 && _N == 361)) {
     return blas::Gemm_Launcher<
-        96, true, false, false, 16, Tile<4, 6, 12, 8>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 96, true, false, false, 16,
+        Tile<4, 6, 12, 8>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
@@ -336,7 +339,8 @@ typename sb_handle_t::event_t _gemm(
                                                                 _a, _lda, _b,
                                                                 _ldb, _beta, _c,
                                                                 _ldc,
-                                                                batch_size);
+                                                                batch_size,
+                                                                _dependencies);
   }  // The following _M, _N ,and _K is used for SSD + Mobilenet v2 (TF version)
   // We computed the best tile combination for each sizes -(4-March-2018)
   // POWER_VR Rogue
@@ -347,38 +351,30 @@ typename sb_handle_t::event_t _gemm(
            (_M == 24 && _K == 256 && _N == 1) ||
            (_M == 128 && _K == 64 && _N == 1)) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 128, Tile<1, 1, 8, 8>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        128, Tile<1, 1, 8, 8>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                _a, _lda,
-                                                                _stridea, _b,
-                                                                _ldb, _strideb,
-                                                                _beta, _c, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                              batch_size, _dependencies);
   }  // The following _M, _N ,and _K is used for SSD + Mobilenet v2 (TF version)
   // We computed the best tile combination for each sizes -(4-March-2018)
   // POWER_VR Rogue
   else if ((_M == 546 && _K == 128 && _N == 1) ||
            (_M == 546 && _K == 256 && _N == 1)) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                _a, _lda,
-                                                                _stridea, _b,
-                                                                _ldb, _strideb,
-                                                                _beta, _c, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                              batch_size, _dependencies);
   }  // The following _M, _N ,and _K is used for SSD + Mobilenet v2 (TF version)
   // We computed the best tile combination for each sizes -(4-March-2018)
   // POWER_VR Rogue
@@ -392,34 +388,26 @@ typename sb_handle_t::event_t _gemm(
            (_M > 64 && _K > 64 && _N > 64 && is_power_of_2(_M) &&
             is_power_of_2(_K) && is_power_of_2(_N))) {
     return blas::Gemm_Launcher<
-        128, false, false, false, 16, Tile<4, 8, 16, 8>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 128, false, false, false,
+        16, Tile<4, 8, 16, 8>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                _a, _lda,
-                                                                _stridea, _b,
-                                                                _ldb, _strideb,
-                                                                _beta, _c, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                              batch_size, _dependencies);
   } else {
     return blas::Gemm_Launcher<
-        64, false, false, false, 32, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        32, Tile<4, 4, 8, 8>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                _a, _lda,
-                                                                _stridea, _b,
-                                                                _ldb, _strideb,
-                                                                _beta, _c, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                              batch_size, _dependencies);
   }
 #endif
 }

--- a/src/interface/blas3/backend/rcar.hpp
+++ b/src/interface/blas3/backend/rcar.hpp
@@ -29,7 +29,7 @@
 namespace blas {
 namespace gemm {
 namespace backend {
-template <bool _t_a, bool _t_b, bool s_a, bool s_b, bool is_beta_zero,
+template <bool _t_a, bool _t_b, bool s_a, s_b, bool is_beta_zero,
           typename SB_Handle, typename container_t0, typename container_t1,
           typename container_t2, typename element_t, typename index_t>
 typename SB_Handle::event_t _gemm(SB_Handle& sb_handle, index_t _M, index_t _N,
@@ -40,46 +40,39 @@ typename SB_Handle::event_t _gemm(SB_Handle& sb_handle, index_t _M, index_t _N,
                                   gemm_batch_type_t batch_type) {
   if (batch_type == gemm_batch_type_t::interleaved) {
     return blas::Gemm_Launcher<
-        64, false, false, false, 64, Tile<4, 4, 4, 4, 1, 1, 1, 1, 4, 4>, _t_a,
-        _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::no_local),
+        container_0_t, container_1_t, container_2_t, 64, false, false, false,
+        64, Tile<4, 4, 4, 4, 1, 1, 1, 1, 4, 4>, _t_a, _t_b, s_a, s_b,
+        static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
         static_cast<int>(gemm_batch_type_t::interleaved)>::
         template _select_gemm(sb_handle, _M, _N, _K, _alpha, a_, _lda, _stridea,
                               b_, _ldb, _strideb, _beta, _C, _ldc, _stridec,
-                              batch_size);
+                              batch_size, _dependencies);
   }
   if (_M < 512 && _N < 512) {
     return blas::Gemm_Launcher<
-        32, false, false, false, 128, Tile<4, 8, 8, 4>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 32, false, false, false,
+        128, Tile<4, 8, 8, 4>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                a_, _lda,
-                                                                _stridea, b_,
-                                                                _ldb, _strideb,
-                                                                _beta, _C, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, a_, _lda, _stridea,
+                              b_, _ldb, _strideb, _beta, _C, _ldc, _stridec,
+                              batch_size, _dependencies);
 
   } else {
     return blas::Gemm_Launcher<
-        32, false, false, false, 128, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
+        container_0_t, container_1_t, container_2_t, 32, false, false, false,
+        128, Tile<8, 4, 4, 8>, _t_a, _t_b, s_a, s_b,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-        static_cast<int>(
-            gemm_batch_type_t::strided)>::template _select_gemm(sb_handle, _M,
-                                                                _N, _K, _alpha,
-                                                                a_, _lda,
-                                                                _stridea, b_,
-                                                                _ldb, _strideb,
-                                                                _beta, _C, _ldc,
-                                                                _stridec,
-                                                                batch_size);
+        static_cast<int>(gemm_batch_type_t::strided)>::
+        template _select_gemm(sb_handle, _M, _N, _K, _alpha, a_, _lda, _stridea,
+                              b_, _ldb, _strideb, _beta, _C, _ldc, _stridec,
+                              batch_size, _dependencies);
   }
 }
 }  // namespace backend

--- a/src/interface/blas3/gemm.cpp.in
+++ b/src/interface/blas3/gemm.cpp.in
@@ -23,9 +23,8 @@
  *
  **************************************************************************/
 #include "container/sycl_iterator.hpp"
-#include "sb_handle/sycl_blas_handle.hpp"
 #include "interface/gemm_interface.hpp"
-#include "operations/blas_constants.hpp"
+#include "sb_handle/sycl_blas_handle.hpp"
 #include "views/view_sycl.hpp"
 
 namespace blas {
@@ -35,14 +34,16 @@ template typename SB_Handle::event_t _gemm(
     SB_Handle& sb_handle, char _TransA, char _TransB, ${INDEX_TYPE} _M,
     ${INDEX_TYPE} _N, ${INDEX_TYPE} _K, ${DATA_TYPE} _alpha, ${container_t0} a_,
     ${INDEX_TYPE} _lda, ${container_t1} b_, ${INDEX_TYPE} _ldb,
-    ${DATA_TYPE} _beta, ${container_t2} _C, ${INDEX_TYPE} _ldc);
+    ${DATA_TYPE} _beta, ${container_t2} _C, ${INDEX_TYPE} _ldc,
+    const typename SB_Handle::event_t& _dependencies);
 // batched gemm
 template typename SB_Handle::event_t _gemm_batched(
     SB_Handle& sb_handle, char _TransA, char _TransB, ${INDEX_TYPE} _M,
     ${INDEX_TYPE} _N, ${INDEX_TYPE} _K, ${DATA_TYPE} _alpha, ${container_t0} a_,
     ${INDEX_TYPE} _lda, ${container_t1} b_, ${INDEX_TYPE} _ldb,
     ${DATA_TYPE} _beta, ${container_t2} _C, ${INDEX_TYPE} _ldc,
-    ${INDEX_TYPE} batch_size, gemm_batch_type_t batch_type);
+    ${INDEX_TYPE} batch_size, gemm_batch_type_t batch_type,
+    const typename SB_Handle::event_t& _dependencies);
 // strided batched gemm
 template typename SB_Handle::event_t _gemm_strided_batched(
     SB_Handle& sb_handle, char _TransA, char _TransB, ${INDEX_TYPE} _M,
@@ -50,6 +51,7 @@ template typename SB_Handle::event_t _gemm_strided_batched(
     ${INDEX_TYPE} _lda, ${INDEX_TYPE} _stridea, ${container_t1} b_,
     ${INDEX_TYPE} _ldb, ${INDEX_TYPE} _strideb, ${DATA_TYPE} _beta,
     ${container_t2} _C, ${INDEX_TYPE} _ldc, ${INDEX_TYPE} _stridec,
-    ${INDEX_TYPE} batch_size);
+    ${INDEX_TYPE} batch_size, const typename SB_Handle::event_t& _dependencies);
+
 }  // namespace internal
 }  // namespace blas

--- a/src/interface/blas3/gemm_launcher.cpp.in
+++ b/src/interface/blas3/gemm_launcher.cpp.in
@@ -24,73 +24,45 @@
  **************************************************************************/
 
 #include "container/sycl_iterator.hpp"
-#include "sb_handle/sycl_blas_handle.hpp"
-#include "sb_handle/kernel_constructor.hpp"
 #include "interface/gemm_launcher.hpp"
 #include "operations/blas3_trees.hpp"
-#include "operations/extension/reduction.hpp"
 #include "operations/blas_constants.hpp"
+#include "operations/extension/reduction.hpp"
+#include "sb_handle/kernel_constructor.hpp"
+#include "sb_handle/sycl_blas_handle.hpp"
 #include "views/view_sycl.hpp"
 
 namespace blas {
 template class Gemm_Launcher<
-    ${WG_SIZE}, ${DOUBLE_BUFFER}, ${CONFLICT_A}, ${CONFLICT_B}, ${CL_SIZE},
-    Tile<${TIR}, ${TIC}, ${TWR}, ${TWC}, ${TSR}, ${TSC}, ${TLR}, ${TLC}, ${TIB}, ${TWB},
-    ${JM_M}, ${JM_N}, ${JM_K}, ${JM_IN_T}, ${JM_OUT_T}>,
+    ${container_t0}, ${container_t1}, ${container_t2}, ${WG_SIZE},
+    ${DOUBLE_BUFFER}, ${CONFLICT_A}, ${CONFLICT_B}, ${CL_SIZE},
+    Tile<${TIR}, ${TIC}, ${TWR}, ${TWC}, ${TSR}, ${TSC}, ${TLR}, ${TLC}, ${TIB},
+         ${TWB}, ${JM_M}, ${JM_N}, ${JM_K}, ${JM_IN_T}, ${JM_OUT_T}>,
     ${TRANS_A}, ${TRANS_B}, ${SYMM_A}, ${SYMM_B},
     static_cast<int>(gemm_memory_t::${GEMM_MEMORY_TYPE}),
     static_cast<int>(gemm_algorithm_t::${GEMM_SHAPE_TYPE}),
     static_cast<int>(gemm_vectorization_t::${GEMM_VECTORIZE_TYPE}),
     ${IS_BETA_ZERO}, ${VECTOR_SIZE},
-    static_cast<int>(gemm_batch_type_t::${BATCH_TYPE}),
-    ${USE_JOINT_MATRIX}>;
+    static_cast<int>(gemm_batch_type_t::${BATCH_TYPE}), ${USE_JOINT_MATRIX}>;
 
 template typename SB_Handle::event_t Gemm_Launcher<
-    ${WG_SIZE}, ${DOUBLE_BUFFER}, ${CONFLICT_A}, ${CONFLICT_B}, ${CL_SIZE},
-    Tile<${TIR}, ${TIC}, ${TWR}, ${TWC}, ${TSR}, ${TSC}, ${TLR}, ${TLC}, ${TIB}, ${TWB},
-    ${JM_M}, ${JM_N}, ${JM_K}, ${JM_IN_T}, ${JM_OUT_T}>,
+    ${container_t0}, ${container_t1}, ${container_t2}, ${WG_SIZE},
+    ${DOUBLE_BUFFER}, ${CONFLICT_A}, ${CONFLICT_B}, ${CL_SIZE},
+    Tile<${TIR}, ${TIC}, ${TWR}, ${TWC}, ${TSR}, ${TSC}, ${TLR}, ${TLC}, ${TIB},
+         ${TWB}, ${JM_M}, ${JM_N}, ${JM_K}, ${JM_IN_T}, ${JM_OUT_T}>,
     ${TRANS_A}, ${TRANS_B}, ${SYMM_A}, ${SYMM_B},
     static_cast<int>(gemm_memory_t::${GEMM_MEMORY_TYPE}),
     static_cast<int>(gemm_algorithm_t::${GEMM_SHAPE_TYPE}),
     static_cast<int>(gemm_vectorization_t::${GEMM_VECTORIZE_TYPE}),
     ${IS_BETA_ZERO}, ${VECTOR_SIZE},
     static_cast<int>(gemm_batch_type_t::${BATCH_TYPE}),
-    ${USE_JOINT_MATRIX}>::
-    _select_gemm<SB_Handle,
-                 BufferIterator<${DATA_TYPE}>,
-                 BufferIterator<${DATA_TYPE}>,
-                 BufferIterator<${DATA_TYPE}>, ${DATA_TYPE},
-                 ${INDEX_TYPE}>(
-        SB_Handle& sb_handle, ${INDEX_TYPE} _M, ${INDEX_TYPE} _N,
-        ${INDEX_TYPE} _K, ${DATA_TYPE} _alpha,
-        BufferIterator<${DATA_TYPE}> a_, ${INDEX_TYPE} _lda,
-        ${INDEX_TYPE} _stridea, BufferIterator<${DATA_TYPE}> b_, 
-        ${INDEX_TYPE} _ldb, ${INDEX_TYPE} _strideb,
-        ${DATA_TYPE} _beta, BufferIterator<${DATA_TYPE}> _C,
-        ${INDEX_TYPE} _ldc, ${INDEX_TYPE} _stridec, 
-        ${INDEX_TYPE} batch_size);
-
-template typename SB_Handle::event_t Gemm_Launcher<
-    ${WG_SIZE}, ${DOUBLE_BUFFER}, ${CONFLICT_A}, ${CONFLICT_B}, ${CL_SIZE},
-    Tile<${TIR}, ${TIC}, ${TWR}, ${TWC}, ${TSR}, ${TSC}, ${TLR}, ${TLC}, ${TIB}, ${TWB},
-    ${JM_M}, ${JM_N}, ${JM_K}, ${JM_IN_T}, ${JM_OUT_T}>,
-    ${TRANS_A}, ${TRANS_B}, ${SYMM_A}, ${SYMM_B},
-    static_cast<int>(gemm_memory_t::${GEMM_MEMORY_TYPE}),
-    static_cast<int>(gemm_algorithm_t::${GEMM_SHAPE_TYPE}),
-    static_cast<int>(gemm_vectorization_t::${GEMM_VECTORIZE_TYPE}),
-    ${IS_BETA_ZERO}, ${VECTOR_SIZE},
-    static_cast<int>(gemm_batch_type_t::${BATCH_TYPE}),
-    ${USE_JOINT_MATRIX}>::
-    _select_gemm<SB_Handle,
-                 BufferIterator<${DATA_TYPE} const>,
-                 BufferIterator<${DATA_TYPE} const>,
-                 BufferIterator<${DATA_TYPE}>, ${DATA_TYPE},
-                 ${INDEX_TYPE}>(
-        SB_Handle& sb_handle, ${INDEX_TYPE} _M, ${INDEX_TYPE} _N,
-        ${INDEX_TYPE} _K, ${DATA_TYPE} _alpha,
-        BufferIterator<${DATA_TYPE} const> a_, ${INDEX_TYPE} _lda, ${INDEX_TYPE} _stridea,
-        BufferIterator<${DATA_TYPE} const> b_, ${INDEX_TYPE} _ldb, ${INDEX_TYPE} _strideb,
-        ${DATA_TYPE} _beta, BufferIterator<${DATA_TYPE}> _C,
-        ${INDEX_TYPE} _ldc, ${INDEX_TYPE} _stridec, ${INDEX_TYPE} batch_size);
+    ${USE_JOINT_MATRIX}>::_select_gemm<SB_Handle, ${DATA_TYPE},
+                                       ${INDEX_TYPE}>(
+    SB_Handle& sb_handle, ${INDEX_TYPE} _M, ${INDEX_TYPE} _N, ${INDEX_TYPE} _K,
+    ${DATA_TYPE} _alpha, ${container_t0} a_, ${INDEX_TYPE} _lda,
+    ${INDEX_TYPE} _stridea, ${container_t1} b_, ${INDEX_TYPE} _ldb,
+    ${INDEX_TYPE} _strideb, ${DATA_TYPE} _beta, ${container_t2} _C,
+    ${INDEX_TYPE} _ldc, ${INDEX_TYPE} _stridec, ${INDEX_TYPE} batch_size,
+    const typename SB_Handle::event_t& _dependencies);
 
 }  // namespace blas

--- a/src/interface/blas3/symm.cpp.in
+++ b/src/interface/blas3/symm.cpp.in
@@ -23,19 +23,19 @@
  *
  **************************************************************************/
 #include "container/sycl_iterator.hpp"
-#include "sb_handle/sycl_blas_handle.hpp"
-#include "interface/gemm_interface.hpp"
 #include "interface/symm_interface.hpp"
-#include "operations/blas_constants.hpp"
+#include "sb_handle/sycl_blas_handle.hpp"
 #include "views/view_sycl.hpp"
 
 namespace blas {
 namespace internal {
 
 template typename SB_Handle::event_t _symm(
-    SB_Handle& sb_handle, char _side, char _uplo, ${INDEX_TYPE} _M, ${INDEX_TYPE} _N,
-    ${DATA_TYPE} _alpha, ${container_t0} a_, ${INDEX_TYPE} _lda, ${container_t1} b_,
-    ${INDEX_TYPE} _ldb, ${DATA_TYPE} _beta, ${container_t2} _C, ${INDEX_TYPE} _ldc);
+    SB_Handle& sb_handle, char _side, char _uplo, ${INDEX_TYPE} _M,
+    ${INDEX_TYPE} _N, ${DATA_TYPE} _alpha, ${container_t0} a_,
+    ${INDEX_TYPE} _lda, ${container_t1} b_, ${INDEX_TYPE} _ldb,
+    ${DATA_TYPE} _beta, ${container_t2} _C, ${INDEX_TYPE} _ldc,
+    const typename SB_Handle::event_t& dependencies);
 
 }  // namespace internal
 }  // namespace blas

--- a/src/interface/blas3/trsm.cpp.in
+++ b/src/interface/blas3/trsm.cpp.in
@@ -22,12 +22,10 @@
  **************************************************************************/
 
 #include "container/sycl_iterator.hpp"
-#include "sb_handle/sycl_blas_handle.hpp"
-#include "sb_handle/kernel_constructor.hpp"
-#include "interface/blas1_interface.hpp"
 #include "interface/trsm_interface.hpp"
 #include "operations/blas3/trsm.hpp"
-#include "operations/blas_constants.hpp"
+#include "sb_handle/kernel_constructor.hpp"
+#include "sb_handle/sycl_blas_handle.hpp"
 #include "views/view_sycl.hpp"
 
 namespace blas {
@@ -36,7 +34,8 @@ namespace internal {
 template typename SB_Handle::event_t _trsm(
     SB_Handle& sb_handle, char side, char uplo, char trans, char diag,
     ${INDEX_TYPE} M, ${INDEX_TYPE} N, ${DATA_TYPE} alpha, ${container_t0} A,
-    ${INDEX_TYPE} lda, ${container_t1} B, ${INDEX_TYPE} ldb);
+    ${INDEX_TYPE} lda, ${container_t1} B, ${INDEX_TYPE} ldb,
+    const typename SB_Handle::event_t& _dependencies);
 
 }  // namespace internal
 }  // namespace blas

--- a/src/interface/gemm_launcher.hpp
+++ b/src/interface/gemm_launcher.hpp
@@ -34,26 +34,27 @@ namespace blas {
 /*!
  * @brief Wrapper around Gemm. Creates the views, then makes and launches Gemm
  */
-template <int WgSize, bool DoubleBuffer, bool ConflictA, bool ConflictB,
+template <typename container_t0, typename container_t1, typename container_t2,
+          int WgSize, bool DoubleBuffer, bool ConflictA, bool ConflictB,
           int ClSize, typename TileT, bool TransA, bool TransB, bool SymmA,
           bool SymmB, int GemmMemoryType, int GemmAlgorithm,
           int GemmVectorization, bool is_beta_zero, int VectorSize,
           int BatchType, bool UseJointMatrix>
-template <typename sb_handle_t, typename container_t0, typename container_t1,
-          typename container_t2, typename element_t, typename index_t>
-typename sb_handle_t::event_t
-Gemm_Launcher<WgSize, DoubleBuffer, ConflictA, ConflictB, ClSize, TileT, TransA,
-              TransB, SymmA, SymmB, GemmMemoryType, GemmAlgorithm,
-              GemmVectorization, is_beta_zero, VectorSize, BatchType,
-              UseJointMatrix>::_select_gemm(sb_handle_t& sb_handle, index_t _M,
-                                            index_t _N, index_t _K,
-                                            element_t _alpha, container_t0 a_,
-                                            index_t _lda, index_t _stridea,
-                                            container_t1 b_, index_t _ldb,
-                                            index_t _strideb, element_t _beta,
-                                            container_t2 _C, index_t _ldc,
-                                            index_t _stridec,
-                                            index_t batch_size) {
+template <typename sb_handle_t, typename element_t, typename index_t>
+typename sb_handle_t::event_t Gemm_Launcher<
+    container_t0, container_t1, container_t2, WgSize, DoubleBuffer, ConflictA,
+    ConflictB, ClSize, TileT, TransA, TransB, SymmA, SymmB, GemmMemoryType,
+    GemmAlgorithm, GemmVectorization, is_beta_zero, VectorSize, BatchType,
+    UseJointMatrix>::_select_gemm(sb_handle_t& sb_handle, index_t _M,
+                                  index_t _N, index_t _K, element_t _alpha,
+                                  container_t0 a_, index_t _lda,
+                                  index_t _stridea, container_t1 b_,
+                                  index_t _ldb, index_t _strideb,
+                                  element_t _beta, container_t2 _C,
+                                  index_t _ldc, index_t _stridec,
+                                  index_t batch_size,
+                                  const typename sb_handle_t::event_t&
+                                      _dependencies) {
   auto buffer_a = make_matrix_view<col_major>(a_, _M, _K, _lda);
   auto buffer_b = make_matrix_view<col_major>(b_, _K, _N, _ldb);
   auto buffer_c = make_matrix_view<col_major>(_C, _M, _N, _ldc);
@@ -65,7 +66,7 @@ Gemm_Launcher<WgSize, DoubleBuffer, ConflictA, ConflictB, ClSize, TileT, TransA,
       buffer_a, buffer_b, buffer_c, element_t(_alpha), element_t(_beta),
       batch_size, element_t(_stridea), element_t(_strideb),
       element_t(_stridec));
-  return sb_handle.execute(gemm);
+  return sb_handle.execute(gemm, _dependencies);
 }
 
 }  // namespace blas

--- a/src/interface/symm_interface.hpp
+++ b/src/interface/symm_interface.hpp
@@ -33,12 +33,11 @@ namespace internal {
 
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename container_2_t, typename element_t, typename index_t>
-typename sb_handle_t::event_t _symm(sb_handle_t& sb_handle, char _side,
-                                    char _uplo, index_t _M, index_t _N,
-                                    element_t _alpha, container_0_t a_,
-                                    index_t _lda, container_1_t b_,
-                                    index_t _ldb, element_t _beta,
-                                    container_2_t _C, index_t _ldc) {
+typename sb_handle_t::event_t _symm(
+    sb_handle_t& sb_handle, char _side, char _uplo, index_t _M, index_t _N,
+    element_t _alpha, container_0_t a_, index_t _lda, container_1_t b_,
+    index_t _ldb, element_t _beta, container_2_t _C, index_t _ldc,
+    const typename sb_handle_t::event_t& _dependencies) {
   const char TRANS_NO = 'n';
   const char TRANS_YES = 't';
   const char SIDE_RIGHT = 'r';
@@ -57,7 +56,7 @@ typename sb_handle_t::event_t _symm(sb_handle_t& sb_handle, char _side,
     return _gemm_backend<true, false>(
         sb_handle, trans_symm, TRANS_NO, _M, _N, _M, _alpha, a_, _lda,
         index_t(0), b_, _ldb, index_t(0), _beta, _C, _ldc, index_t(0),
-        index_t(1), gemm_batch_type_t::strided);
+        index_t(1), gemm_batch_type_t::strided, _dependencies);
   } else if (_side == SIDE_RIGHT) {  // C <- alpha * B * A + beta * C
     // if the valid values are in the upper side, transpose the matrix
     // to make gemm to start reading rows on a valid value.
@@ -67,7 +66,7 @@ typename sb_handle_t::event_t _symm(sb_handle_t& sb_handle, char _side,
     return _gemm_backend<false, true>(
         sb_handle, TRANS_NO, trans_symm, _M, _N, _N, _alpha, b_, _ldb,
         index_t(0), a_, _lda, index_t(0), _beta, _C, _ldc, index_t(0),
-        index_t(1), gemm_batch_type_t::strided);
+        index_t(1), gemm_batch_type_t::strided, _dependencies);
   } else {
     throw std::invalid_argument("invalid _side");
   }

--- a/src/operations/blas3/gemm_local.hpp
+++ b/src/operations/blas3/gemm_local.hpp
@@ -278,12 +278,9 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType,
     const index_t b_size = trans_b ? ldb * k : n * ldb;
     const index_t c_size = ldc * n;
 
-    auto ptr_A = a_.get_data().get_pointer() + a_.get_access_displacement() +
-                 (wg_batch_id * stridea_);
-    auto ptr_B = b_.get_data().get_pointer() + b_.get_access_displacement() +
-                 (wg_batch_id * strideb_);
-    auto ptr_C = c_.get_data().get_pointer() + c_.get_access_displacement() +
-                 (wg_batch_id * stridec_);
+    auto ptr_A = a_.get_pointer() + (wg_batch_id * stridea_);
+    auto ptr_B = b_.get_pointer() + (wg_batch_id * strideb_);
+    auto ptr_C = c_.get_pointer() + (wg_batch_id * stridec_);
 
     const index_t item_id = id.get_local_id(0);
     const index_t tile_id = wg_id / tile_size;

--- a/src/operations/blas3/gemm_local_joint_matrix.hpp
+++ b/src/operations/blas3/gemm_local_joint_matrix.hpp
@@ -289,9 +289,11 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType,
     const index_t b_size = trans_b ? ldb * k : n * ldb;
     const index_t c_size = ldc * n;
 
-    auto ptr_A = a_.get_pointer() + (wg_batch_id * stridea_);
-    auto ptr_B = b_.get_pointer() + (wg_batch_id * strideb_);
-    auto ptr_C = c_.get_pointer() + (wg_batch_id * stridec_);
+    using address_t = cl::sycl::access::address_space;
+    using multi_ptr_ = cl::sycl::multi_ptr<element_t, address_t::global_space>;
+    auto ptr_A = multi_ptr_(a_.get_pointer()) + (wg_batch_id * stridea_);
+    auto ptr_B = multi_ptr_(b_.get_pointer()) + (wg_batch_id * strideb_);
+    auto ptr_C = multi_ptr_(c_.get_pointer()) + (wg_batch_id * stridec_);
 
     auto sg = id.get_sub_group();
     const index_t sg_id = sg.get_group_linear_id();
@@ -370,7 +372,6 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType,
             batch_stride, wg_batch_id, batch_size_);
       }
     } else {
-      using address_t = cl::sycl::access::address_space;
       auto input_scratch = *reinterpret_cast<cl::sycl::multi_ptr<
           typename tile_type::jmInpType, address_t::local_space> *>(&scratch);
 

--- a/src/operations/blas3/gemm_local_joint_matrix.hpp
+++ b/src/operations/blas3/gemm_local_joint_matrix.hpp
@@ -289,12 +289,9 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType,
     const index_t b_size = trans_b ? ldb * k : n * ldb;
     const index_t c_size = ldc * n;
 
-    auto ptr_A = a_.get_data().get_pointer() + a_.get_access_displacement() +
-                 (wg_batch_id * stridea_);
-    auto ptr_B = b_.get_data().get_pointer() + b_.get_access_displacement() +
-                 (wg_batch_id * strideb_);
-    auto ptr_C = c_.get_data().get_pointer() + c_.get_access_displacement() +
-                 (wg_batch_id * stridec_);
+    auto ptr_A = a_.get_pointer() + (wg_batch_id * stridea_);
+    auto ptr_B = b_.get_pointer() + (wg_batch_id * strideb_);
+    auto ptr_C = c_.get_pointer() + (wg_batch_id * stridec_);
 
     auto sg = id.get_sub_group();
     const index_t sg_id = sg.get_group_linear_id();

--- a/src/operations/blas3/trsm.hpp
+++ b/src/operations/blas3/trsm.hpp
@@ -62,8 +62,8 @@ template <typename local_memory_t>
 SYCL_BLAS_INLINE void
 DiagonalBlocksInverter<UnitDiag, Upper, BlockSize, matrix_t>::eval(
     local_memory_t localMem, cl::sycl::nd_item<1> item) noexcept {
-  auto A = A_.get_data().get_pointer() + A_.get_access_displacement();
-  auto invA = invA_.get_data().get_pointer() + invA_.get_access_displacement();
+  auto A = A_.get_pointer();
+  auto invA = invA_.get_pointer();
   value_t* local = localMem.localAcc.get_pointer();
 
   const index_t i = item.get_local_id(0);

--- a/src/sb_handle/kernel_constructor.hpp
+++ b/src/sb_handle/kernel_constructor.hpp
@@ -235,7 +235,11 @@ static SYCL_BLAS_INLINE cl::sycl::event execute_tree(
   cl::sycl::event ev;
   try {
     auto cg1 = [=](cl::sycl::handler &h) mutable {
+#if SYCL_LANGUAGE_VERSION < 202000
+      cl::sycl::event::wait(dependencies);
+#else
       h.depends_on(dependencies);
+#endif
       t.bind(h);
       auto scratch = LocalMemory<value_t, using_local_memory>(shMem, h);
 

--- a/src/sb_handle/kernel_constructor.hpp
+++ b/src/sb_handle/kernel_constructor.hpp
@@ -235,9 +235,7 @@ static SYCL_BLAS_INLINE cl::sycl::event execute_tree(
   cl::sycl::event ev;
   try {
     auto cg1 = [=](cl::sycl::handler &h) mutable {
-#ifdef SB_ENABLE_USM
       h.depends_on(dependencies);
-#endif
       t.bind(h);
       auto scratch = LocalMemory<value_t, using_local_memory>(shMem, h);
 

--- a/src/views/view.hpp
+++ b/src/views/view.hpp
@@ -42,15 +42,11 @@ namespace blas {
 */
 template <class _value_t, class _container_t, typename _IndexType,
           typename _IncrementType>
-SYCL_BLAS_INLINE
-VectorView<_value_t, _container_t, _IndexType, _IncrementType>::VectorView(
-    _container_t data, _IndexType disp, _IncrementType strd, _IndexType size)
-    : data_(data),
-      size_data_(size),
-      size_(size),
-      disp_(disp),
-      strd_(strd),
-      ptr_(data) {}
+SYCL_BLAS_INLINE VectorView<_value_t, _container_t, _IndexType,
+                            _IncrementType>::VectorView(_container_t data,
+                                                        _IncrementType strd,
+                                                        _IndexType size)
+    : data_(data), size_(size), strd_(strd), ptr_(data) {}
 
 /*!
  @brief Creates a view from an existing view.
@@ -60,40 +56,8 @@ template <class _value_t, class _container_t, typename _IndexType,
 SYCL_BLAS_INLINE
 VectorView<_value_t, _container_t, _IndexType, _IncrementType>::VectorView(
     VectorView<_value_t, _container_t, _IndexType, _IncrementType> opV,
-    _IndexType disp, _IncrementType strd, _IndexType size)
-    : data_(opV.get_data()),
-      size_data_(opV.get_data().size()),
-      size_(0),
-      disp_(disp),
-      strd_(strd),
-      ptr_(opV.get_data()) {
-  initialize(size);
-}
-
-/*!
-@brief Initializes the view using the indexing values.
-@param originalSize The original size of the container
-*/
-template <class _value_t, class _container_t, typename _IndexType,
-          typename _IncrementType>
-SYCL_BLAS_INLINE void
-VectorView<_value_t, _container_t, _IndexType, _IncrementType>::initialize(
-    _IndexType originalSize) {
-  if (strd_ > 0) {
-    auto sizeV = (size_data_ - disp_);
-    auto quot = (sizeV + strd_ - 1) / strd_;  // ceiling
-    size_ = quot;
-  } else if (strd_ > 0) {
-    auto nstrd = -strd_;
-    auto quot = (disp_ + nstrd) / nstrd;  // ceiling
-    size_ = quot;
-  } else {
-    // Stride is zero, not valid!
-    throw std::invalid_argument("Cannot create view with 0 stride");
-  }
-  if (originalSize < size_) size_ = originalSize;
-  if (strd_ < 0) disp_ += (size_ - 1) * strd_;
-}
+    _IncrementType strd, _IndexType size)
+    : data_(opV.get_data()), size_(size), strd_(strd), ptr_(opV.get_data()) {}
 
 /*!
  * @brief Returns a reference to the container
@@ -114,16 +78,6 @@ SYCL_BLAS_INLINE _value_t*
 VectorView<_value_t, _container_t, _IndexType, _IncrementType>::get_pointer() {
   return ptr_;
 }
-/*!
- * @brief Returns the displacement
- */
-template <class _value_t, class _container_t, typename _IndexType,
-          typename _IncrementType>
-SYCL_BLAS_INLINE _IndexType
-VectorView<_value_t, _container_t, _IndexType,
-           _IncrementType>::get_access_displacement() {
-  return disp_;
-}
 
 /*! adjust_access_displacement
  * @brief adjust pointer offset
@@ -133,16 +87,6 @@ template <class _value_t, class _container_t, typename _IndexType,
           typename _IncrementType>
 SYCL_BLAS_INLINE void VectorView<_value_t, _container_t, _IndexType,
                                  _IncrementType>::adjust_access_displacement() {
-}
-
-/*!
- * @brief Returns the size of the underlying container.
- */
-template <class _value_t, class _container_t, typename _IndexType,
-          typename _IncrementType>
-SYCL_BLAS_INLINE _IndexType VectorView<_value_t, _container_t, _IndexType,
-                                       _IncrementType>::get_data_size() {
-  return size_data_;
 }
 
 /*!
@@ -178,11 +122,9 @@ SYCL_BLAS_INLINE MatrixView<_value_t, _container_t, _IndexType,
                                                 _IndexType sizeR,
                                                 _IndexType sizeC)
     : data_(data),
-      size_data_(sizeR * sizeC),
       sizeR_(sizeR),
       sizeC_(sizeC),
       sizeL_((layout::is_col_major()) ? sizeR_ : sizeC_),
-      disp_(0),
       ptr_(data) {}
 
 /*!
@@ -197,15 +139,8 @@ template <class _value_t, class _container_t, typename _IndexType,
           typename layout>
 SYCL_BLAS_INLINE
 MatrixView<_value_t, _container_t, _IndexType, layout>::MatrixView(
-    _container_t data, _IndexType sizeR, _IndexType sizeC, _IndexType sizeL,
-    _IndexType disp)
-    : data_(data),
-      size_data_(sizeR * sizeC),
-      sizeR_(sizeR),
-      sizeC_(sizeC),
-      sizeL_(sizeL),
-      disp_(disp),
-      ptr_(data) {}
+    _container_t data, _IndexType sizeR, _IndexType sizeC, _IndexType sizeL)
+    : data_(data), sizeR_(sizeR), sizeC_(sizeC), sizeL_(sizeL), ptr_(data) {}
 
 /*!
  *@brief Creates a matrix view from the given one but with different access
@@ -221,14 +156,12 @@ template <class _value_t, class _container_t, typename _IndexType,
 SYCL_BLAS_INLINE
 MatrixView<_value_t, _container_t, _IndexType, layout>::MatrixView(
     MatrixView<_value_t, _container_t, _IndexType, layout> opM,
-    _IndexType sizeR, _IndexType sizeC, _IndexType sizeL, _IndexType disp)
-    : data_(opM.data_),
-      size_data_(opM.size_data_),
+    _IndexType sizeR, _IndexType sizeC, _IndexType sizeL)
+    : data_(opM.get_data()),
       sizeR_(sizeR),
       sizeC_(sizeC),
       sizeL_(sizeL),
-      disp_(disp),
-      ptr_(opM.data) {}
+      ptr_(opM.get_data()) {}
 
 /*!
  * @brief Returns the container
@@ -238,16 +171,6 @@ template <class _value_t, class _container_t, typename _IndexType,
 SYCL_BLAS_INLINE _container_t
 MatrixView<_value_t, _container_t, _IndexType, layout>::get_data() {
   return data_;
-}
-
-/*!
- * @brief Returns the data size
- */
-template <class _value_t, class _container_t, typename _IndexType,
-          typename layout>
-SYCL_BLAS_INLINE _IndexType
-MatrixView<_value_t, _container_t, _IndexType, layout>::get_data_size() const {
-  return size_data_;
 }
 
 /*!
@@ -302,17 +225,6 @@ template <class _value_t, class _container_t, typename _IndexType,
 SYCL_BLAS_INLINE const _IndexType
 MatrixView<_value_t, _container_t, _IndexType, layout>::getSizeL() const {
   return sizeL_;
-}
-
-/*! get_access_displacement.
- * @brief get displacement from the origin.
- */
-template <class _value_t, class _container_t, typename _IndexType,
-          typename layout>
-SYCL_BLAS_INLINE _IndexType
-MatrixView<_value_t, _container_t, _IndexType,
-           layout>::get_access_displacement() const {
-  return disp_;
 }
 
 /*! adjust_access_displacement.

--- a/src/views/view_sycl.hpp
+++ b/src/views/view_sycl.hpp
@@ -141,11 +141,6 @@ struct VectorView<
   /*!
    * @brief See VectorView.
    */
-  SYCL_BLAS_INLINE index_t get_access_displacement() const { return disp_; }
-
-  /*!
-   * @brief See VectorView.
-   */
   SYCL_BLAS_INLINE increment_t get_stride() const { return stride_; }
 
   /**** EVALUATING ****/
@@ -250,8 +245,6 @@ struct MatrixView<
   SYCL_BLAS_INLINE const index_t get_size_row() const { return sizeR_; }
 
   SYCL_BLAS_INLINE const index_t get_size_col() const { return sizeC_; }
-
-  SYCL_BLAS_INLINE index_t get_access_displacement() const { return disp_; }
 
   SYCL_BLAS_INLINE scalar_t *get_pointer() const { return ptr_; }
 

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -48,10 +48,10 @@ set(SYCL_UNITTEST_SRCS
   ${SYCLBLAS_UNITTEST}/blas2/blas2_syr2_test.cpp
   ${SYCLBLAS_UNITTEST}/blas2/blas2_symv_test.cpp
   # # Blas 3 tests
-  # ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_test.cpp
-  # ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_batched_test.cpp
-  # ${SYCLBLAS_UNITTEST}/blas3/blas3_trsm_test.cpp
-  # ${SYCLBLAS_UNITTEST}/blas3/blas3_symm_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas3/blas3_gemm_batched_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas3/blas3_trsm_test.cpp
+  ${SYCLBLAS_UNITTEST}/blas3/blas3_symm_test.cpp
 )
 
 # Enable testing of the sycl 2020 routines just for Intel DPC++

--- a/test/unittest/blas3/blas3_gemm_batched_test.cpp
+++ b/test/unittest/blas3/blas3_gemm_batched_test.cpp
@@ -28,6 +28,7 @@
 
 template <typename scalar_t>
 const auto BetaNonZeroLDMatch = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(0),                          // offset
     ::testing::Values(5),                          // batch
     ::testing::Values(63, 128),                    // m
@@ -46,6 +47,7 @@ GENERATE_GEMM_TEST(BatchGemm, BetaNonZeroLDMatch);
 
 template <typename scalar_t>
 const auto BetaNonZeroLDMultiplied = ::testing::Combine(
+    ::testing::Values("usm", "buf"),   // allocation type
     ::testing::Values(0),              // offset
     ::testing::Values(1, 5),           // batch
     ::testing::Values(63, 128, 129),   // m
@@ -65,6 +67,7 @@ GENERATE_GEMM_TEST(BatchGemm, BetaNonZeroLDMultiplied);
 
 template <typename scalar_t>
 const auto BetaNonZeroLDMatchAlpha0 = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(0),                          // offset
     ::testing::Values(5),                          // batch
     ::testing::Values(128),                        // m
@@ -83,6 +86,7 @@ GENERATE_GEMM_TEST(BatchGemm, BetaNonZeroLDMatchAlpha0);
 
 template <typename scalar_t>
 const auto BetaNonZeroLDMultipliedAlpha0 = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(0),                          // offset
     ::testing::Values(5),                          // batch
     ::testing::Values(63),                         // m
@@ -102,7 +106,8 @@ GENERATE_GEMM_TEST(BatchGemm, BetaNonZeroLDMultipliedAlpha0);
 // GEMM STRIDED BATCHED tests
 template <typename scalar_t>
 const auto DefaultGemmAndGemmBatched =
-    ::testing::Combine(::testing::Values(0),              // offset
+    ::testing::Combine(::testing::Values("usm", "buf"),   // allocation type
+                       ::testing::Values(0),              // offset
                        ::testing::Values(1, 5),           // batch
                        ::testing::Values(63, 128),        // m
                        ::testing::Values(63, 128),        // n
@@ -122,7 +127,8 @@ GENERATE_GEMM_STRIDED_BATCHED_TEST(BatchStridedGemm, DefaultGemmAndGemmBatched);
 
 template <typename scalar_t>
 const auto AllStridedBatched =
-    ::testing::Combine(::testing::Values(0),              // offset
+    ::testing::Combine(::testing::Values("usm", "buf"),   // allocation type
+                       ::testing::Values(0),              // offset
                        ::testing::Values(5),              // batch
                        ::testing::Values(128),            // m
                        ::testing::Values(128),            // n

--- a/test/unittest/blas3/blas3_gemm_common.hpp
+++ b/test/unittest/blas3/blas3_gemm_common.hpp
@@ -28,13 +28,14 @@
 #include "blas_test.hpp"
 
 template <typename T>
-using gemm_arguments_t = std::tuple<int, int, int, int, int, char, char, T, T,
-                                    int, int, int, gemm_batch_type_t>;
+using gemm_arguments_t =
+    std::tuple<std::string, int, int, int, int, int, char, char, T, T, int, int,
+               int, gemm_batch_type_t>;
 
 template <typename T>
 using gemm_batched_strided_arguments_t =
-    std::tuple<int, int, int, int, int, char, char, T, T, int, int, int, int,
-               int, int>;
+    std::tuple<std::string, int, int, int, int, int, char, char, T, T, int, int,
+               int, int, int, int>;
 
 // Convert batch_type=strided to interleaved on the host
 template <typename scalar_t>
@@ -70,8 +71,9 @@ inline std::vector<scalar_t> interleaved_to_strided(
   return output;
 }
 
-template <typename scalar_t>
+template <typename scalar_t, helper::AllocType mem_alloc>
 inline void verify_gemm(const gemm_arguments_t<scalar_t> arguments) {
+  std::string alloc;
   index_t offset;
   index_t batch;
   index_t m;
@@ -85,7 +87,7 @@ inline void verify_gemm(const gemm_arguments_t<scalar_t> arguments) {
   index_t ldb_mul;
   index_t ldc_mul;
   gemm_batch_type_t batch_type;
-  std::tie(offset, batch, m, n, k, transa, transb, alpha, beta, lda_mul,
+  std::tie(alloc, offset, batch, m, n, k, transa, transb, alpha, beta, lda_mul,
            ldb_mul, ldc_mul, batch_type) = arguments;
 
   const char ta_str[2] = {transa, '\0'};
@@ -131,29 +133,33 @@ inline void verify_gemm(const gemm_arguments_t<scalar_t> arguments) {
     c_m_gpu = strided_to_interleaved(c_m_gpu, offset, ldc, n, batch);
   }
 
-  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(buffer_size_a);
-  auto m_b_gpu = blas::make_sycl_iterator_buffer<scalar_t>(buffer_size_b);
-  auto m_c_gpu = blas::make_sycl_iterator_buffer<scalar_t>(buffer_size_c);
+  auto m_a_gpu = blas::helper::allocate<mem_alloc, scalar_t>(buffer_size_a, q);
+  auto m_b_gpu = blas::helper::allocate<mem_alloc, scalar_t>(buffer_size_b, q);
+  auto m_c_gpu = blas::helper::allocate<mem_alloc, scalar_t>(buffer_size_c, q);
 
-  blas::helper::copy_to_device(sb_handle.get_queue(), a_m.data(), m_a_gpu,
-                               buffer_size_a);
-  blas::helper::copy_to_device(sb_handle.get_queue(), b_m.data(), m_b_gpu,
-                               buffer_size_b);
-  blas::helper::copy_to_device(sb_handle.get_queue(), c_m_gpu.data(), m_c_gpu,
-                               buffer_size_c);
+  auto copy_a =
+      blas::helper::copy_to_device(q, a_m.data(), m_a_gpu, buffer_size_a);
+  auto copy_b =
+      blas::helper::copy_to_device(q, b_m.data(), m_b_gpu, buffer_size_b);
+  auto copy_c =
+      blas::helper::copy_to_device(q, c_m_gpu.data(), m_c_gpu, buffer_size_c);
 
   // SYCL BLAS GEMM implementation
+  typename blas::SB_Handle::event_t gemm_event;
   if (batch == 1) {
-    _gemm(sb_handle, transa, transb, m, n, k, alpha, m_a_gpu + offset, lda,
-          m_b_gpu + offset, ldb, beta, m_c_gpu + offset, ldc);
+    gemm_event = _gemm(sb_handle, transa, transb, m, n, k, alpha,
+                       m_a_gpu + offset, lda, m_b_gpu + offset, ldb, beta,
+                       m_c_gpu + offset, ldc, {copy_a, copy_b, copy_c});
   } else {
-    _gemm_batched(sb_handle, transa, transb, m, n, k, alpha, m_a_gpu + offset,
-                  lda, m_b_gpu + offset, ldb, beta, m_c_gpu + offset, ldc,
-                  batch, batch_type);
+    gemm_event = _gemm_batched(sb_handle, transa, transb, m, n, k, alpha,
+                               m_a_gpu + offset, lda, m_b_gpu + offset, ldb,
+                               beta, m_c_gpu + offset, ldc, batch, batch_type,
+                               {copy_a, copy_b, copy_c});
   }
+  sb_handle.wait(gemm_event);
 
-  auto event = blas::helper::copy_to_host(sb_handle.get_queue(), m_c_gpu,
-                                          c_m_gpu.data(), buffer_size_c);
+  auto event =
+      blas::helper::copy_to_host(q, m_c_gpu, c_m_gpu.data(), buffer_size_c);
   sb_handle.wait(event);
 
   if (batch > 1 && batch_type == gemm_batch_type_t::interleaved) {
@@ -164,6 +170,38 @@ inline void verify_gemm(const gemm_arguments_t<scalar_t> arguments) {
 
   const bool isAlmostEqual = utils::compare_vectors(c_m_gpu, c_m_cpu);
   ASSERT_TRUE(isAlmostEqual);
+
+  helper::deallocate<mem_alloc>(m_a_gpu, q);
+  helper::deallocate<mem_alloc>(m_b_gpu, q);
+  helper::deallocate<mem_alloc>(m_c_gpu, q);
+}
+
+template <typename scalar_t>
+inline void verify_gemm(const gemm_arguments_t<scalar_t> arguments) {
+  std::string alloc;
+  index_t offset;
+  index_t batch;
+  index_t m;
+  index_t n;
+  index_t k;
+  char transa;
+  char transb;
+  scalar_t alpha;
+  scalar_t beta;
+  index_t lda_mul;
+  index_t ldb_mul;
+  index_t ldc_mul;
+  gemm_batch_type_t batch_type;
+  std::tie(alloc, offset, batch, m, n, k, transa, transb, alpha, beta, lda_mul,
+           ldb_mul, ldc_mul, batch_type) = arguments;
+
+  if (alloc == "usm") {
+#ifdef SB_ENABLE_USM
+    verify_gemm<scalar_t, helper::AllocType::usm>(arguments);
+#endif
+  } else {
+    verify_gemm<scalar_t, helper::AllocType::buffer>(arguments);
+  }
 }
 
 template <>
@@ -175,17 +213,19 @@ inline void dump_arg<gemm_batch_type_t>(std::ostream& ss,
 template <class T>
 static std::string generate_name(
     const ::testing::TestParamInfo<gemm_arguments_t<T>>& info) {
+  std::string alloc;
   int offset, batch, m, n, k, ldaMul, ldbMul, ldcMul;
   char transa, transb;
   T alpha, beta;
   gemm_batch_type_t batchType;
-  BLAS_GENERATE_NAME(info.param, offset, batch, m, n, k, transa, transb, alpha,
-                     beta, ldaMul, ldbMul, ldcMul, batchType);
+  BLAS_GENERATE_NAME(info.param, alloc, offset, batch, m, n, k, transa, transb,
+                     alpha, beta, ldaMul, ldbMul, ldcMul, batchType);
 }
 
-template <typename scalar_t>
+template <typename scalar_t, helper::AllocType mem_alloc>
 inline void verify_gemm(
     const gemm_batched_strided_arguments_t<scalar_t> arguments) {
+  std::string alloc;
   index_t offset;
   index_t batch;
   index_t m;
@@ -201,7 +241,7 @@ inline void verify_gemm(
   index_t stride_a_mul;
   index_t stride_b_mul;
   index_t stride_c_mul;
-  std::tie(offset, batch, m, n, k, transa, transb, alpha, beta, lda_mul,
+  std::tie(alloc, offset, batch, m, n, k, transa, transb, alpha, beta, lda_mul,
            ldb_mul, ldc_mul, stride_a_mul, stride_b_mul, stride_c_mul) =
       arguments;
 
@@ -244,24 +284,26 @@ inline void verify_gemm(
                          c_m_cpu.data() + i * stride_c + offset, ldc);
   }
 
-  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(buffer_size_a);
-  auto m_b_gpu = blas::make_sycl_iterator_buffer<scalar_t>(buffer_size_b);
-  auto m_c_gpu = blas::make_sycl_iterator_buffer<scalar_t>(buffer_size_c);
+  auto m_a_gpu = blas::helper::allocate<mem_alloc, scalar_t>(buffer_size_a, q);
+  auto m_b_gpu = blas::helper::allocate<mem_alloc, scalar_t>(buffer_size_b, q);
+  auto m_c_gpu = blas::helper::allocate<mem_alloc, scalar_t>(buffer_size_c, q);
 
-  blas::helper::copy_to_device(sb_handle.get_queue(), a_m.data(), m_a_gpu,
-                               buffer_size_a);
-  blas::helper::copy_to_device(sb_handle.get_queue(), b_m.data(), m_b_gpu,
-                               buffer_size_b);
-  blas::helper::copy_to_device(sb_handle.get_queue(), c_m_gpu.data(), m_c_gpu,
-                               buffer_size_c);
+  auto copy_a =
+      blas::helper::copy_to_device(q, a_m.data(), m_a_gpu, buffer_size_a);
+  auto copy_b =
+      blas::helper::copy_to_device(q, b_m.data(), m_b_gpu, buffer_size_b);
+  auto copy_c =
+      blas::helper::copy_to_device(q, c_m_gpu.data(), m_c_gpu, buffer_size_c);
 
   // SYCL BLAS GEMM STRIDED BATCHED implementation
-  _gemm_strided_batched(sb_handle, transa, transb, m, n, k, alpha,
-                        m_a_gpu + offset, lda, stride_a, m_b_gpu + offset, ldb,
-                        stride_b, beta, m_c_gpu + offset, ldc, stride_c, batch);
+  auto gemm_batched_event = _gemm_strided_batched(
+      sb_handle, transa, transb, m, n, k, alpha, m_a_gpu + offset, lda,
+      stride_a, m_b_gpu + offset, ldb, stride_b, beta, m_c_gpu + offset, ldc,
+      stride_c, batch, {copy_a, copy_b, copy_c});
 
-  auto event = blas::helper::copy_to_host(sb_handle.get_queue(), m_c_gpu,
-                                          c_m_gpu.data(), buffer_size_c);
+  sb_handle.wait({gemm_batched_event});
+  auto event =
+      blas::helper::copy_to_host(q, m_c_gpu, c_m_gpu.data(), buffer_size_c);
   sb_handle.wait(event);
 
   const bool isAlmostEqual =
@@ -269,18 +311,55 @@ inline void verify_gemm(
           ? utils::compare_vectors(c_m_gpu, c_m_cpu)
           : utils::compare_vectors_strided(c_m_gpu, c_m_cpu, stride_c, size_c);
   ASSERT_TRUE(isAlmostEqual);
+
+  helper::deallocate<mem_alloc>(m_a_gpu, q);
+  helper::deallocate<mem_alloc>(m_b_gpu, q);
+  helper::deallocate<mem_alloc>(m_c_gpu, q);
+}
+
+template <typename scalar_t>
+inline void verify_gemm(
+    const gemm_batched_strided_arguments_t<scalar_t> arguments) {
+  std::string alloc;
+  index_t offset;
+  index_t batch;
+  index_t m;
+  index_t n;
+  index_t k;
+  char transa;
+  char transb;
+  scalar_t alpha;
+  scalar_t beta;
+  index_t lda_mul;
+  index_t ldb_mul;
+  index_t ldc_mul;
+  index_t stride_a_mul;
+  index_t stride_b_mul;
+  index_t stride_c_mul;
+  std::tie(alloc, offset, batch, m, n, k, transa, transb, alpha, beta, lda_mul,
+           ldb_mul, ldc_mul, stride_a_mul, stride_b_mul, stride_c_mul) =
+      arguments;
+
+  if (alloc == "usm") {
+#ifdef SB_ENABLE_USM
+    verify_gemm<scalar_t, helper::AllocType::usm>(arguments);
+#endif
+  } else {
+    verify_gemm<scalar_t, helper::AllocType::buffer>(arguments);
+  }
 }
 
 template <class T>
 static std::string generate_batched_strided_name(
     const ::testing::TestParamInfo<gemm_batched_strided_arguments_t<T>>& info) {
+  std::string alloc;
   int offset, batch, m, n, k, ldaMul, ldbMul, ldcMul, stride_a_mul,
       stride_b_mul, stride_c_mul;
   char transa, transb;
   T alpha, beta;
-  BLAS_GENERATE_NAME(info.param, offset, batch, m, n, k, transa, transb, alpha,
-                     beta, ldaMul, ldbMul, ldcMul, stride_a_mul, stride_b_mul,
-                     stride_c_mul);
+  BLAS_GENERATE_NAME(info.param, alloc, offset, batch, m, n, k, transa, transb,
+                     alpha, beta, ldaMul, ldbMul, ldcMul, stride_a_mul,
+                     stride_b_mul, stride_c_mul);
 }
 
 /** Registers GEMM test for all supported data types

--- a/test/unittest/blas3/blas3_gemm_common.hpp
+++ b/test/unittest/blas3/blas3_gemm_common.hpp
@@ -198,6 +198,8 @@ inline void verify_gemm(const gemm_arguments_t<scalar_t> arguments) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     verify_gemm<scalar_t, helper::AllocType::usm>(arguments);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     verify_gemm<scalar_t, helper::AllocType::buffer>(arguments);

--- a/test/unittest/blas3/blas3_gemm_tall_skinny_test.cpp
+++ b/test/unittest/blas3/blas3_gemm_tall_skinny_test.cpp
@@ -28,6 +28,7 @@
 
 template <typename scalar_t>
 const auto BetaNonZeroLDMatch = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(0),                          // offset
     ::testing::Values(1),                          // batch
     ::testing::Values(7, 65),                      // m
@@ -46,6 +47,7 @@ GENERATE_GEMM_TEST(TallSkinnyGemm, BetaNonZeroLDMatch);
 
 template <typename scalar_t>
 const auto BetaNonZeroLDMultiplied = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(0),                          // offset
     ::testing::Values(1),                          // batch
     ::testing::Values(7, 65),                      // m
@@ -64,6 +66,7 @@ GENERATE_GEMM_TEST(TallSkinnyGemm, BetaNonZeroLDMultiplied);
 
 template <typename scalar_t>
 const auto BetaZero = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(0),                          // offset
     ::testing::Values(1),                          // batch
     ::testing::Values(7),                          // m
@@ -82,6 +85,7 @@ GENERATE_GEMM_TEST(TallSkinnyGemm, BetaZero);
 
 template <typename scalar_t>
 const auto OffsetNonZero = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(10),                         // offset
     ::testing::Values(1),                          // batch
     ::testing::Values(7),                          // m

--- a/test/unittest/blas3/blas3_gemm_test.cpp
+++ b/test/unittest/blas3/blas3_gemm_test.cpp
@@ -28,6 +28,7 @@
 
 template <typename scalar_t>
 const auto SmallBetaNonZeroLDMatch = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(0),                          // offset
     ::testing::Values(1),                          // batch
     ::testing::Values(11, 16, 32),                 // m
@@ -46,6 +47,7 @@ GENERATE_GEMM_TEST(Gemm, SmallBetaNonZeroLDMatch);
 
 template <typename scalar_t>
 const auto SmallBetaZeroLDMatch = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(0),                          // offset
     ::testing::Values(1),                          // batch
     ::testing::Values(11, 32),                     // m
@@ -64,6 +66,7 @@ GENERATE_GEMM_TEST(Gemm, SmallBetaZeroLDMatch);
 
 template <typename scalar_t>
 const auto SmallBetaZeroLDMultiplied = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(0),                          // offset
     ::testing::Values(1),                          // batch
     ::testing::Values(11, 32),                     // m
@@ -82,6 +85,7 @@ GENERATE_GEMM_TEST(Gemm, SmallBetaZeroLDMultiplied);
 
 template <typename scalar_t>
 const auto AlphaZero = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(0, 10),                      // offset
     ::testing::Values(1),                          // batch
     ::testing::Values(16),                         // m
@@ -100,6 +104,7 @@ GENERATE_GEMM_TEST(Gemm, AlphaZero);
 
 template <typename scalar_t>
 const auto OffsetNonZero = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(1, 10),                      // offset
     ::testing::Values(1),                          // batch
     ::testing::Values(16, 63),                     // m
@@ -118,6 +123,7 @@ GENERATE_GEMM_TEST(Gemm, OffsetNonZero);
 
 template <typename scalar_t>
 const auto LargeBetaNonZeroLDMatch = ::testing::Combine(
+    ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(0),                          // offset
     ::testing::Values(1),                          // batch
     ::testing::Values(253, 511),                   // m

--- a/test/unittest/blas3/blas3_symm_test.cpp
+++ b/test/unittest/blas3/blas3_symm_test.cpp
@@ -28,10 +28,12 @@
 #include "blas_test.hpp"
 
 template <typename T>
-using symm_arguments_t = std::tuple<int, int, char, char, T, T, int, int, int>;
+using symm_arguments_t =
+    std::tuple<std::string, int, int, char, char, T, T, int, int, int>;
 
-template <typename scalar_t>
+template <typename scalar_t, helper::AllocType mem_alloc>
 inline void verify_symm(const symm_arguments_t<scalar_t> arguments) {
+  std::string alloc;
   index_t m;
   index_t n;
   char side;
@@ -41,7 +43,7 @@ inline void verify_symm(const symm_arguments_t<scalar_t> arguments) {
   index_t lda_mul;
   index_t ldb_mul;
   index_t ldc_mul;
-  std::tie(m, n, side, uplo, alpha, beta, lda_mul, ldb_mul, ldc_mul) =
+  std::tie(alloc, m, n, side, uplo, alpha, beta, lda_mul, ldb_mul, ldc_mul) =
       arguments;
 
   auto q = make_queue();
@@ -74,37 +76,66 @@ inline void verify_symm(const symm_arguments_t<scalar_t> arguments) {
   reference_blas::symm(side_str, uplo_str, m, n, alpha, a_m.data(), lda,
                        b_m.data(), ldb, beta, c_m_cpu.data(), ldc);
 
-  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(size_a);
-  auto m_b_gpu = blas::make_sycl_iterator_buffer<scalar_t>(size_b);
-  auto m_c_gpu = blas::make_sycl_iterator_buffer<scalar_t>(size_c);
+  auto m_a_gpu = blas::helper::allocate<mem_alloc, scalar_t>(size_a, q);
+  auto m_b_gpu = blas::helper::allocate<mem_alloc, scalar_t>(size_b, q);
+  auto m_c_gpu = blas::helper::allocate<mem_alloc, scalar_t>(size_c, q);
 
-  blas::helper::copy_to_device(sb_handle.get_queue(), a_m.data(), m_a_gpu,
-                               size_a);
-  blas::helper::copy_to_device(sb_handle.get_queue(), b_m.data(), m_b_gpu,
-                               size_b);
-  blas::helper::copy_to_device(sb_handle.get_queue(), c_m_gpu.data(), m_c_gpu,
-                               size_c);
+  auto copy_a = blas::helper::copy_to_device(q, a_m.data(), m_a_gpu, size_a);
+  auto copy_b = blas::helper::copy_to_device(q, b_m.data(), m_b_gpu, size_b);
+  auto copy_c =
+      blas::helper::copy_to_device(q, c_m_gpu.data(), m_c_gpu, size_c);
 
   // SYCL BLAS SYMM implementation
-  _symm(sb_handle, side, uplo, m, n, alpha, m_a_gpu, lda, m_b_gpu, ldb, beta,
-        m_c_gpu, ldc);
+  auto symm_event =
+      _symm(sb_handle, side, uplo, m, n, alpha, m_a_gpu, lda, m_b_gpu, ldb,
+            beta, m_c_gpu, ldc, {copy_a, copy_b, copy_c});
 
-  auto event = blas::helper::copy_to_host(sb_handle.get_queue(), m_c_gpu,
-                                          c_m_gpu.data(), size_c);
+  sb_handle.wait(symm_event);
+
+  auto event = blas::helper::copy_to_host(q, m_c_gpu, c_m_gpu.data(), size_c);
   sb_handle.wait(event);
 
   const bool isAlmostEqual = utils::compare_vectors(c_m_gpu, c_m_cpu);
   ASSERT_TRUE(isAlmostEqual);
+
+  helper::deallocate<mem_alloc>(m_a_gpu, q);
+  helper::deallocate<mem_alloc>(m_b_gpu, q);
+  helper::deallocate<mem_alloc>(m_c_gpu, q);
+}
+
+template <typename scalar_t>
+inline void verify_symm(const symm_arguments_t<scalar_t> arguments) {
+  std::string alloc;
+  index_t m;
+  index_t n;
+  char side;
+  char uplo;
+  scalar_t alpha;
+  scalar_t beta;
+  index_t lda_mul;
+  index_t ldb_mul;
+  index_t ldc_mul;
+  std::tie(alloc, m, n, side, uplo, alpha, beta, lda_mul, ldb_mul, ldc_mul) =
+      arguments;
+
+  if (alloc == "usm") {
+#ifdef SB_ENABLE_USM
+    verify_symm<scalar_t, helper::AllocType::usm>(arguments);
+#endif
+  } else {
+    verify_symm<scalar_t, helper::AllocType::buffer>(arguments);
+  }
 }
 
 template <class T>
 static std::string generate_name(
     const ::testing::TestParamInfo<symm_arguments_t<T>>& info) {
+  std::string alloc;
   int m, n, ldaMul, ldbMul, ldcMul;
   char side, uplo;
   T alpha, beta;
-  BLAS_GENERATE_NAME(info.param, m, n, side, uplo, alpha, beta, ldaMul, ldbMul,
-                     ldcMul);
+  BLAS_GENERATE_NAME(info.param, alloc, m, n, side, uplo, alpha, beta, ldaMul,
+                     ldbMul, ldcMul);
 }
 
 /** Registers SYMM test for all supported data types
@@ -119,7 +150,8 @@ static std::string generate_name(
 
 template <typename scalar_t>
 const auto SmallBetaNonZeroLDMatch =
-    ::testing::Combine(::testing::Values(11, 16, 32),     // m
+    ::testing::Combine(::testing::Values("usm", "buf"),   // allocation type
+                       ::testing::Values(11, 16, 32),     // m
                        ::testing::Values(11, 16, 32),     // n
                        ::testing::Values('l', 'r'),       // side
                        ::testing::Values('l', 'u'),       // uplo
@@ -133,11 +165,12 @@ GENERATE_SYMM_TEST(Symm, SmallBetaNonZeroLDMatch);
 
 template <typename scalar_t>
 const auto AlphaZero =
-    ::testing::Combine(::testing::Values(16),                  // m
-                       ::testing::Values(16),                  // n
-                       ::testing::Values('l', 'r'),            // side
-                       ::testing::Values('l', 'u'),            // uplo
-                       ::testing::Values<scalar_t>(0.0),       // alpha
+    ::testing::Combine(::testing::Values("usm", "buf"),   // allocation type
+                       ::testing::Values(16),             // m
+                       ::testing::Values(16),             // n
+                       ::testing::Values('l', 'r'),       // side
+                       ::testing::Values('l', 'u'),       // uplo
+                       ::testing::Values<scalar_t>(0.0),  // alpha
                        ::testing::Values<scalar_t>(0.0, 1.0),  // beta
                        ::testing::Values(1, 2),                // lda_mul
                        ::testing::Values(1, 2),                // ldb_mul
@@ -147,7 +180,8 @@ GENERATE_SYMM_TEST(Symm, AlphaZero);
 
 template <typename scalar_t>
 const auto OffsetNonZero =
-    ::testing::Combine(::testing::Values(16, 63),         // m
+    ::testing::Combine(::testing::Values("usm", "buf"),   // allocation type
+                       ::testing::Values(16, 63),         // m
                        ::testing::Values(16, 63),         // n
                        ::testing::Values('l', 'r'),       // side
                        ::testing::Values('l', 'u'),       // uplo
@@ -161,7 +195,8 @@ GENERATE_SYMM_TEST(Symm, OffsetNonZero);
 
 template <typename scalar_t>
 const auto LargeBetaNonZeroLDMatch =
-    ::testing::Combine(::testing::Values(253, 511),       // m
+    ::testing::Combine(::testing::Values("usm", "buf"),   // allocation type
+                       ::testing::Values(253, 511),       // m
                        ::testing::Values(257, 511),       // n
                        ::testing::Values('l', 'r'),       // side
                        ::testing::Values('l', 'u'),       // uplo

--- a/test/unittest/blas3/blas3_symm_test.cpp
+++ b/test/unittest/blas3/blas3_symm_test.cpp
@@ -121,6 +121,8 @@ inline void verify_symm(const symm_arguments_t<scalar_t> arguments) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     verify_symm<scalar_t, helper::AllocType::usm>(arguments);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     verify_symm<scalar_t, helper::AllocType::buffer>(arguments);

--- a/test/unittest/blas3/blas3_trsm_test.cpp
+++ b/test/unittest/blas3/blas3_trsm_test.cpp
@@ -111,6 +111,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas3/blas3_trsm_test.cpp
+++ b/test/unittest/blas3/blas3_trsm_test.cpp
@@ -24,11 +24,12 @@
 #include "blas_test.hpp"
 
 template <typename scalar_t>
-using combination_t = std::tuple<int, int, char, char, char, char, scalar_t,
-                                 scalar_t, scalar_t, scalar_t>;
+using combination_t = std::tuple<std::string, int, int, char, char, char, char,
+                                 scalar_t, scalar_t, scalar_t, scalar_t>;
 
-template <typename scalar_t>
+template <typename scalar_t, helper::AllocType mem_alloc>
 void run_test(const combination_t<scalar_t> combi) {
+  std::string alloc;
   index_t m;
   index_t n;
   char trans;
@@ -39,8 +40,8 @@ void run_test(const combination_t<scalar_t> combi) {
   scalar_t ldaMul;
   scalar_t ldbMul;
   scalar_t unusedValue;
-  std::tie(m, n, trans, side, diag, uplo, alpha, ldaMul, ldbMul, unusedValue) =
-      combi;
+  std::tie(alloc, m, n, trans, side, diag, uplo, alpha, ldaMul, ldbMul,
+           unusedValue) = combi;
 
   const index_t lda = (side == 'l' ? m : n) * ldaMul;
   const index_t ldb = m * ldbMul;
@@ -69,31 +70,64 @@ void run_test(const combination_t<scalar_t> combi) {
 
   auto q = make_queue();
   blas::SB_Handle sb_handle(q);
-  auto a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(A, A.size());
-  auto b_gpu = blas::make_sycl_iterator_buffer<scalar_t>(B, B.size());
+  auto a_gpu = helper::allocate<mem_alloc, scalar_t>(A.size(), q);
+  auto b_gpu = helper::allocate<mem_alloc, scalar_t>(B.size(), q);
 
-  _trsm(sb_handle, side, uplo, trans, diag, m, n, alpha, a_gpu, lda, b_gpu,
-        ldb);
+  auto copy_a = helper::copy_to_device<scalar_t>(q, A.data(), a_gpu, A.size());
+  auto copy_b = helper::copy_to_device<scalar_t>(q, B.data(), b_gpu, B.size());
 
-  auto event = blas::helper::copy_to_host<scalar_t>(sb_handle.get_queue(),
-                                                    b_gpu, B.data(), B.size());
+  auto trsm_event = _trsm(sb_handle, side, uplo, trans, diag, m, n, alpha,
+                          a_gpu, lda, b_gpu, ldb, {copy_a, copy_b});
+  sb_handle.wait({trsm_event});
+
+  auto event =
+      blas::helper::copy_to_host<scalar_t>(q, b_gpu, B.data(), B.size());
   sb_handle.wait(event);
 
   bool isAlmostEqual = utils::compare_vectors(cpu_B, B);
 
   ASSERT_TRUE(isAlmostEqual);
+
+  helper::deallocate<mem_alloc>(a_gpu, q);
+  helper::deallocate<mem_alloc>(b_gpu, q);
+}
+
+template <typename scalar_t>
+void run_test(const combination_t<scalar_t> combi) {
+  std::string alloc;
+  index_t m;
+  index_t n;
+  char trans;
+  char side;
+  char diag;
+  char uplo;
+  scalar_t alpha;
+  scalar_t ldaMul;
+  scalar_t ldbMul;
+  scalar_t unusedValue;
+  std::tie(alloc, m, n, trans, side, diag, uplo, alpha, ldaMul, ldbMul,
+           unusedValue) = combi;
+
+  if (alloc == "usm") {
+#ifdef SB_ENABLE_USM
+    run_test<scalar_t, helper::AllocType::usm>(combi);
+#endif
+  } else {
+    run_test<scalar_t, helper::AllocType::buffer>(combi);
+  }
 }
 
 static constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
 
 template <typename scalar_t>
 const auto combi =
-    ::testing::Combine(::testing::Values(7, 513, 1027),        // m
-                       ::testing::Values(7, 513, 1027),        // n
-                       ::testing::Values('n', 't'),            // trans
-                       ::testing::Values('l', 'r'),            // side
-                       ::testing::Values('u', 'n'),            // diag
-                       ::testing::Values('l', 'u'),            // uplo
+    ::testing::Combine(::testing::Values("usm", "buf"),  // allocation type
+                       ::testing::Values(7, 513, 1027),  // m
+                       ::testing::Values(7, 513, 1027),  // n
+                       ::testing::Values('n', 't'),      // trans
+                       ::testing::Values('l', 'r'),      // side
+                       ::testing::Values('u', 'n'),      // diag
+                       ::testing::Values('l', 'u'),      // uplo
                        ::testing::Values<scalar_t>(1.0, 2.0),  // alpha
                        ::testing::Values<scalar_t>(1.0, 2.0),  // lda_mul
                        ::testing::Values<scalar_t>(1.0, 2.0),  // ldb_mul
@@ -106,11 +140,12 @@ const auto combi =
 template <class T>
 static std::string generate_name(
     const ::testing::TestParamInfo<combination_t<T>>& info) {
+  std::string alloc;
   int m, n;
   char trans, side, diag, uplo;
   T alpha, ldaMul, ldbMul, unusedValue;
-  BLAS_GENERATE_NAME(info.param, m, n, trans, side, diag, uplo, alpha, ldaMul,
-                     ldbMul, unusedValue);
+  BLAS_GENERATE_NAME(info.param, alloc, m, n, trans, side, diag, uplo, alpha,
+                     ldaMul, ldbMul, unusedValue);
 }
 
 BLAS_REGISTER_TEST_ALL(Trsm, combination_t, combi, generate_name);


### PR DESCRIPTION
This PR extends the USM support in SYCL-BLAS for Level 3 operators. All Level 3 benchmarks and tests now use USM and Buffers.

FYI: This PR is blocked by #385 and #388  