### PR TITLE
Fixed the gemm_batched_strided benchmark

### DIFF
--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -54,6 +54,7 @@ set(sources
   # Level 3 blas
   blas3/gemm.cpp
   blas3/gemm_batched.cpp
+  blas3/gemm_batched_strided.cpp
   blas3/trsm.cpp
   blas3/symm.cpp
 )

--- a/benchmark/syclblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched_strided.cpp
@@ -193,6 +193,7 @@ void register_benchmark(blas_benchmark::Args& args,
 
     auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
                          int t1, int t2, index_t m, index_t k, index_t n,
+                         index_t stride_a, index_t stride_b, index_t stride_c,
                          scalar_t alpha, scalar_t beta, index_t batch_size,
                          bool* success) {
       run<scalar_t>(st, sb_handle_ptr, t1, t2, m, k, n, stride_a, stride_b,
@@ -200,7 +201,7 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         get_name<scalar_t>(t1s, t2s, m, k, n, batch_size).c_str(), BM_lambda,
-        sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size, success)
+        sb_handle_ptr, t1, t2, m, k, n, stride_a, stride_b, stride_c, alpha, beta, batch_size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched_strided.cpp
@@ -27,12 +27,11 @@
 
 template <typename scalar_t>
 std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int stride_a, int stride_b, int stride_c, int batch_size) {
+                     int batch_size) {
   std::ostringstream str{};
   str << "BM_GemmBatchedStrided<"
       << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
-      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
-      << stride_a << "/" << stride_b << "/" << stride_c;
+      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size;
   return str.str();
 }
 
@@ -134,11 +133,8 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
   }
 
   std::ostringstream err_stream;
-  const bool isAlmostEqual =
-      (stride_c == 1) ? utils::compare_vectors(c_temp, c_ref, err_stream, "")
-                      : utils::compare_vectors_strided(c_temp, c_ref, stride_c,
-                                                       c_size, err_stream, "");
-  if (!isAlmostEqual) {
+  if (!utils::compare_vectors_strided(c_temp, c_ref, stride_c, c_size,
+                                      err_stream, "")) {
     const std::string& err_str = err_stream.str();
     state.SkipWithError(err_str.c_str());
     *success = false;
@@ -203,11 +199,8 @@ void register_benchmark(blas_benchmark::Args& args,
                     stride_c, alpha, beta, batch_size, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, stride_a, stride_b, stride_c,
-                           batch_size)
-            .c_str(),
-        BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
-        success)
+        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size).c_str(), BM_lambda,
+        sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size, success)
         ->UseRealTime();
   }
 }


### PR DESCRIPTION
This PR adds the `gemm_batched_strided` benchmark in SYCL-BLAS. This benchmark was accidentally pushed in a previous PR in it's incomplete state, but it is now fixed and working correctly.