### PR TITLE
Add missing benchmarks for level 2 operators

### DIFF
--- a/benchmark/clBench/clblast/CMakeLists.txt
+++ b/benchmark/clBench/clblast/CMakeLists.txt
@@ -46,6 +46,7 @@ set(sources
   blas2/syr.cpp
   blas2/syr2.cpp
   blas2/tbmv.cpp
+  blas2/trmv.cpp
   blas2/spr.cpp
   # Level 3 blas
   blas3/gemm.cpp

--- a/benchmark/clBench/clblast/CMakeLists.txt
+++ b/benchmark/clBench/clblast/CMakeLists.txt
@@ -42,6 +42,7 @@ set(sources
   blas2/gemv.cpp
   blas2/ger.cpp
   blas2/sbmv.cpp
+  blas2/symv.cpp
   blas2/tbmv.cpp
   blas2/spr.cpp
   # Level 3 blas

--- a/benchmark/clBench/clblast/CMakeLists.txt
+++ b/benchmark/clBench/clblast/CMakeLists.txt
@@ -44,6 +44,7 @@ set(sources
   blas2/sbmv.cpp
   blas2/symv.cpp
   blas2/syr.cpp
+  blas2/syr2.cpp
   blas2/tbmv.cpp
   blas2/spr.cpp
   # Level 3 blas

--- a/benchmark/clBench/clblast/CMakeLists.txt
+++ b/benchmark/clBench/clblast/CMakeLists.txt
@@ -43,6 +43,7 @@ set(sources
   blas2/ger.cpp
   blas2/sbmv.cpp
   blas2/symv.cpp
+  blas2/syr.cpp
   blas2/tbmv.cpp
   blas2/spr.cpp
   # Level 3 blas

--- a/benchmark/clBench/clblast/CMakeLists.txt
+++ b/benchmark/clBench/clblast/CMakeLists.txt
@@ -40,6 +40,7 @@ set(sources
   # Level 2 blas
   blas2/gbmv.cpp
   blas2/gemv.cpp
+  blas2/ger.cpp
   blas2/sbmv.cpp
   blas2/tbmv.cpp
   blas2/spr.cpp

--- a/benchmark/clBench/clblast/blas2/ger.cpp
+++ b/benchmark/clBench/clblast/blas2/ger.cpp
@@ -1,0 +1,164 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename ger.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(int m, int n) {
+  std::ostringstream str{};
+  str << "BM_Ger<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << m << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, ExecutorType* executorPtr, index_t m,
+         index_t n, scalar_t alpha, bool* success) {
+  // Standard test setup.
+
+  index_t xlen = m;
+  index_t ylen = n;
+
+  index_t lda = m;
+  index_t incX = 1;
+  index_t incY = 1;
+
+  // The counters are double. We convert m and n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  const double m_d = static_cast<double>(m);
+  const double n_d = static_cast<double>(n);
+
+  state.counters["m"] = m_d;
+  state.counters["n"] = n_d;
+
+  const double nflops_timesAlpha = std::min(m, n);
+  const double nflops_XtimesYplusA = 2 * m_d * n_d;
+  const double nflops_tot = nflops_XtimesYplusA + nflops_timesAlpha;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  const double mem_readWriteA = 2 * m_d * n_d;
+  const double mem_readX = xlen;
+  const double mem_readY = ylen;
+  state.counters["bytes_processed"] =
+      (mem_readWriteA + mem_readX + mem_readY) * sizeof(scalar_t);
+
+  ExecutorType& sb_handle = *executorPtr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(m * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+  std::vector<scalar_t> v_y =
+      blas_benchmark::utils::random_data<scalar_t>(ylen);
+
+  auto layout = clblast::Layout::kColMajor;
+
+  MemBuffer<scalar_t> m_a_gpu(executorPtr, m_a.data(),
+                              static_cast<size_t>(m * n));
+  MemBuffer<scalar_t> v_x_gpu(executorPtr, v_x.data(),
+                              static_cast<size_t>(xlen));
+  MemBuffer<scalar_t> v_y_gpu(executorPtr, v_y.data(),
+                              static_cast<size_t>(ylen));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> m_a_ref = m_a;
+  reference_blas::ger(m, n, alpha, v_x.data(), incX, v_y.data(), incY,
+                      m_a_ref.data(), lda);
+  std::vector<scalar_t> m_a_temp(m_a);
+
+  {
+    MemBuffer<scalar_t> m_a_temp_gpu(executorPtr, m_a_temp.data(),
+                                     static_cast<size_t>(m * n));
+    cl_event event;
+    clblast::Ger(layout, m, n, alpha, v_x_gpu.dev(), 0, incX, v_y_gpu.dev(), 0,
+                 incY, m_a_temp_gpu.dev(), 0, lda, executorPtr->_queue(),
+                 &event);
+    CLEventHandler::wait(event);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(m_a_temp, m_a_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl_event> {
+    cl_event event;
+    clblast::Ger(layout, m, n, alpha, v_x_gpu.dev(), 0, incX, v_y_gpu.dev(), 0,
+                 incY, m_a_gpu.dev(), 0, lda, executorPtr->_queue(), &event);
+    CLEventHandler::wait(event);
+    return {event};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, ExecutorType* executorPtr,
+                        bool* success) {
+  auto ger_params = blas_benchmark::utils::get_ger_params<scalar_t>(args);
+
+  for (auto p : ger_params) {
+    index_t m, n;
+    scalar_t alpha;
+    std::tie(m, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, ExecutorType* executorPtr,
+                         index_t m, index_t n, scalar_t alpha, bool* success) {
+      run<scalar_t>(st, executorPtr, m, n, alpha, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(m, n).c_str(), BM_lambda,
+                                 executorPtr, m, n, alpha, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, ExecutorType* executorPtr,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, executorPtr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/clBench/clblast/blas2/ger.cpp
+++ b/benchmark/clBench/clblast/blas2/ger.cpp
@@ -61,8 +61,9 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t m,
   const double mem_readWriteA = 2 * m_d * n_d;
   const double mem_readX = xlen;
   const double mem_readY = ylen;
-  state.counters["bytes_processed"] =
+  const double tot_mem_processed =
       (mem_readWriteA + mem_readX + mem_readY) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = tot_mem_processed;
 
   ExecutorType& sb_handle = *executorPtr;
 
@@ -132,6 +133,7 @@ void run(benchmark::State& state, ExecutorType* executorPtr, index_t m,
     blas_benchmark::utils::update_counters(state, times);
   }
 
+  state.SetBytesProcessed(state.iterations() * tot_mem_processed);
   state.SetItemsProcessed(state.iterations() * nflops_tot);
 
   blas_benchmark::utils::calc_avg_counters(state);

--- a/benchmark/clBench/clblast/blas2/symv.cpp
+++ b/benchmark/clBench/clblast/blas2/symv.cpp
@@ -1,0 +1,176 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename symv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, int n, scalar_t alpha, scalar_t beta) {
+  std::ostringstream str{};
+  str << "BM_Symv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n << "/" << alpha << "/" << beta;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
+         index_t n, scalar_t alpha, scalar_t beta, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+
+  index_t incX = 1;
+  index_t incY = 1;
+
+  index_t lda = n;
+  index_t xlen = n;
+  index_t ylen = n;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = (n_d * (n_d + 1) / 2);
+
+  const double nflops_AtimesX = 2 * n_d * n_d;
+  const double nflops_timesAlpha = xlen;
+  const double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
+  const double nflops_tot =
+      nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  const double mem_readA = A_validVal;
+  const double mem_readX = xlen;
+  const double mem_writeY = ylen;
+  const double mem_readY = (beta != scalar_t{0}) ? ylen : 0;
+  const double tot_mem_processed =
+      (mem_readA + mem_readX + mem_writeY + mem_readY) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = tot_mem_processed;
+
+  ExecutorType& ex = *executorPtr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+  std::vector<scalar_t> v_y =
+      blas_benchmark::utils::random_data<scalar_t>(ylen);
+
+  // Specify the triangle.
+  clblast::Triangle a_tr = blas_benchmark::utils::translate_triangle(uplo_str);
+
+  auto layout = clblast::Layout::kColMajor;
+
+  MemBuffer<scalar_t> m_a_gpu(executorPtr, m_a.data(),
+                              static_cast<size_t>(lda * n));
+  MemBuffer<scalar_t> v_x_gpu(executorPtr, v_x.data(),
+                              static_cast<size_t>(xlen));
+  MemBuffer<scalar_t> v_y_gpu(executorPtr, v_y.data(),
+                              static_cast<size_t>(ylen));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> v_y_ref = v_y;
+  reference_blas::symv(uplo_str, n, alpha, m_a.data(), lda, v_x.data(), incX,
+                       beta, v_y_ref.data(), incY);
+  std::vector<scalar_t> v_y_temp(v_y);
+  {
+    MemBuffer<scalar_t> v_y_temp_gpu(executorPtr, v_y_temp.data(),
+                                     static_cast<size_t>(ylen));
+    cl_event event;
+    clblast::Symv<scalar_t>(layout, a_tr, n, alpha, m_a_gpu.dev(), 0, lda,
+                            v_x_gpu.dev(), 0, incX, beta, v_y_temp_gpu.dev(), 0,
+                            incY, executorPtr->_queue(), &event);
+    CLEventHandler::wait(event);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(v_y_temp, v_y_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl_event> {
+    cl_event event;
+    clblast::Symv<scalar_t>(layout, a_tr, n, alpha, m_a_gpu.dev(), 0, lda,
+                            v_x_gpu.dev(), 0, incX, beta, v_y_gpu.dev(), 0,
+                            incY, executorPtr->_queue(), &event);
+    CLEventHandler::wait(event);
+    return {event};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetBytesProcessed(state.iterations() * tot_mem_processed);
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, ExecutorType* executorPtr,
+                        bool* success) {
+  auto symv_params = blas_benchmark::utils::get_symv_params<scalar_t>(args);
+
+  for (auto p : symv_params) {
+    std::string uplos;
+    index_t n;
+    scalar_t alpha, beta;
+    std::tie(uplos, n, alpha, beta) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, ExecutorType* executorPtr,
+                         std::string uplos, index_t n, scalar_t alpha,
+                         scalar_t beta, bool* success) {
+      run<scalar_t>(st, executorPtr, uplos, n, alpha, beta, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, n, alpha, beta).c_str(), BM_lambda,
+        executorPtr, uplos, n, alpha, beta, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, ExecutorType* executorPtr,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, executorPtr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/clBench/clblast/blas2/syr.cpp
+++ b/benchmark/clBench/clblast/blas2/syr.cpp
@@ -1,0 +1,160 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename syr.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, int n, scalar_t alpha) {
+  std::ostringstream str{};
+  str << "BM_Syr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n << "/" << alpha;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
+         index_t n, scalar_t alpha, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+
+  index_t lda = n;
+  index_t incX = 1;
+
+  // The counters are double. We convert m and n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  scalar_t size_d = static_cast<scalar_t>(n * (n + 1) / 2);
+
+  state.counters["n"] = static_cast<double>(n);
+
+  const double nflops_timesAlpha = static_cast<double>(n);
+  const double nflops_AplusXtimeAlphaX = 2. * size_d;
+  const double nflops_tot = nflops_AplusXtimeAlphaX + nflops_timesAlpha;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  const double mem_readWriteA = 2 * size_d;
+  const double mem_readX = static_cast<double>(n);
+  const double tot_mem_processed =
+      (mem_readWriteA + mem_readX) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = tot_mem_processed;
+
+  ExecutorType& ex = *executorPtr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(n * n);
+  std::vector<scalar_t> v_x = blas_benchmark::utils::random_data<scalar_t>(n);
+
+  // Specify the triangle.
+  clblast::Triangle a_tr = blas_benchmark::utils::translate_triangle(uplo_str);
+
+  // Specify the layout.
+  auto layout = clblast::Layout::kColMajor;
+
+  MemBuffer<scalar_t> m_a_gpu(executorPtr, m_a.data(),
+                              static_cast<size_t>(n * n));
+  MemBuffer<scalar_t> v_x_gpu(executorPtr, v_x.data(), static_cast<size_t>(n));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> m_a_ref = m_a;
+  reference_blas::syr(uplo_str, n, alpha, v_x.data(), incX, m_a_ref.data(),
+                      lda);
+  std::vector<scalar_t> m_a_temp(m_a);
+
+  {
+    MemBuffer<scalar_t> m_a_temp_gpu(executorPtr, m_a_temp.data(),
+                                     static_cast<size_t>(n * n));
+    cl_event event;
+    clblast::Syr(layout, a_tr, n, alpha, v_x_gpu.dev(), 0, incX,
+                 m_a_temp_gpu.dev(), 0, lda, executorPtr->_queue(), &event);
+    CLEventHandler::wait(event);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(m_a_temp, m_a_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl_event> {
+    cl_event event;
+    clblast::Syr(layout, a_tr, n, alpha, v_x_gpu.dev(), 0, incX, m_a_gpu.dev(),
+                 0, lda, executorPtr->_queue(), &event);
+    CLEventHandler::wait(event);
+    return std::vector{event};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetBytesProcessed(state.iterations() * tot_mem_processed);
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, ExecutorType* executorPtr,
+                        bool* success) {
+  auto syr_params = blas_benchmark::utils::get_syr_params<scalar_t>(args);
+
+  for (auto p : syr_params) {
+    std::string uplo;
+    index_t n;
+    scalar_t alpha;
+    std::tie(uplo, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, ExecutorType* executorPtr,
+                         std::string uplo, index_t n, scalar_t alpha,
+                         bool* success) {
+      run<scalar_t>(st, executorPtr, uplo, n, alpha, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, alpha).c_str(),
+                                 BM_lambda, executorPtr, uplo, n, alpha,
+                                 success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, ExecutorType* executorPtr,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, executorPtr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/clBench/clblast/blas2/syr2.cpp
+++ b/benchmark/clBench/clblast/blas2/syr2.cpp
@@ -1,0 +1,174 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename syr2.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, int n, scalar_t alpha) {
+  std::ostringstream str{};
+  str << "BM_Syr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n << "/" << alpha;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
+         index_t n, scalar_t alpha, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+
+  index_t lda = n;
+  index_t incX = 1;
+  index_t incY = 1;
+
+  // The counters are double. We convert m and n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  scalar_t size_d = static_cast<scalar_t>(n * (n + 1) / 2);
+  const double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  const double nflops_AlphaTimesX = n_d;
+  const double nflops_AplusYtimesX = 4.0 * size_d;
+  const double nflops_tot = nflops_AplusYtimesX + nflops_AlphaTimesX;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  const double mem_readWriteA = 2 * size_d;
+  const double mem_readX = 2 * static_cast<double>(n * std::abs(incX));
+  const double tot_mem_processed =
+      (mem_readWriteA + mem_readX) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = tot_mem_processed;
+
+  ExecutorType& sb_handle = *executorPtr;
+
+  const int v_x_size = 1 + (n - 1) * std::abs(incX);
+  const int v_y_size = 1 + (n - 1) * std::abs(incY);
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(n * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(v_x_size);
+  std::vector<scalar_t> v_y =
+      blas_benchmark::utils::random_data<scalar_t>(v_y_size);
+
+  // Specify the triangle.
+  clblast::Triangle a_tr = blas_benchmark::utils::translate_triangle(uplo_str);
+
+  // Specify the layout.
+  auto layout = clblast::Layout::kColMajor;
+
+  MemBuffer<scalar_t> m_a_gpu(executorPtr, m_a.data(),
+                              static_cast<size_t>(n * n));
+  MemBuffer<scalar_t> v_x_gpu(executorPtr, v_x.data(),
+                              static_cast<size_t>(v_x_size));
+  MemBuffer<scalar_t> v_y_gpu(executorPtr, v_y.data(),
+                              static_cast<size_t>(v_y_size));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> m_a_ref = m_a;
+  reference_blas::syr2(uplo_str, n, alpha, v_x.data(), incX, v_y.data(), incY,
+                       m_a_ref.data(), lda);
+  std::vector<scalar_t> m_a_temp(m_a);
+
+  {
+    MemBuffer<scalar_t> m_a_temp_gpu(executorPtr, m_a_temp.data(),
+                                     static_cast<size_t>(n * n));
+    cl_event event;
+    clblast::Syr2(layout, a_tr, n, alpha, v_x_gpu.dev(), 0, incX, v_y_gpu.dev(),
+                  0, incY, m_a_temp_gpu.dev(), 0, lda, executorPtr->_queue(),
+                  &event);
+    CLEventHandler::wait(event);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(m_a_temp, m_a_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl_event> {
+    cl_event event;
+    clblast::Syr2(layout, a_tr, n, alpha, v_x_gpu.dev(), 0, incX, v_y_gpu.dev(),
+                  0, incY, m_a_gpu.dev(), 0, lda, executorPtr->_queue(),
+                  &event);
+    CLEventHandler::wait(event);
+    return std::vector{event};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetBytesProcessed(state.iterations() * tot_mem_processed);
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, ExecutorType* executorPtr,
+                        bool* success) {
+  // syr2 use the same parameters so reuse syr function
+  auto syr2_params = blas_benchmark::utils::get_syr_params<scalar_t>(args);
+
+  for (auto p : syr2_params) {
+    std::string uplo;
+    index_t n;
+    scalar_t alpha;
+    std::tie(uplo, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, ExecutorType* executorPtr,
+                         std::string uplo, index_t n, scalar_t alpha,
+                         bool* success) {
+      run<scalar_t>(st, executorPtr, uplo, n, alpha, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, alpha).c_str(),
+                                 BM_lambda, executorPtr, uplo, n, alpha,
+                                 success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, ExecutorType* executorPtr,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, executorPtr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/clBench/clblast/blas2/trmv.cpp
+++ b/benchmark/clBench/clblast/blas2/trmv.cpp
@@ -1,0 +1,189 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trmv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
+  std::ostringstream str{};
+  str << "BM_Trmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << t << "/" << diag << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
+         std::string t, std::string diag, index_t n, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+  const char* t_str = t.c_str();
+  const char* diag_str = diag.c_str();
+
+  index_t xlen = n;
+  index_t lda = n;
+  index_t incX = 1;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  const double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = n_d * (n_d + 1) / 2;
+
+  const double nflops_tot = 2 * A_validVal;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  const double mem_readA = A_validVal;
+  const double mem_readX = n_d;
+  const double mem_writeX = n_d;
+  const double tot_mem_processed =
+      (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = tot_mem_processed;
+
+  ExecutorType& sb_handle = *executorPtr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+
+  // Populate the correct triangular matrix with larger values
+  // in column-major way
+  for (int i = 0; i < n; ++i)
+    for (int j = 0; j < n; ++j)
+      m_a[(j * lda) + i] =
+          (*uplo_str == 'u') ? ((i >= j) ? blas_benchmark::utils::random_scalar(
+                                               scalar_t{9}, scalar_t{11})
+                                         : 0)
+                             : ((i <= j) ? blas_benchmark::utils::random_scalar(
+                                               scalar_t{9}, scalar_t{11})
+                                         : 0);
+
+  // Specify the triangle.
+  clblast::Triangle a_uplo =
+      blas_benchmark::utils::translate_triangle(uplo_str);
+
+  // Specify the transposition.
+  clblast::Transpose a_tr =
+      blas_benchmark::utils::translate_transposition(t_str);
+
+  // Specify the unit-diagonal.
+  clblast::Diagonal a_diag =
+      blas_benchmark::utils::translate_diagonal(diag_str);
+
+  // Specify the layout.
+  auto layout = clblast::Layout::kColMajor;
+
+  MemBuffer<scalar_t> m_a_gpu(executorPtr, m_a.data(),
+                              static_cast<size_t>(lda * n));
+  MemBuffer<scalar_t> v_x_gpu(executorPtr, v_x.data(),
+                              static_cast<size_t>(xlen));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> v_x_ref = v_x;
+  reference_blas::trmv(uplo_str, t_str, diag_str, n, m_a.data(), lda,
+                       v_x_ref.data(), incX);
+  std::vector<scalar_t> v_x_temp = v_x;
+  {
+    MemBuffer<scalar_t> v_x_temp_gpu(executorPtr, v_x_temp.data(),
+                                     static_cast<size_t>(xlen));
+    cl_event event;
+    clblast::Trmv<scalar_t>(layout, a_uplo, a_tr, a_diag, n, m_a_gpu.dev(), 0,
+                            lda, v_x_temp_gpu.dev(), 0, incX,
+                            executorPtr->_queue(), &event);
+    CLEventHandler::wait(event);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(v_x_temp, v_x_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl_event> {
+    cl_event event;
+    clblast::Trmv<scalar_t>(layout, a_uplo, a_tr, a_diag, n, m_a_gpu.dev(), 0,
+                            lda, v_x_gpu.dev(), 0, incX, executorPtr->_queue(),
+                            &event);
+    CLEventHandler::wait(event);
+    return std::vector{event};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetBytesProcessed(state.iterations() * tot_mem_processed);
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, ExecutorType* executorPtr,
+                        bool* success) {
+  // trmv uses the same parameters as trsv
+  auto trmv_params = blas_benchmark::utils::get_trsv_params(args);
+
+  for (auto p : trmv_params) {
+    std::string uplos;
+    std::string ts;
+    std::string diags;
+    index_t n;
+    std::tie(uplos, ts, diags, n) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, ExecutorType* executorPtr,
+                         std::string uplos, std::string ts, std::string diags,
+                         index_t n, bool* success) {
+      run<scalar_t>(st, executorPtr, uplos, ts, diags, n, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda, executorPtr,
+        uplos, ts, diags, n, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, ExecutorType* executorPtr,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, executorPtr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/clBench/clblast/blas2/trmv.cpp
+++ b/benchmark/clBench/clblast/blas2/trmv.cpp
@@ -67,21 +67,10 @@ void run(benchmark::State& state, ExecutorType* executorPtr, std::string uplo,
   ExecutorType& sb_handle = *executorPtr;
 
   // Input matrix/vector, output vector.
-  std::vector<scalar_t> m_a(lda * n);
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(lda * n);
   std::vector<scalar_t> v_x =
       blas_benchmark::utils::random_data<scalar_t>(xlen);
-
-  // Populate the correct triangular matrix with larger values
-  // in column-major way
-  for (int i = 0; i < n; ++i)
-    for (int j = 0; j < n; ++j)
-      m_a[(j * lda) + i] =
-          (*uplo_str == 'u') ? ((i >= j) ? blas_benchmark::utils::random_scalar(
-                                               scalar_t{9}, scalar_t{11})
-                                         : 0)
-                             : ((i <= j) ? blas_benchmark::utils::random_scalar(
-                                               scalar_t{9}, scalar_t{11})
-                                         : 0);
 
   // Specify the triangle.
   clblast::Triangle a_uplo =

--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -46,6 +46,7 @@ set(sources
   blas2/ger.cpp
   blas2/sbmv.cpp
   blas2/symv.cpp
+  blas2/syr.cpp
   blas2/tbmv.cpp
   # Level 3 blas
   blas3/gemm.cpp

--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -45,6 +45,7 @@ set(sources
   blas2/gemv.cpp
   blas2/ger.cpp
   blas2/sbmv.cpp
+  blas2/symv.cpp
   blas2/tbmv.cpp
   # Level 3 blas
   blas3/gemm.cpp

--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -47,6 +47,7 @@ set(sources
   blas2/sbmv.cpp
   blas2/symv.cpp
   blas2/syr.cpp
+  blas2/syr2.cpp
   blas2/tbmv.cpp
   # Level 3 blas
   blas3/gemm.cpp

--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -43,6 +43,7 @@ set(sources
   blas2/spr.cpp
   blas2/gbmv.cpp
   blas2/gemv.cpp
+  blas2/ger.cpp
   blas2/sbmv.cpp
   blas2/tbmv.cpp
   # Level 3 blas

--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -49,6 +49,7 @@ set(sources
   blas2/syr.cpp
   blas2/syr2.cpp
   blas2/tbmv.cpp
+  blas2/trmv.cpp
   # Level 3 blas
   blas3/gemm.cpp
   blas3/gemm_batched.cpp

--- a/benchmark/syclblas/blas2/ger.cpp
+++ b/benchmark/syclblas/blas2/ger.cpp
@@ -1,0 +1,157 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename ger.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(int m, int n) {
+  std::ostringstream str{};
+  str << "BM_Ger<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << m << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t m,
+         index_t n, scalar_t alpha, bool* success) {
+  // Standard test setup.
+
+  index_t xlen = m;
+  index_t ylen = n;
+
+  index_t lda = m;
+  index_t incX = 1;
+  index_t incY = 1;
+
+  // The counters are double. We convert m and n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  const double m_d = static_cast<double>(m);
+  const double n_d = static_cast<double>(n);
+
+  state.counters["m"] = m_d;
+  state.counters["n"] = n_d;
+
+  const double nflops_timesAlpha = std::min(m, n);
+  const double nflops_XtimesYplusA = 2 * m_d * n_d;
+  const double nflops_tot = nflops_XtimesYplusA + nflops_timesAlpha;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  const double mem_readWriteA = 2 * m_d * n_d;
+  const double mem_readX = xlen;
+  const double mem_readY = ylen;
+  state.counters["bytes_processed"] =
+      (mem_readWriteA + mem_readX + mem_readY) * sizeof(scalar_t);
+
+  blas::SB_Handle& sb_handle = *sb_handle_ptr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(m * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+  std::vector<scalar_t> v_y =
+      blas_benchmark::utils::random_data<scalar_t>(ylen);
+
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_a, m * n);
+  auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_x, xlen);
+  auto v_y_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_y, ylen);
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> m_a_ref = m_a;
+  reference_blas::ger(m, n, alpha, v_x.data(), incX, v_y.data(), incY,
+                      m_a_ref.data(), lda);
+  std::vector<scalar_t> m_a_temp(m_a);
+
+  {
+    auto m_a_temp_gpu =
+        blas::make_sycl_iterator_buffer<scalar_t>(m_a_temp, m * n);
+    auto event = _ger(sb_handle, m, n, alpha, v_x_gpu, incX, v_y_gpu,
+                            incY, m_a_temp_gpu, lda);
+    sb_handle.wait();
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(m_a_temp, m_a_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
+    auto event = _ger(sb_handle, m, n, alpha, v_x_gpu, incX, v_y_gpu,
+                            incY, m_a_gpu, lda);
+    sb_handle.wait();
+    return event;
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+  sb_handle.wait();
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        blas::SB_Handle* sb_handle_ptr, bool* success) {
+  auto ger_params = blas_benchmark::utils::get_ger_params<scalar_t>(args);
+
+  for (auto p : ger_params) {
+    index_t m, n;
+    scalar_t alpha;
+    std::tie(m, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
+                         index_t m, index_t n, scalar_t alpha, bool* success) {
+      run<scalar_t>(st, sb_handle_ptr, m, n, alpha, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(m, n).c_str(), BM_lambda,
+                                 sb_handle_ptr, m, n, alpha, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      blas::SB_Handle* sb_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, sb_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/syclblas/blas2/symv.cpp
+++ b/benchmark/syclblas/blas2/symv.cpp
@@ -1,0 +1,165 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename symv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, int n, scalar_t alpha, scalar_t beta) {
+  std::ostringstream str{};
+  str << "BM_Symv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n << "/" << alpha << "/" << beta;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
+         std::string uplo, index_t n, scalar_t alpha, scalar_t beta,
+         bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+
+  index_t incX = 1;
+  index_t incY = 1;
+
+  index_t lda = n;
+  index_t xlen = n;
+  index_t ylen = n;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = (n_d * (n_d + 1) / 2);
+
+  const double nflops_AtimesX = 2 * n_d * n_d;
+  const double nflops_timesAlpha = xlen;
+  const double nflops_addBetaY = (beta != scalar_t{0}) ? 2 * ylen : 0;
+  const double nflops_tot =
+      nflops_AtimesX + nflops_timesAlpha + nflops_addBetaY;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  const double mem_readA = A_validVal;
+  const double mem_readX = xlen;
+  const double mem_writeY = ylen;
+  const double mem_readY = (beta != scalar_t{0}) ? ylen : 0;
+  state.counters["bytes_processed"] =
+      (mem_readA + mem_readX + mem_writeY + mem_readY) * sizeof(scalar_t);
+
+  blas::SB_Handle& sb_handle = *sb_handle_ptr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+  std::vector<scalar_t> v_y =
+      blas_benchmark::utils::random_data<scalar_t>(ylen);
+
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_a, n * n);
+  auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_x, xlen);
+  auto v_y_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_y, ylen);
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> v_y_ref = v_y;
+  reference_blas::symv(uplo_str, n, alpha, m_a.data(), lda, v_x.data(), incX,
+                       beta, v_y_ref.data(), incY);
+  std::vector<scalar_t> v_y_temp(v_y);
+  {
+    auto v_y_temp_gpu =
+        blas::make_sycl_iterator_buffer<scalar_t>(v_y_temp, ylen);
+    auto event = _symv(sb_handle, *uplo_str, n, alpha, m_a_gpu, lda,
+                             v_x_gpu, incX, beta, v_y_temp_gpu, incY);
+    sb_handle.wait();
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(v_y_temp, v_y_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
+    auto event = _symv(sb_handle, *uplo_str, n, alpha, m_a_gpu, lda,
+                             v_x_gpu, incX, beta, v_y_gpu, incY);
+    sb_handle.wait();
+    return event;
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+  sb_handle.wait();
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        blas::SB_Handle* sb_handle_ptr, bool* success) {
+  auto symv_params = blas_benchmark::utils::get_symv_params<scalar_t>(args);
+
+  for (auto p : symv_params) {
+    std::string uplos;
+    index_t n;
+    scalar_t alpha, beta;
+    std::tie(uplos, n, alpha, beta) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
+                         std::string uplos, index_t n, scalar_t alpha,
+                         scalar_t beta, bool* success) {
+      run<scalar_t>(st, sb_handle_ptr, uplos, n, alpha, beta, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, n, alpha, beta).c_str(), BM_lambda,
+        sb_handle_ptr, uplos, n, alpha, beta, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      blas::SB_Handle* sb_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, sb_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/syclblas/blas2/syr.cpp
+++ b/benchmark/syclblas/blas2/syr.cpp
@@ -1,0 +1,150 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename syr.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, int n, scalar_t alpha) {
+  std::ostringstream str{};
+  str << "BM_Syr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n << "/" << alpha;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
+         std::string uplo, index_t n, scalar_t alpha, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+
+  index_t lda = n;
+  index_t incX = 1;
+
+  // The counters are double. We convert m and n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  scalar_t size_d = static_cast<scalar_t>(n * (n + 1) / 2);
+
+  state.counters["n"] = static_cast<double>(n);
+
+  const double nflops_timesAlpha = static_cast<double>(n);
+  const double nflops_AplusXtimeAlphaX = 2. * size_d;
+  const double nflops_tot = nflops_AplusXtimeAlphaX + nflops_timesAlpha;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  const double mem_readWriteA = 2 * size_d;
+  const double mem_readX = static_cast<double>(n);
+  state.counters["bytes_processed"] =
+      (mem_readWriteA + mem_readX) * sizeof(scalar_t);
+
+  blas::SB_Handle& sb_handle = *sb_handle_ptr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(n * n);
+  std::vector<scalar_t> v_x = blas_benchmark::utils::random_data<scalar_t>(n);
+
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_a, n * n);
+  auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_x, n);
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> m_a_ref = m_a;
+  reference_blas::syr(uplo_str, n, alpha, v_x.data(), incX, m_a_ref.data(),
+                      lda);
+  std::vector<scalar_t> m_a_temp(m_a);
+
+  {
+    auto m_a_temp_gpu =
+        blas::make_sycl_iterator_buffer<scalar_t>(m_a_temp, n * n);
+    auto event =
+        _syr(sb_handle, *uplo_str, n, alpha, v_x_gpu, incX, m_a_temp_gpu, lda);
+    sb_handle.wait();
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(m_a_temp, m_a_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
+    auto event =
+        _syr(sb_handle, *uplo_str, n, alpha, v_x_gpu, incX, m_a_gpu, lda);
+    sb_handle.wait();
+    return event;
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+  sb_handle.wait();
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        blas::SB_Handle* sb_handle_ptr, bool* success) {
+  auto syr_params = blas_benchmark::utils::get_syr_params<scalar_t>(args);
+
+  for (auto p : syr_params) {
+    std::string uplo;
+    index_t n;
+    scalar_t alpha;
+    std::tie(uplo, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
+                         std::string uplo, index_t n, scalar_t alpha,
+                         bool* success) {
+      run<scalar_t>(st, sb_handle_ptr, uplo, n, alpha, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, alpha).c_str(),
+                                 BM_lambda, sb_handle_ptr, uplo, n, alpha,
+                                 success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      blas::SB_Handle* sb_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, sb_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/syclblas/blas2/syr.cpp
+++ b/benchmark/syclblas/blas2/syr.cpp
@@ -55,8 +55,9 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
 
   const double mem_readWriteA = 2 * size_d;
   const double mem_readX = static_cast<double>(n);
-  state.counters["bytes_processed"] =
+  const double tot_mem_processed =
       (mem_readWriteA + mem_readX) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = tot_mem_processed;
 
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
 
@@ -115,6 +116,7 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
     blas_benchmark::utils::update_counters(state, times);
   }
 
+  state.SetBytesProcessed(state.iterations() * tot_mem_processed);
   state.SetItemsProcessed(state.iterations() * nflops_tot);
 
   blas_benchmark::utils::calc_avg_counters(state);

--- a/benchmark/syclblas/blas2/syr2.cpp
+++ b/benchmark/syclblas/blas2/syr2.cpp
@@ -1,0 +1,160 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename syr2.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, int n, scalar_t alpha) {
+  std::ostringstream str{};
+  str << "BM_Syr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << n << "/" << alpha;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
+         std::string uplo, index_t n, scalar_t alpha, bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+
+  index_t lda = n;
+  index_t incX = 1;
+  index_t incY = 1;
+
+  // The counters are double. We convert m and n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  scalar_t size_d = static_cast<scalar_t>(n * (n + 1) / 2);
+  const double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  const double nflops_AlphaTimesX = n_d;
+  const double nflops_AplusYtimesX = 4.0 * size_d;
+  const double nflops_tot = nflops_AplusYtimesX + nflops_AlphaTimesX;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  double mem_readWriteA = 2 * size_d;
+  double mem_readX = 2 * static_cast<double>(n * std::abs(incX));
+  state.counters["bytes_processed"] =
+      (mem_readWriteA + mem_readX) * sizeof(scalar_t);
+
+  blas::SB_Handle& sb_handle = *sb_handle_ptr;
+
+  const int v_x_size = 1 + (n - 1) * std::abs(incX);
+  const int v_y_size = 1 + (n - 1) * std::abs(incY);
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(n * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(v_x_size);
+  std::vector<scalar_t> v_y =
+      blas_benchmark::utils::random_data<scalar_t>(v_y_size);
+
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_a, n * n);
+  auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_x, v_x_size);
+  auto v_y_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_y, v_y_size);
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> m_a_ref = m_a;
+  reference_blas::syr2(uplo_str, n, alpha, v_x.data(), incX, v_y.data(), incY,
+                       m_a_ref.data(), lda);
+  std::vector<scalar_t> m_a_temp(m_a);
+
+  {
+    auto m_a_temp_gpu =
+        blas::make_sycl_iterator_buffer<scalar_t>(m_a_temp, n * n);
+    auto event = _syr2(sb_handle, *uplo_str, n, alpha, v_x_gpu, incX, v_y_gpu,
+                       incY, m_a_temp_gpu, lda);
+    sb_handle.wait();
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(m_a_temp, m_a_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
+    auto event = _syr2(sb_handle, *uplo_str, n, alpha, v_x_gpu, incX, v_y_gpu,
+                       incY, m_a_gpu, lda);
+    sb_handle.wait();
+    return event;
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+  sb_handle.wait();
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        blas::SB_Handle* sb_handle_ptr, bool* success) {
+  // syr2 use the same parameters so reuse syr function
+  auto syr2_params = blas_benchmark::utils::get_syr_params<scalar_t>(args);
+
+  for (auto p : syr2_params) {
+    std::string uplo;
+    index_t n;
+    scalar_t alpha;
+    std::tie(uplo, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
+                         std::string uplo, index_t n, scalar_t alpha,
+                         bool* success) {
+      run<scalar_t>(st, sb_handle_ptr, uplo, n, alpha, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, alpha).c_str(),
+                                 BM_lambda, sb_handle_ptr, uplo, n, alpha,
+                                 success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      blas::SB_Handle* sb_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, sb_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/syclblas/blas2/syr2.cpp
+++ b/benchmark/syclblas/blas2/syr2.cpp
@@ -55,10 +55,11 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
   const double nflops_tot = nflops_AplusYtimesX + nflops_AlphaTimesX;
   state.counters["n_fl_ops"] = nflops_tot;
 
-  double mem_readWriteA = 2 * size_d;
-  double mem_readX = 2 * static_cast<double>(n * std::abs(incX));
-  state.counters["bytes_processed"] =
+  const double mem_readWriteA = 2 * size_d;
+  const double mem_readX = 2 * static_cast<double>(n * std::abs(incX));
+  const double tot_mem_processed =
       (mem_readWriteA + mem_readX) * sizeof(scalar_t);
+  state.counters["bytes_processed"] = tot_mem_processed;
 
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
 
@@ -124,6 +125,7 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
     blas_benchmark::utils::update_counters(state, times);
   }
 
+  state.SetBytesProcessed(state.iterations() * tot_mem_processed);
   state.SetItemsProcessed(state.iterations() * nflops_tot);
 
   blas_benchmark::utils::calc_avg_counters(state);

--- a/benchmark/syclblas/blas2/trmv.cpp
+++ b/benchmark/syclblas/blas2/trmv.cpp
@@ -1,0 +1,169 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trmv.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
+  std::ostringstream str{};
+  str << "BM_Trmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << t << "/" << diag << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
+         std::string uplo, std::string t, std::string diag, index_t n,
+         bool* success) {
+  // Standard test setup.
+  const char* uplo_str = uplo.c_str();
+  const char* t_str = t.c_str();
+  const char* diag_str = diag.c_str();
+
+  index_t xlen = n;
+  index_t lda = n;
+  index_t incX = 1;
+
+  // The counters are double. We convert n to double to avoid
+  // integer overflows for n_fl_ops and bytes_processed
+  const double n_d = static_cast<double>(n);
+
+  state.counters["n"] = n_d;
+
+  // Compute the number of A non-zero elements.
+  const double A_validVal = n_d * (n_d + 1) / 2;
+
+  const double nflops_tot = 2 * A_validVal;
+  state.counters["n_fl_ops"] = nflops_tot;
+
+  const double mem_readA = A_validVal;
+  const double mem_readX = n_d;
+  const double mem_writeX = n_d;
+  state.counters["bytes_processed"] =
+      (mem_readA + mem_readX + mem_writeX) * sizeof(scalar_t);
+
+  blas::SB_Handle& sb_handle = *sb_handle_ptr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a(lda * n);
+  std::vector<scalar_t> v_x =
+      blas_benchmark::utils::random_data<scalar_t>(xlen);
+
+  // Populate the correct triangular matrix with larger values
+  // in column-major way
+  for (int i = 0; i < n; ++i)
+    for (int j = 0; j < n; ++j)
+      m_a[(j * lda) + i] =
+          (*uplo_str == 'u') ? ((i >= j) ? blas_benchmark::utils::random_scalar(
+                                               scalar_t{9}, scalar_t{11})
+                                         : 0)
+                             : ((i <= j) ? blas_benchmark::utils::random_scalar(
+                                               scalar_t{9}, scalar_t{11})
+                                         : 0);
+
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_a, lda * n);
+  auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_x, xlen);
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> v_x_ref = v_x;
+  reference_blas::trmv(uplo_str, t_str, diag_str, n, m_a.data(), lda,
+                       v_x_ref.data(), incX);
+  std::vector<scalar_t> v_x_temp = v_x;
+  {
+    auto v_x_temp_gpu =
+        blas::make_sycl_iterator_buffer<scalar_t>(v_x_temp, xlen);
+    auto event = _trmv(sb_handle, *uplo_str, *t_str, *diag_str, n,
+                             m_a_gpu, lda, v_x_temp_gpu, incX);
+    sb_handle.wait();
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(v_x_temp, v_x_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
+    auto event = _trmv(sb_handle, *uplo_str, *t_str, *diag_str, n,
+                             m_a_gpu, lda, v_x_gpu, incX);
+    sb_handle.wait();
+    return event;
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+  sb_handle.wait();
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetItemsProcessed(state.iterations() * nflops_tot);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        blas::SB_Handle* sb_handle_ptr, bool* success) {
+  // trmv uses the same parameters as trsv
+  auto trmv_params = blas_benchmark::utils::get_trsv_params(args);
+
+  for (auto p : trmv_params) {
+    std::string uplos;
+    std::string ts;
+    std::string diags;
+    index_t n;
+    std::tie(uplos, ts, diags, n) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
+                         std::string uplos, std::string ts, std::string diags,
+                         index_t n, bool* success) {
+      run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
+        sb_handle_ptr, uplos, ts, diags, n, success);
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      blas::SB_Handle* sb_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, sb_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/syclblas/blas2/trmv.cpp
+++ b/benchmark/syclblas/blas2/trmv.cpp
@@ -68,21 +68,10 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
 
   // Input matrix/vector, output vector.
-  std::vector<scalar_t> m_a(lda * n);
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(lda * n);
   std::vector<scalar_t> v_x =
       blas_benchmark::utils::random_data<scalar_t>(xlen);
-
-  // Populate the correct triangular matrix with larger values
-  // in column-major way
-  for (int i = 0; i < n; ++i)
-    for (int j = 0; j < n; ++j)
-      m_a[(j * lda) + i] =
-          (*uplo_str == 'u') ? ((i >= j) ? blas_benchmark::utils::random_scalar(
-                                               scalar_t{9}, scalar_t{11})
-                                         : 0)
-                             : ((i <= j) ? blas_benchmark::utils::random_scalar(
-                                               scalar_t{9}, scalar_t{11})
-                                         : 0);
 
   auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_a, lda * n);
   auto v_x_gpu = blas::make_sycl_iterator_buffer<scalar_t>(v_x, xlen);


### PR DESCRIPTION
This PR adds benchmarks for those operators available in syclBLAS. It also adds the clblast counterpart.

List of operators added to benchmarks:

- ger
- symv
- syr
- syr2
- trmv