### PR TITLE
Add rocBLAS benchmarks for level3 operators and blas-like extensions

### DIFF
--- a/benchmark/cublas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/cublas/blas3/gemm_batched_strided.cpp
@@ -185,7 +185,7 @@ template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         cublasHandle_t* cuda_handle_ptr, bool* success) {
   auto gemm_batched_strided_params =
-      blas_benchmark::utils::get_gemm_batched_params<scalar_t>(args);
+      blas_benchmark::utils::get_gemm_batched_strided_params<scalar_t>(args);
 
   for (auto p : gemm_batched_strided_params) {
     std::string t1s, t2s;

--- a/benchmark/cublas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/cublas/blas3/gemm_batched_strided.cpp
@@ -70,7 +70,8 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int t1,
 
   blas_benchmark::utils::init_level_3_counters<
       blas_benchmark::utils::Level3Op::gemm_batched_strided, scalar_t>(
-      state, beta, m, n, k, batch_size);
+      state, beta, m, n, k, batch_size, stride_a_mul, stride_b_mul,
+      stride_c_mul);
 
   cublasHandle_t& cuda_handle = *cuda_handle_ptr;
 

--- a/benchmark/cublas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/cublas/blas3/gemm_batched_strided.cpp
@@ -27,11 +27,13 @@
 
 template <typename scalar_t>
 std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size) {
+                     int batch_size, int stride_a_mul, int stride_b_mul,
+                     int stride_c_mul) {
   std::ostringstream str{};
   str << "BM_GemmBatchedStrided<"
       << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
-      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size;
+      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
+      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul;
 
   return str.str();
 }
@@ -66,39 +68,38 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int t1,
   index_t ldb = trB ? k : n;
   index_t ldc = m;
 
-  // Stride parameters are computed automatically inside the run function
-  // instead of passing them as function argument. It makes more readable and do
-  // not affect perfomance measurment.
-  const long long int stride_a = stride_a_mul * (trA ? (lda * k) : (lda * m));
-  const long long int stride_b = stride_b_mul * (trB ? (ldb * n) : (ldb * k));
-  const long long int stride_c = stride_c_mul * m * n;
-
   blas_benchmark::utils::init_level_3_counters<
       blas_benchmark::utils::Level3Op::gemm_batched_strided, scalar_t>(
       state, beta, m, n, k, batch_size);
 
   cublasHandle_t& cuda_handle = *cuda_handle_ptr;
 
-  // Matrices sizes
+  // Data sizes
+  // Elementary matrices
   const index_t a_size = m * k;
   const index_t b_size = k * n;
   const index_t c_size = m * n;
+  // Strides
+  const index_t stride_a = stride_a_mul * a_size;
+  const index_t stride_b = stride_b_mul * b_size;
+  const index_t stride_c = stride_c_mul * c_size;
+  // Batched matrices
+  const int size_a_batch = a_size + (batch_size - 1) * stride_a;
+  const int size_b_batch = b_size + (batch_size - 1) * stride_b;
+  const int size_c_batch = c_size + (batch_size - 1) * stride_c;
 
   // Matrices (Total size is equal to matrix size x batch_size since we're using
   // default striding values)
   std::vector<scalar_t> a =
-      blas_benchmark::utils::random_data<scalar_t>(a_size * batch_size);
+      blas_benchmark::utils::random_data<scalar_t>(size_a_batch);
   std::vector<scalar_t> b =
-      blas_benchmark::utils::random_data<scalar_t>(b_size * batch_size);
+      blas_benchmark::utils::random_data<scalar_t>(size_b_batch);
   std::vector<scalar_t> c =
-      blas_benchmark::utils::const_data<scalar_t>(c_size * batch_size, 0);
+      blas_benchmark::utils::const_data<scalar_t>(size_c_batch, 0);
 
-  blas_benchmark::utils::CUDAVector<scalar_t> a_gpu(a_size * batch_size,
-                                                    a.data());
-  blas_benchmark::utils::CUDAVector<scalar_t> b_gpu(b_size * batch_size,
-                                                    b.data());
-  blas_benchmark::utils::CUDAVector<scalar_t> c_gpu(c_size * batch_size,
-                                                    c.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> a_gpu(size_a_batch, a.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> b_gpu(size_b_batch, b.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> c_gpu(size_c_batch, c.data());
 
   cublasOperation_t c_t_a = trA ? CUBLAS_OP_N : CUBLAS_OP_T;
 
@@ -107,27 +108,25 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int t1,
 #ifdef BLAS_VERIFY_BENCHMARK
   // Run a first time with a verification of the results
   std::vector<scalar_t> c_ref = c;
-  auto _base = [=](index_t dim0, index_t dim1, index_t idx) {
-    return dim0 * dim1 * idx;
-  };
   for (int batch_idx = 0; batch_idx < batch_size; batch_idx++) {
     reference_blas::gemm(t_a, t_b, m, n, k, alpha,
-                         a.data() + _base(m, k, batch_idx), lda,
-                         b.data() + _base(k, n, batch_idx), ldb, beta,
-                         c_ref.data() + _base(m, n, batch_idx), ldc);
+                         a.data() + batch_idx * stride_a, lda,
+                         b.data() + batch_idx * stride_b, ldb, beta,
+                         c_ref.data() + batch_idx * stride_c, ldc);
   }
 
   std::vector<scalar_t> c_temp = c;
   {
-    blas_benchmark::utils::CUDAVector<scalar_t, true> c_temp_gpu(
-        c_size * batch_size, c_temp.data());
+    blas_benchmark::utils::CUDAVector<scalar_t, true> c_temp_gpu(size_c_batch,
+                                                                 c_temp.data());
     cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, k, &alpha, a_gpu,
                              lda, stride_a, b_gpu, ldb, stride_b, &beta,
                              c_temp_gpu, ldc, stride_c, batch_size);
   }
 
   std::ostringstream err_stream;
-  if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+  if (!utils::compare_vectors_strided(c_temp, c_ref, stride_c, c_size,
+                                      err_stream, "")) {
     const std::string& err_str = err_stream.str();
     state.SkipWithError(err_str.c_str());
     *success = false;
@@ -205,9 +204,11 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_size, strd_a_mul, strd_b_mul, strd_c_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size).c_str(), BM_lambda,
-        cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size, stride_a_mul,
-        stride_b_mul, stride_c_mul, success)
+        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, stride_a_mul,
+                           stride_b_mul, stride_c_mul)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
+        stride_a_mul, stride_b_mul, stride_c_mul, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -67,7 +67,7 @@ set(sources
   blas3/syr2k.cpp
   blas3/trsm.cpp
   blas3/trmm.cpp
-  # blas3/trsm_batched.cpp
+  blas3/trsm_batched.cpp
   blas3/gemm_batched.cpp
   # blas3/gemm_batched_strided.cpp
 

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -69,7 +69,7 @@ set(sources
   blas3/trmm.cpp
   blas3/trsm_batched.cpp
   blas3/gemm_batched.cpp
-  # blas3/gemm_batched_strided.cpp
+  blas3/gemm_batched_strided.cpp
 
 )
 

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -68,7 +68,7 @@ set(sources
   blas3/trsm.cpp
   blas3/trmm.cpp
   # blas3/trsm_batched.cpp
-  # blas3/gemm_batched.cpp
+  blas3/gemm_batched.cpp
   # blas3/gemm_batched_strided.cpp
 
 )

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -60,6 +60,17 @@ set(sources
   blas2/trmv.cpp
   blas2/spmv.cpp
 
+  # Level 3 blas
+  blas3/gemm.cpp
+  blas3/symm.cpp
+  blas3/syrk.cpp
+  blas3/syr2k.cpp
+  blas3/trsm.cpp
+  blas3/trmm.cpp
+  # blas3/trsm_batched.cpp
+  # blas3/gemm_batched.cpp
+  # blas3/gemm_batched_strided.cpp
+
 )
 
 # Add individual benchmarks for each method

--- a/benchmark/rocblas/blas3/gemm.cpp
+++ b/benchmark/rocblas/blas3/gemm.cpp
@@ -87,9 +87,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_ai, int t_bi,
   }
 
   // Matrix options (rocBLAS)
-  const rocblas_operation trans_a =
+  const rocblas_operation trans_a_rb =
       t_a_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
-  const rocblas_operation trans_b =
+  const rocblas_operation trans_b_rb =
       t_b_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
 
   // Data sizes
@@ -127,8 +127,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_ai, int t_bi,
       blas_benchmark::utils::HIPVector<scalar_t, true> c_temp_gpu(
           c_size, c_temp.data());
       // rocBLAS function call
-      rocblas_gemm_f<scalar_t>(rb_handle, trans_a, trans_b, m, n, k, &alpha,
-                               a_gpu, lda, b_gpu, ldb, &beta, c_temp_gpu, ldc);
+      rocblas_gemm_f<scalar_t>(rb_handle, trans_a_rb, trans_b_rb, m, n, k,
+                               &alpha, a_gpu, lda, b_gpu, ldb, &beta,
+                               c_temp_gpu, ldc);
     }
 
     std::ostringstream err_stream;
@@ -139,8 +140,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_ai, int t_bi,
     };
 #endif
     auto blas_warmup = [&]() -> void {
-      rocblas_gemm_f<scalar_t>(rb_handle, trans_a, trans_b, m, n, k, &alpha,
-                               a_gpu, lda, b_gpu, ldb, &beta, c_gpu, ldc);
+      rocblas_gemm_f<scalar_t>(rb_handle, trans_a_rb, trans_b_rb, m, n, k,
+                               &alpha, a_gpu, lda, b_gpu, ldb, &beta, c_gpu,
+                               ldc);
       return;
     };
 
@@ -150,8 +152,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_ai, int t_bi,
 
     auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
       CHECK_HIP_ERROR(hipEventRecord(start, NULL));
-      rocblas_gemm_f<scalar_t>(rb_handle, trans_a, trans_b, m, n, k, &alpha,
-                               a_gpu, lda, b_gpu, ldb, &beta, c_gpu, ldc);
+      rocblas_gemm_f<scalar_t>(rb_handle, trans_a_rb, trans_b_rb, m, n, k,
+                               &alpha, a_gpu, lda, b_gpu, ldb, &beta, c_gpu,
+                               ldc);
       CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
       CHECK_HIP_ERROR(hipEventSynchronize(stop));
       return std::vector{start, stop};

--- a/benchmark/rocblas/blas3/gemm.cpp
+++ b/benchmark/rocblas/blas3/gemm.cpp
@@ -77,13 +77,11 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
     double total_mem =
         (mem_readA + mem_readB + mem_readC + mem_writeC) * sizeof(scalar_t);
     state.counters["bytes_processed"] = total_mem;
-    state.SetBytesProcessed(state.iterations() * total_mem);
 
     double nflops_AtimesB = (2 * k_d) * m_d * n_d;
     double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
-    double nflops_tot = nflops_AtimesB + nflops_addBetaC;
-    state.counters["n_fl_ops"] = nflops_tot;
-    state.SetItemsProcessed(state.iterations() * nflops_tot);
+    double total_nflops = nflops_AtimesB + nflops_addBetaC;
+    state.counters["n_fl_ops"] = total_nflops;
   }
 
   // Matrix options (rocBLAS)
@@ -110,9 +108,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
     blas_benchmark::utils::HIPVector<scalar_t> a_gpu(a_size, a.data());
     blas_benchmark::utils::HIPVector<scalar_t> b_gpu(b_size, b.data());
     blas_benchmark::utils::HIPVector<scalar_t> c_gpu(c_size, c.data());
-
-    CHECK_ROCBLAS_STATUS(
-        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
 
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference gemm
@@ -173,6 +168,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetBytesProcessed(state.iterations() *
+                            state.counters["bytes_processed"]);
+    state.SetItemsProcessed(state.iterations() * state.counters["n_fl_ops"]);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas3/gemm.cpp
+++ b/benchmark/rocblas/blas3/gemm.cpp
@@ -1,0 +1,213 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename gemm.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string t_a, std::string t_b, int m, int k, int n) {
+  std::ostringstream str{};
+  str << "BM_Gemm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << t_a << "/" << t_b << "/" << m << "/" << k << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_gemm_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_sgemm(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dgemm(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, int t_ai, int t_bi,
+         index_t m, index_t k, index_t n, scalar_t alpha, scalar_t beta,
+         bool* success) {
+  // Standard test setup.
+  std::string t_a = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(t_ai));
+  std::string t_b = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(t_bi));
+  const char* t_a_str = t_a.c_str();
+  const char* t_b_str = t_b.c_str();
+
+  index_t lda = t_a_str[0] == 'n' ? m : k;
+  index_t ldb = t_b_str[0] == 'n' ? k : n;
+  index_t ldc = m;
+
+  {
+    // The counters are double. We convert m, n and k to double to avoid
+    // integer overflows for n_fl_ops and bytes_processed
+    double m_d = static_cast<double>(m);
+    double n_d = static_cast<double>(n);
+    double k_d = static_cast<double>(k);
+
+    state.counters["m"] = m_d;
+    state.counters["k"] = k_d;
+    state.counters["n"] = n_d;
+
+    double mem_readA = m_d * k_d;
+    double mem_readB = k_d * n_d;
+    double mem_writeC = m_d * n_d;
+    double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
+    double total_mem =
+        (mem_readA + mem_readB + mem_readC + mem_writeC) * sizeof(scalar_t);
+    state.counters["bytes_processed"] = total_mem;
+    state.SetBytesProcessed(state.iterations() * total_mem);
+
+    double nflops_AtimesB = (2 * k_d) * m_d * n_d;
+    double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
+    double nflops_tot = nflops_AtimesB + nflops_addBetaC;
+    state.counters["n_fl_ops"] = nflops_tot;
+    state.SetItemsProcessed(state.iterations() * nflops_tot);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_operation trans_a =
+      t_a_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
+  const rocblas_operation trans_b =
+      t_b_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
+
+  // Data sizes
+  const int a_size = m * k;
+  const int b_size = k * n;
+  const int c_size = m * n;
+
+  // Matrices
+  std::vector<scalar_t> a =
+      blas_benchmark::utils::random_data<scalar_t>(a_size);
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(b_size);
+  std::vector<scalar_t> c =
+      blas_benchmark::utils::const_data<scalar_t>(c_size, 0);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> a_gpu(a_size, a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> b_gpu(b_size, b.data());
+    blas_benchmark::utils::HIPVector<scalar_t> c_gpu(c_size, c.data());
+
+    CHECK_ROCBLAS_STATUS(
+        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference gemm
+    std::vector<scalar_t> c_ref = c;
+    reference_blas::gemm(t_a_str, t_b_str, m, n, k, alpha, a.data(), lda,
+                         b.data(), ldb, beta, c_ref.data(), ldc);
+
+    // Rocblas verification gemm
+    std::vector<scalar_t> c_temp = c;
+    {
+      // Temp result on device (copied back to Host upon destruction)
+      blas_benchmark::utils::HIPVector<scalar_t, true> c_temp_gpu(
+          c_size, c_temp.data());
+      // rocBLAS function call
+      rocblas_gemm_f<scalar_t>(rb_handle, trans_a, trans_b, m, n, k, &alpha,
+                               a_gpu, lda, b_gpu, ldb, &beta, c_temp_gpu, ldc);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+    auto blas_warmup = [&]() -> void {
+      rocblas_gemm_f<scalar_t>(rb_handle, trans_a, trans_b, m, n, k, &alpha,
+                               a_gpu, lda, b_gpu, ldb, &beta, c_gpu, ldc);
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_gemm_f<scalar_t>(rb_handle, trans_a, trans_b, m, n, k, &alpha,
+                               a_gpu, lda, b_gpu, ldb, &beta, c_gpu, ldc);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto gemm_params = blas_benchmark::utils::get_blas3_params<scalar_t>(args);
+
+  for (auto p : gemm_params) {
+    std::string t_a, t_b;
+    index_t m, n, k;
+    scalar_t alpha, beta;
+    std::tie(t_a, t_b, m, k, n, alpha, beta) = p;
+    int t_ai = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t_a));
+    int t_bi = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t_b));
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         int t_ai, int t_bi, index_t m, index_t k, index_t n,
+                         scalar_t alpha, scalar_t beta, bool* success) {
+      run<scalar_t>(st, rb_handle, t_ai, t_bi, m, k, n, alpha, beta, success);
+    };
+    benchmark::RegisterBenchmark(get_name<scalar_t>(t_a, t_b, m, k, n).c_str(),
+                                 BM_lambda, rb_handle, t_ai, t_bi, m, k, n,
+                                 alpha, beta, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas3/gemm.cpp
+++ b/benchmark/rocblas/blas3/gemm.cpp
@@ -59,30 +59,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
   index_t ldb = t_b_str[0] == 'n' ? k : n;
   index_t ldc = m;
 
-  {
-    // The counters are double. We convert m, n and k to double to avoid
-    // integer overflows for n_fl_ops and bytes_processed
-    double m_d = static_cast<double>(m);
-    double n_d = static_cast<double>(n);
-    double k_d = static_cast<double>(k);
-
-    state.counters["m"] = m_d;
-    state.counters["k"] = k_d;
-    state.counters["n"] = n_d;
-
-    double mem_readA = m_d * k_d;
-    double mem_readB = k_d * n_d;
-    double mem_writeC = m_d * n_d;
-    double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
-    double total_mem =
-        (mem_readA + mem_readB + mem_readC + mem_writeC) * sizeof(scalar_t);
-    state.counters["bytes_processed"] = total_mem;
-
-    double nflops_AtimesB = (2 * k_d) * m_d * n_d;
-    double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
-    double total_nflops = nflops_AtimesB + nflops_addBetaC;
-    state.counters["n_fl_ops"] = total_nflops;
-  }
+  blas_benchmark::utils::init_level_3_counters<
+      blas_benchmark::utils::Level3Op::gemm, scalar_t>(state, beta, m, n, k);
 
   // Matrix options (rocBLAS)
   const rocblas_operation trans_a_rb =

--- a/benchmark/rocblas/blas3/gemm_batched.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched.cpp
@@ -172,7 +172,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_a_i,
     };
 
     // Warmup
-    blas_benchmark::utils::warmup(blas_method_def);
+    blas_benchmark::utils::warmup(blas_warmup);
     CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);

--- a/benchmark/rocblas/blas3/gemm_batched.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched.cpp
@@ -1,0 +1,241 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename gemm_batched.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string t1, std::string t2, int m, int k, int n,
+                     int batch_count, int batch_type) {
+  std::ostringstream str{};
+  str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
+      << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
+      << batch_count << "/"
+      << blas_benchmark::utils::batch_type_to_str(batch_type);
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_gemm_batched_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_sgemm_batched(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dgemm_batched(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_ai,
+         index_t t_bi, index_t m, index_t k, index_t n, scalar_t alpha,
+         scalar_t beta, index_t batch_count, int batch_type_i, bool* success) {
+  // Standard setup
+  std::string t_a = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(t_ai));
+  std::string t_b = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(t_bi));
+  const char* t_a_str = t_a.c_str();
+  const char* t_b_str = t_b.c_str();
+  auto batch_type = static_cast<blas::gemm_batch_type_t>(batch_type_i);
+
+  index_t lda = t_a_str[0] == 'n' ? m : k;
+  index_t ldb = t_b_str[0] == 'n' ? k : n;
+  index_t ldc = m;
+
+  {
+    // The counters are double. We convert m, n, k and batch_count to double to
+    // avoid integer overflows for n_fl_ops and bytes_processed
+    double m_d = static_cast<double>(m);
+    double n_d = static_cast<double>(n);
+    double k_d = static_cast<double>(k);
+    double batch_count_d = static_cast<double>(batch_count);
+
+    state.counters["m"] = m_d;
+    state.counters["k"] = k_d;
+    state.counters["n"] = n_d;
+    state.counters["batch_count"] = batch_count_d;
+
+    const double nflops_AtimesB = (2 * k_d) * m_d * n_d;
+    const double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
+    const double total_nflops =
+        (nflops_AtimesB + nflops_addBetaC) * batch_count_d;
+    state.counters["n_fl_ops"] = total_nflops;
+    state.SetItemsProcessed(state.iterations() * total_nflops);
+
+    const double mem_readA = m_d * k_d;
+    const double mem_readB = k_d * n_d;
+    const double mem_writeC = m_d * n_d;
+    const double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
+    const double total_mem = (mem_readA + mem_readB + mem_readC + mem_writeC) *
+                             batch_count_d * sizeof(scalar_t);
+    state.counters["bytes_processed"] = total_mem;
+    state.SetBytesProcessed(state.iterations() * total_mem);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_operation trans_a_rb =
+      t_a_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
+  const rocblas_operation trans_b_rb =
+      t_b_str[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
+
+  // Data sizes
+  const int a_size = m * k;
+  const int b_size = k * n;
+  const int c_size = m * n;
+
+  // Matrices
+  std::vector<scalar_t> a =
+      blas_benchmark::utils::random_data<scalar_t>(a_size * batch_count);
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(b_size * batch_count);
+  std::vector<scalar_t> c =
+      blas_benchmark::utils::const_data<scalar_t>(c_size * batch_count, 0);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVectorBatched<scalar_t> a_batched_gpu(
+        a_size, batch_count, a.data());
+    blas_benchmark::utils::HIPVectorBatched<scalar_t> b_batched_gpu(
+        b_size, batch_count, b.data());
+    blas_benchmark::utils::HIPVectorBatched<scalar_t> c_batched_gpu(
+        c_size, batch_count);
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference batched gemm
+    std::vector<scalar_t> c_ref = c;
+    for (int batch = 0; batch < batch_count; batch++) {
+      reference_blas::gemm(t_a_str, t_b_str, m, n, k, alpha,
+                           a.data() + batch * a_size, lda,
+                           b.data() + batch * b_size, ldb, beta,
+                           c_ref.data() + batch * c_size, ldc);
+    }
+
+    // Rocblas verification gemm_batched
+    std::vector<scalar_t> c_temp = c;
+    {
+      blas_benchmark::utils::HIPVectorBatched<scalar_t, true> c_temp_gpu(
+          c_size, batch_count, c_temp.data());
+      rocblas_gemm_batched_f<scalar_t>(
+          rb_handle, trans_a_rb, trans_b_rb, m, n, k, &alpha, a_batched_gpu,
+          lda, b_batched_gpu, ldb, &beta, c_temp_gpu, ldc, batch_count);
+    }
+
+    std::ostringstream err_stream;
+    for (int i = 0; i < batch_count; ++i) {
+      if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+        const std::string& err_str = err_stream.str();
+        state.SkipWithError(err_str.c_str());
+        *success = false;
+      };
+    }
+
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_gemm_batched_f<scalar_t>(
+          rb_handle, trans_a_rb, trans_b_rb, m, n, k, &alpha, a_batched_gpu,
+          lda, b_batched_gpu, ldb, &beta, c_batched_gpu, ldc, batch_count);
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_gemm_batched_f<scalar_t>(
+          rb_handle, trans_a_rb, trans_b_rb, m, n, k, &alpha, a_batched_gpu,
+          lda, b_batched_gpu, ldb, &beta, c_batched_gpu, ldc, batch_count);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_method_def);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto gemm_batched_params =
+      blas_benchmark::utils::get_gemm_batched_params<scalar_t>(args);
+
+  for (auto p : gemm_batched_params) {
+    std::string t_a, t_b;
+    index_t m, n, k, batch_count;
+    scalar_t alpha, beta;
+    int batch_type;
+    std::tie(t_a, t_b, m, k, n, alpha, beta, batch_count, batch_type) = p;
+
+    if (batch_type == 1) {
+      std::cerr << "interleaved memory for gemm_batched operator is not "
+                   "supported by rocBLAS\n";
+      continue;
+    }
+
+    int t_ai = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t_a));
+    int t_bi = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t_b));
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         int t_ai, int t_bi, index_t m, index_t k, index_t n,
+                         scalar_t alpha, scalar_t beta, index_t batch_count,
+                         int batch_type, bool* success) {
+      run<scalar_t>(st, rb_handle, t_ai, t_bi, m, k, n, alpha, beta,
+                    batch_count, batch_type, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(t_a, t_b, m, k, n, batch_count, batch_type).c_str(),
+        BM_lambda, rb_handle, t_ai, t_bi, m, k, n, alpha, beta, batch_count,
+        batch_type, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas3/gemm_batched.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched.cpp
@@ -66,33 +66,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_a_i,
   index_t ldb = trB ? k : n;
   index_t ldc = m;
 
-  {
-    // The counters are double. We convert m, n, k and batch_size to double to
-    // avoid integer overflows for n_fl_ops and bytes_processed
-    double m_d = static_cast<double>(m);
-    double n_d = static_cast<double>(n);
-    double k_d = static_cast<double>(k);
-    double batch_size_d = static_cast<double>(batch_size);
-
-    state.counters["m"] = m_d;
-    state.counters["k"] = k_d;
-    state.counters["n"] = n_d;
-    state.counters["batch_size"] = batch_size_d;
-
-    const double nflops_AtimesB = (2 * k_d) * m_d * n_d;
-    const double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
-    const double total_nflops =
-        (nflops_AtimesB + nflops_addBetaC) * batch_size_d;
-    state.counters["n_fl_ops"] = total_nflops;
-
-    const double mem_readA = m_d * k_d;
-    const double mem_readB = k_d * n_d;
-    const double mem_writeC = m_d * n_d;
-    const double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
-    const double total_mem = (mem_readA + mem_readB + mem_readC + mem_writeC) *
-                             batch_size_d * sizeof(scalar_t);
-    state.counters["bytes_processed"] = total_mem;
-  }
+  blas_benchmark::utils::init_level_3_counters<
+      blas_benchmark::utils::Level3Op::gemm_batched, scalar_t>(
+      state, beta, m, n, k, batch_size);
 
   // Matrix options (rocBLAS)
   const rocblas_operation trans_a_rb =

--- a/benchmark/rocblas/blas3/gemm_batched.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched.cpp
@@ -27,11 +27,11 @@
 
 template <typename scalar_t>
 std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_count, int batch_type) {
+                     int batch_size, int batch_type) {
   std::ostringstream str{};
   str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
       << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
-      << batch_count << "/"
+      << batch_size << "/"
       << blas_benchmark::utils::batch_type_to_str(batch_type);
   return str.str();
 }
@@ -49,7 +49,7 @@ static inline void rocblas_gemm_batched_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_ai,
          index_t t_bi, index_t m, index_t k, index_t n, scalar_t alpha,
-         scalar_t beta, index_t batch_count, int batch_type_i, bool* success) {
+         scalar_t beta, index_t batch_size, int batch_type_i, bool* success) {
   // Standard setup
   std::string t_a = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(t_ai));
@@ -64,22 +64,22 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_ai,
   index_t ldc = m;
 
   {
-    // The counters are double. We convert m, n, k and batch_count to double to
+    // The counters are double. We convert m, n, k and batch_size to double to
     // avoid integer overflows for n_fl_ops and bytes_processed
     double m_d = static_cast<double>(m);
     double n_d = static_cast<double>(n);
     double k_d = static_cast<double>(k);
-    double batch_count_d = static_cast<double>(batch_count);
+    double batch_size_d = static_cast<double>(batch_size);
 
     state.counters["m"] = m_d;
     state.counters["k"] = k_d;
     state.counters["n"] = n_d;
-    state.counters["batch_count"] = batch_count_d;
+    state.counters["batch_size"] = batch_size_d;
 
     const double nflops_AtimesB = (2 * k_d) * m_d * n_d;
     const double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
     const double total_nflops =
-        (nflops_AtimesB + nflops_addBetaC) * batch_count_d;
+        (nflops_AtimesB + nflops_addBetaC) * batch_size_d;
     state.counters["n_fl_ops"] = total_nflops;
     state.SetItemsProcessed(state.iterations() * total_nflops);
 
@@ -88,7 +88,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_ai,
     const double mem_writeC = m_d * n_d;
     const double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
     const double total_mem = (mem_readA + mem_readB + mem_readC + mem_writeC) *
-                             batch_count_d * sizeof(scalar_t);
+                             batch_size_d * sizeof(scalar_t);
     state.counters["bytes_processed"] = total_mem;
     state.SetBytesProcessed(state.iterations() * total_mem);
   }
@@ -106,25 +106,25 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_ai,
 
   // Matrices
   std::vector<scalar_t> a =
-      blas_benchmark::utils::random_data<scalar_t>(a_size * batch_count);
+      blas_benchmark::utils::random_data<scalar_t>(a_size * batch_size);
   std::vector<scalar_t> b =
-      blas_benchmark::utils::random_data<scalar_t>(b_size * batch_count);
+      blas_benchmark::utils::random_data<scalar_t>(b_size * batch_size);
   std::vector<scalar_t> c =
-      blas_benchmark::utils::const_data<scalar_t>(c_size * batch_count, 0);
+      blas_benchmark::utils::const_data<scalar_t>(c_size * batch_size, 0);
 
   {
     // Device memory allocation & H2D copy
     blas_benchmark::utils::HIPVectorBatched<scalar_t> a_batched_gpu(
-        a_size, batch_count, a.data());
+        a_size, batch_size, a.data());
     blas_benchmark::utils::HIPVectorBatched<scalar_t> b_batched_gpu(
-        b_size, batch_count, b.data());
-    blas_benchmark::utils::HIPVectorBatched<scalar_t> c_batched_gpu(
-        c_size, batch_count);
+        b_size, batch_size, b.data());
+    blas_benchmark::utils::HIPVectorBatched<scalar_t> c_batched_gpu(c_size,
+                                                                    batch_size);
 
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference batched gemm
     std::vector<scalar_t> c_ref = c;
-    for (int batch = 0; batch < batch_count; batch++) {
+    for (int batch = 0; batch < batch_size; batch++) {
       reference_blas::gemm(t_a_str, t_b_str, m, n, k, alpha,
                            a.data() + batch * a_size, lda,
                            b.data() + batch * b_size, ldb, beta,
@@ -135,27 +135,25 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_ai,
     std::vector<scalar_t> c_temp = c;
     {
       blas_benchmark::utils::HIPVectorBatched<scalar_t, true> c_temp_gpu(
-          c_size, batch_count, c_temp.data());
+          c_size, batch_size, c_temp.data());
       rocblas_gemm_batched_f<scalar_t>(
           rb_handle, trans_a_rb, trans_b_rb, m, n, k, &alpha, a_batched_gpu,
-          lda, b_batched_gpu, ldb, &beta, c_temp_gpu, ldc, batch_count);
+          lda, b_batched_gpu, ldb, &beta, c_temp_gpu, ldc, batch_size);
     }
 
     std::ostringstream err_stream;
-    for (int i = 0; i < batch_count; ++i) {
-      if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
-        const std::string& err_str = err_stream.str();
-        state.SkipWithError(err_str.c_str());
-        *success = false;
-      };
-    }
+    if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
 
 #endif
 
     auto blas_warmup = [&]() -> void {
       rocblas_gemm_batched_f<scalar_t>(
           rb_handle, trans_a_rb, trans_b_rb, m, n, k, &alpha, a_batched_gpu,
-          lda, b_batched_gpu, ldb, &beta, c_batched_gpu, ldc, batch_count);
+          lda, b_batched_gpu, ldb, &beta, c_batched_gpu, ldc, batch_size);
       return;
     };
 
@@ -167,7 +165,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_ai,
       CHECK_HIP_ERROR(hipEventRecord(start, NULL));
       rocblas_gemm_batched_f<scalar_t>(
           rb_handle, trans_a_rb, trans_b_rb, m, n, k, &alpha, a_batched_gpu,
-          lda, b_batched_gpu, ldb, &beta, c_batched_gpu, ldc, batch_count);
+          lda, b_batched_gpu, ldb, &beta, c_batched_gpu, ldc, batch_size);
       CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
       CHECK_HIP_ERROR(hipEventSynchronize(stop));
       return std::vector{start, stop};
@@ -204,10 +202,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
 
   for (auto p : gemm_batched_params) {
     std::string t_a, t_b;
-    index_t m, n, k, batch_count;
+    index_t m, n, k, batch_size;
     scalar_t alpha, beta;
     int batch_type;
-    std::tie(t_a, t_b, m, k, n, alpha, beta, batch_count, batch_type) = p;
+    std::tie(t_a, t_b, m, k, n, alpha, beta, batch_size, batch_type) = p;
 
     if (batch_type == 1) {
       std::cerr << "interleaved memory for gemm_batched operator is not "
@@ -220,14 +218,14 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
 
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
                          int t_ai, int t_bi, index_t m, index_t k, index_t n,
-                         scalar_t alpha, scalar_t beta, index_t batch_count,
+                         scalar_t alpha, scalar_t beta, index_t batch_size,
                          int batch_type, bool* success) {
-      run<scalar_t>(st, rb_handle, t_ai, t_bi, m, k, n, alpha, beta,
-                    batch_count, batch_type, success);
+      run<scalar_t>(st, rb_handle, t_ai, t_bi, m, k, n, alpha, beta, batch_size,
+                    batch_type, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t_a, t_b, m, k, n, batch_count, batch_type).c_str(),
-        BM_lambda, rb_handle, t_ai, t_bi, m, k, n, alpha, beta, batch_count,
+        get_name<scalar_t>(t_a, t_b, m, k, n, batch_size, batch_type).c_str(),
+        BM_lambda, rb_handle, t_ai, t_bi, m, k, n, alpha, beta, batch_size,
         batch_type, success)
         ->UseRealTime();
   }

--- a/benchmark/rocblas/blas3/gemm_batched.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched.cpp
@@ -84,7 +84,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_a_i,
     const double total_nflops =
         (nflops_AtimesB + nflops_addBetaC) * batch_size_d;
     state.counters["n_fl_ops"] = total_nflops;
-    state.SetItemsProcessed(state.iterations() * total_nflops);
 
     const double mem_readA = m_d * k_d;
     const double mem_readB = k_d * n_d;
@@ -93,7 +92,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_a_i,
     const double total_mem = (mem_readA + mem_readB + mem_readC + mem_writeC) *
                              batch_size_d * sizeof(scalar_t);
     state.counters["bytes_processed"] = total_mem;
-    state.SetBytesProcessed(state.iterations() * total_mem);
   }
 
   // Matrix options (rocBLAS)
@@ -188,6 +186,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_a_i,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetBytesProcessed(state.iterations() *
+                            state.counters["bytes_processed"]);
+    state.SetItemsProcessed(state.iterations() * state.counters["n_fl_ops"]);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas3/gemm_batched.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched.cpp
@@ -150,7 +150,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_a_i,
       state.SkipWithError(err_str.c_str());
       *success = false;
     };
-
 #endif
 
     auto blas_warmup = [&]() -> void {

--- a/benchmark/rocblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched_strided.cpp
@@ -92,7 +92,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
     const double total_nflops =
         (nflops_AtimesB + nflops_addBetaC) * batch_size_d;
     state.counters["n_fl_ops"] = total_nflops;
-    state.SetItemsProcessed(state.iterations() * total_nflops);
 
     const double mem_readA = m_d * k_d;
     const double mem_readB = k_d * n_d;
@@ -101,7 +100,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
     const double total_mem = (mem_readA + mem_readB + mem_readC + mem_writeC) *
                              batch_size_d * sizeof(scalar_t);
     state.counters["bytes_processed"] = total_mem;
-    state.SetBytesProcessed(state.iterations() * total_mem);
   }
 
   // Matrix options (rocBLAS)
@@ -209,6 +207,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetBytesProcessed(state.iterations() *
+                            state.counters["bytes_processed"]);
+    state.SetItemsProcessed(state.iterations() * state.counters["n_fl_ops"]);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched_strided.cpp
@@ -233,13 +233,12 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     int t_b_i = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t_b));
 
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
-                         int t_a_i, int t_b_i, index_t m, index_t k, index_t n,
+                         int t1i, int t2i, index_t m, index_t k, index_t n,
                          scalar_t alpha, scalar_t beta, index_t batch_size,
                          index_t stride_a_mul, index_t stride_b_mul,
                          index_t stride_c_mul, bool* success) {
-      run<scalar_t>(st, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta,
-                    batch_size, stride_a_mul, stride_b_mul, stride_c_mul,
-                    success);
+      run<scalar_t>(st, rb_handle, t1i, t2i, m, k, n, alpha, beta, batch_size,
+                    stride_a_mul, stride_b_mul, stride_c_mul, success);
     };
     benchmark::RegisterBenchmark(
         get_name<scalar_t>(t_a, t_b, m, k, n, batch_size, stride_a_mul,

--- a/benchmark/rocblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched_strided.cpp
@@ -70,37 +70,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
   index_t ldb = trB ? k : n;
   index_t ldc = m;
 
-  {
-    // The counters are double. We convert dimensions, stride multipliers &
-    // batch_size to double to avoid integer overflows for n_fl_ops and
-    // bytes_processed
-    const double m_d = static_cast<double>(m);
-    const double n_d = static_cast<double>(n);
-    const double k_d = static_cast<double>(k);
-    const double batch_size_d = static_cast<double>(batch_size);
-
-    state.counters["m"] = m_d;
-    state.counters["k"] = k_d;
-    state.counters["n"] = n_d;
-    state.counters["batch_size"] = batch_size_d;
-    state.counters["stride_a_mul"] = static_cast<double>(stride_a_mul);
-    state.counters["stride_b_mul"] = static_cast<double>(stride_b_mul);
-    state.counters["stride_c_mul"] = static_cast<double>(stride_c_mul);
-
-    const double nflops_AtimesB = (2 * k_d) * m_d * n_d;
-    const double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
-    const double total_nflops =
-        (nflops_AtimesB + nflops_addBetaC) * batch_size_d;
-    state.counters["n_fl_ops"] = total_nflops;
-
-    const double mem_readA = m_d * k_d;
-    const double mem_readB = k_d * n_d;
-    const double mem_writeC = m_d * n_d;
-    const double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
-    const double total_mem = (mem_readA + mem_readB + mem_readC + mem_writeC) *
-                             batch_size_d * sizeof(scalar_t);
-    state.counters["bytes_processed"] = total_mem;
-  }
+  blas_benchmark::utils::init_level_3_counters<
+      blas_benchmark::utils::Level3Op::gemm_batched_strided, scalar_t>(
+      state, beta, m, n, k, batch_size);
 
   // Matrix options (rocBLAS)
   const rocblas_operation trans_a_rb =

--- a/benchmark/rocblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched_strided.cpp
@@ -19,7 +19,7 @@
  *
  *  SYCL-BLAS: BLAS implementation using SYCL
  *
- *  @filename gemm_batched.cpp
+ *  @filename gemm_batched_strided.cpp
  *
  **************************************************************************/
 
@@ -27,37 +27,41 @@
 
 template <typename scalar_t>
 std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int batch_type) {
+                     int batch_size, int stride_a_mul, int stride_b_mul,
+                     int stride_c_mul) {
   std::ostringstream str{};
-  str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
-      << batch_size << "/"
-      << blas_benchmark::utils::batch_type_to_str(batch_type);
+  str << "BM_GemmBatchedStrided<"
+      << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
+      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
+      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul << "/";
+
   return str.str();
 }
 
 template <typename scalar_t, typename... args_t>
-static inline void rocblas_gemm_batched_f(args_t&&... args) {
+static inline void rocblas_gemm_strided_batched(args_t&&... args) {
   if constexpr (std::is_same_v<scalar_t, float>) {
-    CHECK_ROCBLAS_STATUS(rocblas_sgemm_batched(std::forward<args_t>(args)...));
+    CHECK_ROCBLAS_STATUS(
+        rocblas_sgemm_strided_batched(std::forward<args_t>(args)...));
   } else if constexpr (std::is_same_v<scalar_t, double>) {
-    CHECK_ROCBLAS_STATUS(rocblas_dgemm_batched(std::forward<args_t>(args)...));
+    CHECK_ROCBLAS_STATUS(
+        rocblas_dgemm_strided_batched(std::forward<args_t>(args)...));
   }
   return;
 }
 
 template <typename scalar_t>
-void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_a_i,
-         index_t t_b_i, index_t m, index_t k, index_t n, scalar_t alpha,
-         scalar_t beta, index_t batch_size, int batch_type_i, bool* success) {
-  // Standard setup
+void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
+         int t_b_i, index_t m, index_t k, index_t n, scalar_t alpha,
+         scalar_t beta, index_t batch_size, index_t stride_a_mul,
+         index_t stride_b_mul, index_t stride_c_mul, bool* success) {
+  // Standard test setup.
   std::string t_a = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(t_a_i));
   std::string t_b = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(t_b_i));
   const char* t_a_str = t_a.c_str();
   const char* t_b_str = t_b.c_str();
-  auto batch_type = static_cast<blas::gemm_batch_type_t>(batch_type_i);
 
   const bool trA = (t_a_str[0] == 'n');
   const bool trB = (t_b_str[0] == 'n');
@@ -67,17 +71,21 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_a_i,
   index_t ldc = m;
 
   {
-    // The counters are double. We convert m, n, k and batch_size to double to
-    // avoid integer overflows for n_fl_ops and bytes_processed
-    double m_d = static_cast<double>(m);
-    double n_d = static_cast<double>(n);
-    double k_d = static_cast<double>(k);
-    double batch_size_d = static_cast<double>(batch_size);
+    // The counters are double. We convert dimensions, stride multipliers &
+    // batch_size to double to avoid integer overflows for n_fl_ops and
+    // bytes_processed
+    const double m_d = static_cast<double>(m);
+    const double n_d = static_cast<double>(n);
+    const double k_d = static_cast<double>(k);
+    const double batch_size_d = static_cast<double>(batch_size);
 
     state.counters["m"] = m_d;
     state.counters["k"] = k_d;
     state.counters["n"] = n_d;
     state.counters["batch_size"] = batch_size_d;
+    state.counters["stride_a_mul"] = static_cast<double>(stride_a_mul);
+    state.counters["stride_b_mul"] = static_cast<double>(stride_b_mul);
+    state.counters["stride_c_mul"] = static_cast<double>(stride_c_mul);
 
     const double nflops_AtimesB = (2 * k_d) * m_d * n_d;
     const double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;
@@ -103,60 +111,71 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_a_i,
       trB ? rocblas_operation_none : rocblas_operation_transpose;
 
   // Data sizes
-  const int a_size = m * k;
-  const int b_size = k * n;
-  const int c_size = m * n;
+  // Elementary matrices
+  const index_t a_size = m * k;
+  const index_t b_size = k * n;
+  const index_t c_size = m * n;
+  // Strides
+  const index_t stride_a = stride_a_mul * a_size;
+  const index_t stride_b = stride_b_mul * b_size;
+  const index_t stride_c = stride_c_mul * c_size;
+  // Batched matrices
+  const int size_a_batch = a_size + (batch_size - 1) * stride_a;
+  const int size_b_batch = b_size + (batch_size - 1) * stride_b;
+  const int size_c_batch = c_size + (batch_size - 1) * stride_c;
 
   // Matrices
   std::vector<scalar_t> a =
-      blas_benchmark::utils::random_data<scalar_t>(a_size * batch_size);
+      blas_benchmark::utils::random_data<scalar_t>(size_a_batch);
   std::vector<scalar_t> b =
-      blas_benchmark::utils::random_data<scalar_t>(b_size * batch_size);
+      blas_benchmark::utils::random_data<scalar_t>(size_b_batch);
   std::vector<scalar_t> c =
-      blas_benchmark::utils::const_data<scalar_t>(c_size * batch_size, 0);
+      blas_benchmark::utils::const_data<scalar_t>(size_c_batch, 0);
 
   {
     // Device memory allocation & H2D copy
-    blas_benchmark::utils::HIPVectorBatched<scalar_t> a_batched_gpu(
-        a_size, batch_size, a.data());
-    blas_benchmark::utils::HIPVectorBatched<scalar_t> b_batched_gpu(
-        b_size, batch_size, b.data());
-    blas_benchmark::utils::HIPVectorBatched<scalar_t> c_batched_gpu(c_size,
-                                                                    batch_size);
+    blas_benchmark::utils::HIPVectorBatchedStrided<scalar_t> a_batched_gpu(
+        a_size, batch_size, stride_a, a.data());
+    blas_benchmark::utils::HIPVectorBatchedStrided<scalar_t> b_batched_gpu(
+        b_size, batch_size, stride_b, b.data());
+    blas_benchmark::utils::HIPVectorBatchedStrided<scalar_t> c_batched_gpu(
+        c_size, batch_size, stride_c, c.data());
 
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference batched gemm
     std::vector<scalar_t> c_ref = c;
     for (int batch = 0; batch < batch_size; batch++) {
       reference_blas::gemm(t_a_str, t_b_str, m, n, k, alpha,
-                           a.data() + batch * a_size, lda,
-                           b.data() + batch * b_size, ldb, beta,
-                           c_ref.data() + batch * c_size, ldc);
+                           a.data() + batch * stride_a, lda,
+                           b.data() + batch * stride_b, ldb, beta,
+                           c_ref.data() + batch * stride_c, ldc);
     }
 
-    // Rocblas verification gemm_batched
+    // Rocblas verification gemm_batched_strided
     std::vector<scalar_t> c_temp = c;
     {
-      blas_benchmark::utils::HIPVectorBatched<scalar_t, true> c_temp_gpu(
-          c_size, batch_size, c_temp.data());
-      rocblas_gemm_batched_f<scalar_t>(
+      blas_benchmark::utils::HIPVectorBatchedStrided<scalar_t, true> c_temp_gpu(
+          c_size, batch_size, stride_c, c_temp.data());
+      rocblas_gemm_strided_batched<scalar_t>(
           rb_handle, trans_a_rb, trans_b_rb, m, n, k, &alpha, a_batched_gpu,
-          lda, b_batched_gpu, ldb, &beta, c_temp_gpu, ldc, batch_size);
+          lda, stride_a, b_batched_gpu, ldb, stride_b, &beta, c_temp_gpu, ldc,
+          stride_c, batch_size);
     }
 
     std::ostringstream err_stream;
-    if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+    if (!utils::compare_vectors_strided(c_temp, c_ref, stride_c, c_size,
+                                        err_stream, "")) {
       const std::string& err_str = err_stream.str();
       state.SkipWithError(err_str.c_str());
       *success = false;
     };
-
 #endif
 
     auto blas_warmup = [&]() -> void {
-      rocblas_gemm_batched_f<scalar_t>(
+      rocblas_gemm_strided_batched<scalar_t>(
           rb_handle, trans_a_rb, trans_b_rb, m, n, k, &alpha, a_batched_gpu,
-          lda, b_batched_gpu, ldb, &beta, c_batched_gpu, ldc, batch_size);
+          lda, stride_a, b_batched_gpu, ldb, stride_b, &beta, c_batched_gpu,
+          ldc, stride_c, batch_size);
       return;
     };
 
@@ -166,16 +185,17 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_a_i,
 
     auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
       CHECK_HIP_ERROR(hipEventRecord(start, NULL));
-      rocblas_gemm_batched_f<scalar_t>(
+      rocblas_gemm_strided_batched<scalar_t>(
           rb_handle, trans_a_rb, trans_b_rb, m, n, k, &alpha, a_batched_gpu,
-          lda, b_batched_gpu, ldb, &beta, c_batched_gpu, ldc, batch_size);
+          lda, stride_a, b_batched_gpu, ldb, stride_b, &beta, c_batched_gpu,
+          ldc, stride_c, batch_size);
       CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
       CHECK_HIP_ERROR(hipEventSynchronize(stop));
       return std::vector{start, stop};
     };
 
     // Warmup
-    blas_benchmark::utils::warmup(blas_method_def);
+    blas_benchmark::utils::warmup(blas_warmup);
     CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);
@@ -200,36 +220,33 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_a_i,
 template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                         bool* success) {
-  auto gemm_batched_params =
-      blas_benchmark::utils::get_gemm_batched_params<scalar_t>(args);
+  auto gemm_batched_strided_params =
+      blas_benchmark::utils::get_gemm_batched_strided_params<scalar_t>(args);
 
-  for (auto p : gemm_batched_params) {
+  for (auto p : gemm_batched_strided_params) {
     std::string t_a, t_b;
-    index_t m, n, k, batch_size;
+    index_t m, n, k, batch_size, stride_a_mul, stride_b_mul, stride_c_mul;
     scalar_t alpha, beta;
-    int batch_type;
-    std::tie(t_a, t_b, m, k, n, alpha, beta, batch_size, batch_type) = p;
-
-    if (batch_type == 1) {
-      std::cerr << "interleaved memory for gemm_batched operator is not "
-                   "supported by rocBLAS\n";
-      continue;
-    }
-
+    std::tie(t_a, t_b, m, k, n, alpha, beta, batch_size, stride_a_mul,
+             stride_b_mul, stride_c_mul) = p;
     int t_a_i = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t_a));
     int t_b_i = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t_b));
 
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
                          int t_a_i, int t_b_i, index_t m, index_t k, index_t n,
                          scalar_t alpha, scalar_t beta, index_t batch_size,
-                         int batch_type, bool* success) {
+                         index_t stride_a_mul, index_t stride_b_mul,
+                         index_t stride_c_mul, bool* success) {
       run<scalar_t>(st, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta,
-                    batch_size, batch_type, success);
+                    batch_size, stride_a_mul, stride_b_mul, stride_c_mul,
+                    success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t_a, t_b, m, k, n, batch_size, batch_type).c_str(),
+        get_name<scalar_t>(t_a, t_b, m, k, n, batch_size, stride_a_mul,
+                           stride_b_mul, stride_c_mul)
+            .c_str(),
         BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, batch_size,
-        batch_type, success)
+        stride_a_mul, stride_b_mul, stride_c_mul, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched_strided.cpp
@@ -140,7 +140,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
         c_size, batch_size, stride_c, c.data());
 
 #ifdef BLAS_VERIFY_BENCHMARK
-    // Reference batched gemm
+    // Reference gemm batched strided (strided loop of gemm)
     std::vector<scalar_t> c_ref = c;
     for (int batch = 0; batch < batch_size; batch++) {
       reference_blas::gemm(t_a_str, t_b_str, m, n, k, alpha,
@@ -237,10 +237,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
                          int t1i, int t2i, index_t m, index_t k, index_t n,
                          scalar_t alpha, scalar_t beta, index_t batch_size,
-                         index_t stride_a_mul, index_t stride_b_mul,
-                         index_t stride_c_mul, bool* success) {
+                         index_t strd_a_mul, index_t strd_b_mul,
+                         index_t strd_c_mul, bool* success) {
       run<scalar_t>(st, rb_handle, t1i, t2i, m, k, n, alpha, beta, batch_size,
-                    stride_a_mul, stride_b_mul, stride_c_mul, success);
+                    strd_a_mul, strd_b_mul, strd_c_mul, success);
     };
     benchmark::RegisterBenchmark(
         get_name<scalar_t>(t_a, t_b, m, k, n, batch_size, stride_a_mul,

--- a/benchmark/rocblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched_strided.cpp
@@ -72,7 +72,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
 
   blas_benchmark::utils::init_level_3_counters<
       blas_benchmark::utils::Level3Op::gemm_batched_strided, scalar_t>(
-      state, beta, m, n, k, batch_size);
+      state, beta, m, n, k, batch_size, stride_a_mul, stride_b_mul,
+      stride_c_mul);
 
   // Matrix options (rocBLAS)
   const rocblas_operation trans_a_rb =

--- a/benchmark/rocblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched_strided.cpp
@@ -33,7 +33,7 @@ std::string get_name(std::string t1, std::string t2, int m, int k, int n,
   str << "BM_GemmBatchedStrided<"
       << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
       << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
-      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul << "/";
+      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul;
 
   return str.str();
 }

--- a/benchmark/rocblas/blas3/symm.cpp
+++ b/benchmark/rocblas/blas3/symm.cpp
@@ -77,9 +77,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
     const double nflops_addBetaC = 2 * m_d * n_d;
     const double total_nflops = nflops_AtimesB + nflops_addBetaC;
     state.counters["n_fl_ops"] = total_nflops;
-
-    state.SetBytesProcessed(state.iterations() * total_mem);
-    state.SetItemsProcessed(state.iterations() * total_nflops);
   }
 
   // Matrix options (rocBLAS)
@@ -106,9 +103,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
     blas_benchmark::utils::HIPVector<scalar_t> a_gpu(a_size, a.data());
     blas_benchmark::utils::HIPVector<scalar_t> b_gpu(b_size, b.data());
     blas_benchmark::utils::HIPVector<scalar_t> c_gpu(c_size, c.data());
-
-    CHECK_ROCBLAS_STATUS(
-        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
 
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference symm
@@ -167,6 +161,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetBytesProcessed(state.iterations() *
+                            state.counters["bytes_processed"]);
+    state.SetItemsProcessed(state.iterations() * state.counters["n_fl_ops"]);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas3/symm.cpp
+++ b/benchmark/rocblas/blas3/symm.cpp
@@ -54,30 +54,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
   index_t ldb = m;
   index_t ldc = ldb;
 
-  {
-    // The counters are double. We convert m, n and k to double to avoid
-    // integer overflows for n_fl_ops and bytes_processed
-    double m_d = static_cast<double>(m);
-    double n_d = static_cast<double>(n);
-
-    state.counters["m"] = m_d;
-    state.counters["n"] = n_d;
-
-    const double mem_readB = m_d * n_d;
-    const double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
-    const double mem_writeC = m_d * n_d;
-    const double mem_readA =
-        (side == 'l') ? (m_d * (m_d + 1) / 2) : (n_d * (n_d + 1) / 2);
-    const double total_mem =
-        (mem_readB + mem_readC + mem_writeC + mem_readA) * sizeof(scalar_t);
-    state.counters["bytes_processed"] = total_mem;
-
-    const double nflops_AtimesB =
-        (side == 'l') ? (2 * m_d * m_d) * n_d : 2 * n_d * n_d * n_d;
-    const double nflops_addBetaC = 2 * m_d * n_d;
-    const double total_nflops = nflops_AtimesB + nflops_addBetaC;
-    state.counters["n_fl_ops"] = total_nflops;
-  }
+  blas_benchmark::utils::init_level_3_counters<
+      blas_benchmark::utils::Level3Op::symm, scalar_t>(state, beta, m, n, 0, 1,
+                                                       side);
 
   // Matrix options (rocBLAS)
   const rocblas_side side_rb =

--- a/benchmark/rocblas/blas3/symm.cpp
+++ b/benchmark/rocblas/blas3/symm.cpp
@@ -85,7 +85,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
   // Matrix options (rocBLAS)
   const rocblas_side side_rb =
       (side == 'l') ? rocblas_side_left : rocblas_side_right;
-
   const rocblas_fill uplo_rb =
       (uplo == 'u') ? rocblas_fill_upper : rocblas_fill_lower;
 
@@ -133,6 +132,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
       *success = false;
     };
 #endif
+
     auto blas_warmup = [&]() -> void {
       rocblas_symm_f<scalar_t>(rb_handle, side_rb, uplo_rb, m, n, &alpha, a_gpu,
                                lda, b_gpu, ldb, &beta, c_gpu, ldc);

--- a/benchmark/rocblas/blas3/symm.cpp
+++ b/benchmark/rocblas/blas3/symm.cpp
@@ -1,0 +1,206 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename symm.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(char side, char uplo, int m, int n, scalar_t alpha,
+                     scalar_t beta) {
+  std::ostringstream str{};
+  str << "BM_Symm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << side << "/" << uplo << "/" << m << "/" << n << "/" << alpha << "/"
+      << beta;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_symm_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_ssymm(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dsymm(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
+         char uplo, index_t m, index_t n, scalar_t alpha, scalar_t beta,
+         bool* success) {
+  // Standard test setup.
+  index_t lda = (side == 'l') ? m : n;
+  index_t ldb = m;
+  index_t ldc = ldb;
+
+  {
+    // The counters are double. We convert m, n and k to double to avoid
+    // integer overflows for n_fl_ops and bytes_processed
+    double m_d = static_cast<double>(m);
+    double n_d = static_cast<double>(n);
+
+    state.counters["m"] = m_d;
+    state.counters["n"] = n_d;
+
+    const double mem_readB = m_d * n_d;
+    const double mem_readC = (beta != scalar_t{0}) ? m_d * n_d : 0;
+    const double mem_writeC = m_d * n_d;
+    const double mem_readA =
+        (side == 'l') ? (m_d * (m_d + 1) / 2) : (n_d * (n_d + 1) / 2);
+    const double total_mem =
+        (mem_readB + mem_readC + mem_writeC + mem_readA) * sizeof(scalar_t);
+    state.counters["bytes_processed"] = total_mem;
+
+    const double nflops_AtimesB =
+        (side == 'l') ? (2 * m_d * m_d) * n_d : 2 * n_d * n_d * n_d;
+    const double nflops_addBetaC = 2 * m_d * n_d;
+    const double total_nflops = nflops_AtimesB + nflops_addBetaC;
+    state.counters["n_fl_ops"] = total_nflops;
+
+    state.SetBytesProcessed(state.iterations() * total_mem);
+    state.SetItemsProcessed(state.iterations() * total_nflops);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_side side_rb =
+      (side == 'l') ? rocblas_side_left : rocblas_side_right;
+
+  const rocblas_fill uplo_rb =
+      (uplo == 'u') ? rocblas_fill_upper : rocblas_fill_lower;
+
+  // Data sizes
+  const int a_size = lda * lda;
+  const int b_size = ldb * n;
+  const int c_size = ldc * n;
+
+  // Matrices
+  std::vector<scalar_t> a =
+      blas_benchmark::utils::random_data<scalar_t>(a_size);
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(b_size);
+  std::vector<scalar_t> c =
+      blas_benchmark::utils::random_data<scalar_t>(c_size);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> a_gpu(a_size, a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> b_gpu(b_size, b.data());
+    blas_benchmark::utils::HIPVector<scalar_t> c_gpu(c_size, c.data());
+
+    CHECK_ROCBLAS_STATUS(
+        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference symm
+    std::vector<scalar_t> c_ref = c;
+    reference_blas::symm(&side, &uplo, m, n, alpha, a.data(), lda, b.data(),
+                         ldb, beta, c_ref.data(), ldc);
+
+    // Rocblas verification symm
+    std::vector<scalar_t> c_temp = c;
+    {
+      blas_benchmark::utils::HIPVector<scalar_t, true> c_temp_gpu(
+          c_size, c_temp.data());
+      rocblas_symm_f<scalar_t>(rb_handle, side_rb, uplo_rb, m, n, &alpha, a_gpu,
+                               lda, b_gpu, ldb, &beta, c_temp_gpu, ldc);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+    auto blas_warmup = [&]() -> void {
+      rocblas_symm_f<scalar_t>(rb_handle, side_rb, uplo_rb, m, n, &alpha, a_gpu,
+                               lda, b_gpu, ldb, &beta, c_gpu, ldc);
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_symm_f<scalar_t>(rb_handle, side_rb, uplo_rb, m, n, &alpha, a_gpu,
+                               lda, b_gpu, ldb, &beta, c_gpu, ldc);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto symm_params = blas_benchmark::utils::get_symm_params<scalar_t>(args);
+
+  for (auto p : symm_params) {
+    char side, uplo;
+    index_t m, n;
+    scalar_t alpha, beta;
+    std::tie(side, uplo, m, n, alpha, beta) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         char side, char uplo, index_t m, index_t n,
+                         scalar_t alpha, scalar_t beta, bool* success) {
+      run<scalar_t>(st, rb_handle, side, uplo, m, n, alpha, beta, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(side, uplo, m, n, alpha, beta).c_str(), BM_lambda,
+        rb_handle, side, uplo, m, n, alpha, beta, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas3/syr2k.cpp
+++ b/benchmark/rocblas/blas3/syr2k.cpp
@@ -85,7 +85,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
   // Matrix options (rocBLAS)
   const rocblas_fill uplo_rb =
       (uplo == 'u') ? rocblas_fill_upper : rocblas_fill_lower;
-
   const rocblas_operation trans_rb =
       (trans == 'n') ? rocblas_operation_none : rocblas_operation_transpose;
 

--- a/benchmark/rocblas/blas3/syr2k.cpp
+++ b/benchmark/rocblas/blas3/syr2k.cpp
@@ -53,32 +53,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
   const index_t lda = (trans == 'n') ? n : k;
   const index_t ldc = n;
 
-  {
-    // The counters are double. We convert m, n and k to double to avoid
-    // integer overflows for n_fl_ops and bytes_processed
-    const double n_d = static_cast<double>(n);
-    const double k_d = static_cast<double>(k);
-
-    state.counters["k"] = k_d;
-    state.counters["n"] = n_d;
-
-    const double mem_readAreadB = 2 * n_d * k_d;
-    const double mem_readC = (beta != scalar_t{0}) ? n_d * (n_d + 1) / 2. : 0.;
-    const double mem_writeC = n_d * (n_d + 1) / 2.;
-    const double total_mem =
-        (mem_readAreadB + mem_readC + mem_writeC) * sizeof(scalar_t);
-
-    state.counters["bytes_processed"] = total_mem;
-
-    const double nflops_AtimesB = 2 * n_d * (n_d + 1) * k_d;
-    const double nflops_timesAlpha = n_d * (n_d + 1) / 2.;
-    const double nflops_addBetaC =
-        (beta != scalar_t{0}) ? (2 * n_d * (n_d + 1) / 2.) : 0.;
-    const double total_nflops =
-        nflops_AtimesB + nflops_timesAlpha + nflops_addBetaC;
-
-    state.counters["n_fl_ops"] = total_nflops;
-  }
+  blas_benchmark::utils::init_level_3_counters<
+      blas_benchmark::utils::Level3Op::syr2k, scalar_t>(state, beta, 0, n, k);
 
   // Matrix options (rocBLAS)
   const rocblas_fill uplo_rb =

--- a/benchmark/rocblas/blas3/syr2k.cpp
+++ b/benchmark/rocblas/blas3/syr2k.cpp
@@ -69,7 +69,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
         (mem_readAreadB + mem_readC + mem_writeC) * sizeof(scalar_t);
 
     state.counters["bytes_processed"] = total_mem;
-    state.SetBytesProcessed(state.iterations() * total_mem);
 
     const double nflops_AtimesB = 2 * n_d * (n_d + 1) * k_d;
     const double nflops_timesAlpha = n_d * (n_d + 1) / 2.;
@@ -79,7 +78,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
         nflops_AtimesB + nflops_timesAlpha + nflops_addBetaC;
 
     state.counters["n_fl_ops"] = total_nflops;
-    state.SetItemsProcessed(state.iterations() * total_nflops);
   }
 
   // Matrix options (rocBLAS)
@@ -105,9 +103,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
     blas_benchmark::utils::HIPVector<scalar_t> a_gpu(m_size, a.data());
     blas_benchmark::utils::HIPVector<scalar_t> b_gpu(m_size, b.data());
     blas_benchmark::utils::HIPVector<scalar_t> c_gpu(c_size, c.data());
-
-    CHECK_ROCBLAS_STATUS(
-        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
 
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference syr2k
@@ -166,6 +161,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetBytesProcessed(state.iterations() *
+                            state.counters["bytes_processed"]);
+    state.SetItemsProcessed(state.iterations() * state.counters["n_fl_ops"]);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas3/syr2k.cpp
+++ b/benchmark/rocblas/blas3/syr2k.cpp
@@ -1,0 +1,206 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename syr2k.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
+                     scalar_t beta) {
+  std::ostringstream str{};
+  str << "BM_Syr2k<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
+      << beta;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_syr2k_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_ssyr2k(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dsyr2k(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
+         char trans, index_t n, index_t k, scalar_t alpha, scalar_t beta,
+         bool* success) {
+  // Standard test setup.
+  const index_t lda = (trans == 'n') ? n : k;
+  const index_t ldc = n;
+
+  {
+    // The counters are double. We convert m, n and k to double to avoid
+    // integer overflows for n_fl_ops and bytes_processed
+    const double n_d = static_cast<double>(n);
+    const double k_d = static_cast<double>(k);
+
+    state.counters["k"] = k_d;
+    state.counters["n"] = n_d;
+
+    const double mem_readAreadB = 2 * n_d * k_d;
+    const double mem_readC = (beta != scalar_t{0}) ? n_d * (n_d + 1) / 2. : 0.;
+    const double mem_writeC = n_d * (n_d + 1) / 2.;
+    const double total_mem =
+        (mem_readAreadB + mem_readC + mem_writeC) * sizeof(scalar_t);
+
+    state.counters["bytes_processed"] = total_mem;
+    state.SetBytesProcessed(state.iterations() * total_mem);
+
+    const double nflops_AtimesB = 2 * n_d * (n_d + 1) * k_d;
+    const double nflops_timesAlpha = n_d * (n_d + 1) / 2.;
+    const double nflops_addBetaC =
+        (beta != scalar_t{0}) ? (2 * n_d * (n_d + 1) / 2.) : 0.;
+    const double total_nflops =
+        nflops_AtimesB + nflops_timesAlpha + nflops_addBetaC;
+
+    state.counters["n_fl_ops"] = total_nflops;
+    state.SetItemsProcessed(state.iterations() * total_nflops);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_fill uplo_rb =
+      (uplo == 'u') ? rocblas_fill_upper : rocblas_fill_lower;
+
+  const rocblas_operation trans_rb =
+      (trans == 'n') ? rocblas_operation_none : rocblas_operation_transpose;
+
+  // Data sizes
+  const index_t m_size = (trans == 'n') ? (lda * k) : (lda * n);
+  const index_t c_size = ldc * n;
+
+  // Matrices
+  std::vector<scalar_t> a =
+      blas_benchmark::utils::random_data<scalar_t>(m_size);
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(m_size);
+  std::vector<scalar_t> c =
+      blas_benchmark::utils::random_data<scalar_t>(c_size);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> a_gpu(m_size, a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> b_gpu(m_size, b.data());
+    blas_benchmark::utils::HIPVector<scalar_t> c_gpu(c_size, c.data());
+
+    CHECK_ROCBLAS_STATUS(
+        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference syr2k
+    std::vector<scalar_t> c_ref = c;
+    reference_blas::syr2k(&uplo, &trans, n, k, alpha, a.data(), lda, b.data(),
+                          lda, beta, c_ref.data(), ldc);
+
+    // Rocblas verification syr2k
+    std::vector<scalar_t> c_temp = c;
+    {
+      blas_benchmark::utils::HIPVector<scalar_t, true> c_temp_gpu(
+          c_size, c_temp.data());
+      rocblas_syr2k_f<scalar_t>(rb_handle, uplo_rb, trans_rb, n, k, &alpha,
+                                a_gpu, lda, b_gpu, lda, &beta, c_temp_gpu, ldc);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_syr2k_f<scalar_t>(rb_handle, uplo_rb, trans_rb, n, k, &alpha,
+                                a_gpu, lda, b_gpu, lda, &beta, c_gpu, ldc);
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_syr2k_f<scalar_t>(rb_handle, uplo_rb, trans_rb, n, k, &alpha,
+                                a_gpu, lda, b_gpu, lda, &beta, c_gpu, ldc);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto syr2k_params = blas_benchmark::utils::get_syrk_params<scalar_t>(args);
+
+  for (auto p : syr2k_params) {
+    char uplo, trans;
+    index_t n, k;
+    scalar_t alpha, beta;
+    std::tie(uplo, trans, n, k, alpha, beta) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         char uplo, char trans, index_t n, index_t k,
+                         scalar_t alpha, scalar_t beta, bool* success) {
+      run<scalar_t>(st, rb_handle, uplo, trans, n, k, alpha, beta, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplo, trans, n, k, alpha, beta).c_str(), BM_lambda,
+        rb_handle, uplo, trans, n, k, alpha, beta, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas3/syrk.cpp
+++ b/benchmark/rocblas/blas3/syrk.cpp
@@ -68,14 +68,12 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
     const double total_mem =
         (mem_readA + mem_readC + mem_writeC) * sizeof(scalar_t);
     state.counters["bytes_processed"] = total_mem;
-    state.SetBytesProcessed(state.iterations() * total_mem);
 
     const double nflops_AtimesA = n_d * (n_d + 1) * k_d;
     const double nflops_addBetaC =
         (beta != scalar_t{0}) ? (n_d * (n_d + 1)) : 0;
     const double total_nflops = nflops_AtimesA + nflops_addBetaC;
     state.counters["n_fl_ops"] = total_nflops;
-    state.SetItemsProcessed(state.iterations() * total_nflops);
   }
 
   // Matrix options (rocBLAS)
@@ -156,6 +154,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetBytesProcessed(state.iterations() *
+                            state.counters["bytes_processed"]);
+    state.SetItemsProcessed(state.iterations() * state.counters["n_fl_ops"]);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas3/syrk.cpp
+++ b/benchmark/rocblas/blas3/syrk.cpp
@@ -1,0 +1,195 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename syrk.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
+                     scalar_t beta) {
+  std::ostringstream str{};
+  str << "BM_Syrk<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
+      << beta;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_syrk_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_ssyrk(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dsyrk(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
+         char trans, index_t n, index_t k, scalar_t alpha, scalar_t beta,
+         bool* success) {
+  // Standard test setup.
+  index_t lda = (trans == 'n') ? n : k;
+  index_t ldc = n;
+
+  {
+    // The counters are double. We convert m, n and k to double to avoid
+    // integer overflows for n_fl_ops and bytes_processed
+    const double n_d = static_cast<double>(n);
+    const double k_d = static_cast<double>(k);
+
+    state.counters["k"] = k_d;
+    state.counters["n"] = n_d;
+
+    const double mem_readA = n_d * k_d;
+    const double mem_readC = (beta != scalar_t{0}) ? n_d * (n_d + 1) / 2. : 0.;
+    const double mem_writeC = n_d * (n_d + 1) / 2.;
+    const double total_mem =
+        (mem_readA + mem_readC + mem_writeC) * sizeof(scalar_t);
+    state.counters["bytes_processed"] = total_mem;
+    state.SetBytesProcessed(state.iterations() * total_mem);
+
+    const double nflops_AtimesA = n_d * (n_d + 1) * k_d;
+    const double nflops_addBetaC =
+        (beta != scalar_t{0}) ? (n_d * (n_d + 1)) : 0;
+    const double total_nflops = nflops_AtimesA + nflops_addBetaC;
+    state.counters["n_fl_ops"] = total_nflops;
+    state.SetItemsProcessed(state.iterations() * total_nflops);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_fill uplo_rb =
+      (uplo == 'u') ? rocblas_fill_upper : rocblas_fill_lower;
+
+  const rocblas_operation trans_rb =
+      (trans == 'n') ? rocblas_operation_none : rocblas_operation_transpose;
+
+  // Data sizes
+  const index_t a_size = (trans == 'n') ? (lda * k) : (lda * n);
+  const index_t c_size = ldc * n;
+
+  // Matrices
+  std::vector<scalar_t> a =
+      blas_benchmark::utils::random_data<scalar_t>(a_size);
+  std::vector<scalar_t> c =
+      blas_benchmark::utils::random_data<scalar_t>(c_size);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> a_gpu(a_size, a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> c_gpu(c_size, c.data());
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference syrk
+    std::vector<scalar_t> c_ref = c;
+    reference_blas::syrk(&uplo, &trans, n, k, alpha, a.data(), lda, beta,
+                         c_ref.data(), ldc);
+
+    // Rocblas verification syrk
+    std::vector<scalar_t> c_temp = c;
+    {
+      blas_benchmark::utils::HIPVector<scalar_t, true> c_temp_gpu(
+          c_size, c_temp.data());
+      rocblas_syrk_f<scalar_t>(rb_handle, uplo_rb, trans_rb, n, k, &alpha,
+                               a_gpu, lda, &beta, c_temp_gpu, ldc);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(c_temp, c_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+    auto blas_warmup = [&]() -> void {
+      rocblas_syrk_f<scalar_t>(rb_handle, uplo_rb, trans_rb, n, k, &alpha,
+                               a_gpu, lda, &beta, c_gpu, ldc);
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_syrk_f<scalar_t>(rb_handle, uplo_rb, trans_rb, n, k, &alpha,
+                               a_gpu, lda, &beta, c_gpu, ldc);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto syrk_params = blas_benchmark::utils::get_syrk_params<scalar_t>(args);
+
+  for (auto p : syrk_params) {
+    char uplo, trans;
+    index_t n, k;
+    scalar_t alpha, beta;
+    std::tie(uplo, trans, n, k, alpha, beta) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         char uplo, char trans, index_t n, index_t k,
+                         scalar_t alpha, scalar_t beta, bool* success) {
+      run<scalar_t>(st, rb_handle, uplo, trans, n, k, alpha, beta, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(uplo, trans, n, k, alpha, beta).c_str(), BM_lambda,
+        rb_handle, uplo, trans, n, k, alpha, beta, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas3/syrk.cpp
+++ b/benchmark/rocblas/blas3/syrk.cpp
@@ -53,28 +53,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
   index_t lda = (trans == 'n') ? n : k;
   index_t ldc = n;
 
-  {
-    // The counters are double. We convert m, n and k to double to avoid
-    // integer overflows for n_fl_ops and bytes_processed
-    const double n_d = static_cast<double>(n);
-    const double k_d = static_cast<double>(k);
-
-    state.counters["k"] = k_d;
-    state.counters["n"] = n_d;
-
-    const double mem_readA = n_d * k_d;
-    const double mem_readC = (beta != scalar_t{0}) ? n_d * (n_d + 1) / 2. : 0.;
-    const double mem_writeC = n_d * (n_d + 1) / 2.;
-    const double total_mem =
-        (mem_readA + mem_readC + mem_writeC) * sizeof(scalar_t);
-    state.counters["bytes_processed"] = total_mem;
-
-    const double nflops_AtimesA = n_d * (n_d + 1) * k_d;
-    const double nflops_addBetaC =
-        (beta != scalar_t{0}) ? (n_d * (n_d + 1)) : 0;
-    const double total_nflops = nflops_AtimesA + nflops_addBetaC;
-    state.counters["n_fl_ops"] = total_nflops;
-  }
+  blas_benchmark::utils::init_level_3_counters<
+      blas_benchmark::utils::Level3Op::syrk, scalar_t>(state, beta, 0, n, k);
 
   // Matrix options (rocBLAS)
   const rocblas_fill uplo_rb =

--- a/benchmark/rocblas/blas3/syrk.cpp
+++ b/benchmark/rocblas/blas3/syrk.cpp
@@ -81,7 +81,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
   // Matrix options (rocBLAS)
   const rocblas_fill uplo_rb =
       (uplo == 'u') ? rocblas_fill_upper : rocblas_fill_lower;
-
   const rocblas_operation trans_rb =
       (trans == 'n') ? rocblas_operation_none : rocblas_operation_transpose;
 
@@ -122,6 +121,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
       *success = false;
     };
 #endif
+
     auto blas_warmup = [&]() -> void {
       rocblas_syrk_f<scalar_t>(rb_handle, uplo_rb, trans_rb, n, k, &alpha,
                                a_gpu, lda, &beta, c_gpu, ldc);

--- a/benchmark/rocblas/blas3/trmm.cpp
+++ b/benchmark/rocblas/blas3/trmm.cpp
@@ -65,14 +65,12 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
     const double mem_readA = lda_d * (lda_d + 1) / 2;
     const double total_mem = (mem_readWriteB + mem_readA) * sizeof(scalar_t);
     state.counters["bytes_processed"] = total_mem;
-    state.SetBytesProcessed(state.iterations() * total_mem);
 
     const double nflops_AtimesB =
         (2 * lda_d * (lda_d + 1) / 2) * ((side == 'l') ? n_d : m_d);
     const double nflops_timesAlpha = m_d * n_d;
     const double total_nflops = nflops_AtimesB + nflops_timesAlpha;
     state.counters["n_fl_ops"] = total_nflops;
-    state.SetItemsProcessed(state.iterations() * total_nflops);
   }
 
   // Matrix options (rocBLAS)
@@ -165,6 +163,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetBytesProcessed(state.iterations() *
+                            state.counters["bytes_processed"]);
+    state.SetItemsProcessed(state.iterations() * state.counters["n_fl_ops"]);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas3/trmm.cpp
+++ b/benchmark/rocblas/blas3/trmm.cpp
@@ -1,0 +1,206 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trmm.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(char side, char uplo, char t, char diag, int m, int n) {
+  std::ostringstream str{};
+  str << "BM_Trmm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << side << "/" << uplo << "/" << t << "/" << diag << "/" << m << "/" << n;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_trmm_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_strmm(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dtrmm(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
+         char uplo, char trans, char diag, index_t m, index_t n, scalar_t alpha,
+         bool* success) {
+  // Standard test setup.
+  index_t lda = side == 'l' ? m : n;
+  index_t ldb = m;
+
+  {
+    // The counters are double. We convert m, n and k to double to avoid
+    // integer overflows for n_fl_ops and bytes_processed
+    const double m_d = static_cast<double>(m);
+    const double n_d = static_cast<double>(n);
+    const double lda_d = static_cast<double>(lda);
+
+    state.counters["m"] = m_d;
+    state.counters["n"] = n_d;
+
+    const double mem_readWriteB = 2 * m_d * n_d;
+    const double mem_readA = lda_d * (lda_d + 1) / 2;
+    const double total_mem = (mem_readWriteB + mem_readA) * sizeof(scalar_t);
+    state.counters["bytes_processed"] = total_mem;
+    state.SetBytesProcessed(state.iterations() * total_mem);
+
+    const double nflops_AtimesB =
+        (2 * lda_d * (lda_d + 1) / 2) * ((side == 'l') ? n_d : m_d);
+    const double nflops_timesAlpha = m_d * n_d;
+    const double total_nflops = nflops_AtimesB + nflops_timesAlpha;
+    state.counters["n_fl_ops"] = total_nflops;
+    state.SetItemsProcessed(state.iterations() * total_nflops);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_side side_rb =
+      (side == 'l') ? rocblas_side_left : rocblas_side_right;
+
+  const rocblas_fill uplo_rb =
+      (uplo == 'u') ? rocblas_fill_upper : rocblas_fill_lower;
+
+  const rocblas_operation trans_rb =
+      (trans == 'n') ? rocblas_operation_none : rocblas_operation_transpose;
+
+  const rocblas_diagonal diag_rb =
+      (diag == 'u') ? rocblas_diagonal_unit : rocblas_diagonal_non_unit;
+
+  // Data sizes
+  const index_t a_dim_2 = (side == 'l') ? m : n;
+  const index_t a_size = lda * a_dim_2;
+  const index_t b_size = ldb * n;
+
+  // Matrices
+  std::vector<scalar_t> a(a_size);
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(b_size);
+
+  // Populate the main input diagonal.
+  const scalar_t diag_value =
+      diag == 'u' ? scalar_t{1}
+                  : blas_benchmark::utils::random_scalar<scalar_t>();
+
+  blas_benchmark::utils::fill_trsm_matrix(a, a_dim_2, lda, uplo, diag_value,
+                                          scalar_t{0});
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> a_gpu(a_size, a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> b_gpu(b_size, b.data());
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference trmm
+    std::vector<scalar_t> b_ref = b;
+    reference_blas::trmm(&side, &uplo, &trans, &diag, m, n, alpha, a.data(),
+                         lda, b_ref.data(), ldb);
+
+    // Rocblas verification trmm
+    std::vector<scalar_t> b_temp = b;
+    {
+      blas_benchmark::utils::HIPVector<scalar_t, true> b_temp_gpu(
+          b_size, b_temp.data());
+      rocblas_trmm_f<scalar_t>(rb_handle, side_rb, uplo_rb, trans_rb, diag_rb,
+                               m, n, &alpha, a_gpu, lda, b_temp_gpu, ldb);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(b_temp, b_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+    auto blas_warmup = [&]() -> void {
+      rocblas_trmm_f<scalar_t>(rb_handle, side_rb, uplo_rb, trans_rb, diag_rb,
+                               m, n, &alpha, a_gpu, lda, b_gpu, ldb);
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_trmm_f<scalar_t>(rb_handle, side_rb, uplo_rb, trans_rb, diag_rb,
+                               m, n, &alpha, a_gpu, lda, b_gpu, ldb);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto trmm_params = blas_benchmark::utils::get_trsm_params<scalar_t>(args);
+
+  for (auto p : trmm_params) {
+    char side, uplo, trans, diag;
+    index_t m, n;
+    scalar_t alpha;
+    std::tie(side, uplo, trans, diag, m, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         char side, char uplo, char t, char diag, index_t m,
+                         index_t n, scalar_t alpha, bool* success) {
+      run<scalar_t>(st, rb_handle, side, uplo, t, diag, m, n, alpha, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
+        rb_handle, side, uplo, trans, diag, m, n, alpha, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas3/trmm.cpp
+++ b/benchmark/rocblas/blas3/trmm.cpp
@@ -78,13 +78,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
   // Matrix options (rocBLAS)
   const rocblas_side side_rb =
       (side == 'l') ? rocblas_side_left : rocblas_side_right;
-
   const rocblas_fill uplo_rb =
       (uplo == 'u') ? rocblas_fill_upper : rocblas_fill_lower;
-
   const rocblas_operation trans_rb =
       (trans == 'n') ? rocblas_operation_none : rocblas_operation_transpose;
-
   const rocblas_diagonal diag_rb =
       (diag == 'u') ? rocblas_diagonal_unit : rocblas_diagonal_non_unit;
 
@@ -133,6 +130,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
       *success = false;
     };
 #endif
+
     auto blas_warmup = [&]() -> void {
       rocblas_trmm_f<scalar_t>(rb_handle, side_rb, uplo_rb, trans_rb, diag_rb,
                                m, n, &alpha, a_gpu, lda, b_gpu, ldb);

--- a/benchmark/rocblas/blas3/trmm.cpp
+++ b/benchmark/rocblas/blas3/trmm.cpp
@@ -51,27 +51,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
   index_t lda = side == 'l' ? m : n;
   index_t ldb = m;
 
-  {
-    // The counters are double. We convert m, n and k to double to avoid
-    // integer overflows for n_fl_ops and bytes_processed
-    const double m_d = static_cast<double>(m);
-    const double n_d = static_cast<double>(n);
-    const double lda_d = static_cast<double>(lda);
-
-    state.counters["m"] = m_d;
-    state.counters["n"] = n_d;
-
-    const double mem_readWriteB = 2 * m_d * n_d;
-    const double mem_readA = lda_d * (lda_d + 1) / 2;
-    const double total_mem = (mem_readWriteB + mem_readA) * sizeof(scalar_t);
-    state.counters["bytes_processed"] = total_mem;
-
-    const double nflops_AtimesB =
-        (2 * lda_d * (lda_d + 1) / 2) * ((side == 'l') ? n_d : m_d);
-    const double nflops_timesAlpha = m_d * n_d;
-    const double total_nflops = nflops_AtimesB + nflops_timesAlpha;
-    state.counters["n_fl_ops"] = total_nflops;
-  }
+  blas_benchmark::utils::init_level_3_counters<
+      blas_benchmark::utils::Level3Op::trmm, scalar_t>(state, 0, m, n, 0, 1,
+                                                       side);
 
   // Matrix options (rocBLAS)
   const rocblas_side side_rb =

--- a/benchmark/rocblas/blas3/trsm.cpp
+++ b/benchmark/rocblas/blas3/trsm.cpp
@@ -81,13 +81,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
   // Matrix options (rocBLAS)
   const rocblas_side side_rb =
       (side == 'l') ? rocblas_side_left : rocblas_side_right;
-
   const rocblas_fill uplo_rb =
       (uplo == 'u') ? rocblas_fill_upper : rocblas_fill_lower;
-
   const rocblas_operation trans_rb =
       (trans == 'n') ? rocblas_operation_none : rocblas_operation_transpose;
-
   const rocblas_diagonal diag_rb =
       (diag == 'u') ? rocblas_diagonal_unit : rocblas_diagonal_non_unit;
 
@@ -139,6 +136,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
       *success = false;
     };
 #endif
+
     auto blas_warmup = [&]() -> void {
       rocblas_trsm_f<scalar_t>(rb_handle, side_rb, uplo_rb, trans_rb, diag_rb,
                                m, n, &alpha, a_gpu, lda, b_gpu, ldb);

--- a/benchmark/rocblas/blas3/trsm.cpp
+++ b/benchmark/rocblas/blas3/trsm.cpp
@@ -68,14 +68,12 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
     const double mem_readWriteB = 2 * m_d * n_d;
     const double total_mem = (mem_readA * mem_readWriteB) * sizeof(scalar_t);
     state.counters["bytes_processed"] = total_mem;
-    state.SetBytesProcessed(state.iterations() * total_mem);
 
     const double nflops_AtimesB =
         2 * k_d * (k_d + 1) / 2 * (side == 'l' ? n_d : m_d);
     const double nflops_timesAlpha = m_d * n_d;
     const double total_nflops = nflops_AtimesB + nflops_timesAlpha;
     state.counters["n_fl_ops"] = total_nflops;
-    state.SetItemsProcessed(state.iterations() * total_nflops);
   }
 
   // Matrix options (rocBLAS)
@@ -110,9 +108,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
     // Device memory allocation & H2D copy
     blas_benchmark::utils::HIPVector<scalar_t> a_gpu(a_size, a.data());
     blas_benchmark::utils::HIPVector<scalar_t> b_gpu(b_size, b.data());
-
-    CHECK_ROCBLAS_STATUS(
-        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
 
 #ifdef BLAS_VERIFY_BENCHMARK
     // Reference trsm
@@ -171,6 +166,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetBytesProcessed(state.iterations() *
+                            state.counters["bytes_processed"]);
+    state.SetItemsProcessed(state.iterations() * state.counters["n_fl_ops"]);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas3/trsm.cpp
+++ b/benchmark/rocblas/blas3/trsm.cpp
@@ -1,0 +1,213 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trsm.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(char side, char uplo, char trans, char diag, index_t m,
+                     index_t n) {
+  std::ostringstream str{};
+  str << "BM_Trsm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
+      << side << "/" << uplo << "/" << trans << "/" << diag << "/" << m << "/"
+      << n;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_trsm_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_strsm(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dtrsm(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
+         char uplo, char trans, char diag, index_t m, index_t n, scalar_t alpha,
+         bool* success) {
+  // Standard test setup.
+  index_t lda = (side == 'l') ? m : n;
+  index_t ldb = m;
+  index_t k = (side == 'l') ? m : n;
+
+  {
+    // The counters are double. We convert m, n and k to double to avoid
+    // integer overflows for n_fl_ops and bytes_processed
+    const double m_d = static_cast<double>(m);
+    const double n_d = static_cast<double>(n);
+    const double k_d = static_cast<double>(k);
+
+    state.counters["m"] = m_d;
+    state.counters["n"] = n_d;
+
+    const double mem_readA = k_d * (k_d + 1) / 2;
+    const double mem_readWriteB = 2 * m_d * n_d;
+    const double total_mem = (mem_readA * mem_readWriteB) * sizeof(scalar_t);
+    state.counters["bytes_processed"] = total_mem;
+    state.SetBytesProcessed(state.iterations() * total_mem);
+
+    const double nflops_AtimesB =
+        2 * k_d * (k_d + 1) / 2 * (side == 'l' ? n_d : m_d);
+    const double nflops_timesAlpha = m_d * n_d;
+    const double total_nflops = nflops_AtimesB + nflops_timesAlpha;
+    state.counters["n_fl_ops"] = total_nflops;
+    state.SetItemsProcessed(state.iterations() * total_nflops);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_side side_rb =
+      (side == 'l') ? rocblas_side_left : rocblas_side_right;
+
+  const rocblas_fill uplo_rb =
+      (uplo == 'u') ? rocblas_fill_upper : rocblas_fill_lower;
+
+  const rocblas_operation trans_rb =
+      (trans == 'n') ? rocblas_operation_none : rocblas_operation_transpose;
+
+  const rocblas_diagonal diag_rb =
+      (diag == 'u') ? rocblas_diagonal_unit : rocblas_diagonal_non_unit;
+
+  // Data sizes
+  const int a_size = k * lda;
+  const int b_size = ldb * n;
+
+  // Matrices
+  std::vector<scalar_t> a(a_size);
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(b_size);
+
+  // Populate the main input diagonal.
+  const scalar_t diag_value =
+      diag == 'u' ? scalar_t{1}
+                  : blas_benchmark::utils::random_scalar<scalar_t>(
+                        scalar_t{1}, scalar_t{10});
+
+  blas_benchmark::utils::fill_trsm_matrix(a, k, lda, uplo, diag_value,
+                                          scalar_t{0});
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVector<scalar_t> a_gpu(a_size, a.data());
+    blas_benchmark::utils::HIPVector<scalar_t> b_gpu(b_size, b.data());
+
+    CHECK_ROCBLAS_STATUS(
+        rocblas_set_pointer_mode(rb_handle, rocblas_pointer_mode_host));
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference trsm
+    std::vector<scalar_t> x_ref = b;
+    reference_blas::trsm(&side, &uplo, &trans, &diag, m, n, alpha, a.data(),
+                         lda, x_ref.data(), ldb);
+
+    // Rocblas verification trsm
+    std::vector<scalar_t> x_temp = b;
+    {
+      blas_benchmark::utils::HIPVector<scalar_t, true> x_temp_gpu(
+          b_size, x_temp.data());
+      rocblas_trsm_f<scalar_t>(rb_handle, side_rb, uplo_rb, trans_rb, diag_rb,
+                               m, n, &alpha, a_gpu, lda, x_temp_gpu, ldb);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(x_temp, x_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+#endif
+    auto blas_warmup = [&]() -> void {
+      rocblas_trsm_f<scalar_t>(rb_handle, side_rb, uplo_rb, trans_rb, diag_rb,
+                               m, n, &alpha, a_gpu, lda, b_gpu, ldb);
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_trsm_f<scalar_t>(rb_handle, side_rb, uplo_rb, trans_rb, diag_rb,
+                               m, n, &alpha, a_gpu, lda, b_gpu, ldb);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_warmup);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto trsm_params = blas_benchmark::utils::get_trsm_params<scalar_t>(args);
+
+  for (auto p : trsm_params) {
+    char side, uplo, trans, diag;
+    index_t m, n;
+    scalar_t alpha;
+    std::tie(side, uplo, trans, diag, m, n, alpha) = p;
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         char side, char uplo, char trans, char diag, index_t m,
+                         index_t n, scalar_t alpha, bool* success) {
+      run<scalar_t>(st, rb_handle, side, uplo, trans, diag, m, n, alpha,
+                    success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
+        rb_handle, side, uplo, trans, diag, m, n, alpha, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas3/trsm.cpp
+++ b/benchmark/rocblas/blas3/trsm.cpp
@@ -54,27 +54,9 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
   index_t ldb = m;
   index_t k = (side == 'l') ? m : n;
 
-  {
-    // The counters are double. We convert m, n and k to double to avoid
-    // integer overflows for n_fl_ops and bytes_processed
-    const double m_d = static_cast<double>(m);
-    const double n_d = static_cast<double>(n);
-    const double k_d = static_cast<double>(k);
-
-    state.counters["m"] = m_d;
-    state.counters["n"] = n_d;
-
-    const double mem_readA = k_d * (k_d + 1) / 2;
-    const double mem_readWriteB = 2 * m_d * n_d;
-    const double total_mem = (mem_readA * mem_readWriteB) * sizeof(scalar_t);
-    state.counters["bytes_processed"] = total_mem;
-
-    const double nflops_AtimesB =
-        2 * k_d * (k_d + 1) / 2 * (side == 'l' ? n_d : m_d);
-    const double nflops_timesAlpha = m_d * n_d;
-    const double total_nflops = nflops_AtimesB + nflops_timesAlpha;
-    state.counters["n_fl_ops"] = total_nflops;
-  }
+  blas_benchmark::utils::init_level_3_counters<
+      blas_benchmark::utils::Level3Op::trsm, scalar_t>(state, 0, m, n, 0, 1,
+                                                       side);
 
   // Matrix options (rocBLAS)
   const rocblas_side side_rb =

--- a/benchmark/rocblas/blas3/trsm_batched.cpp
+++ b/benchmark/rocblas/blas3/trsm_batched.cpp
@@ -60,11 +60,12 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, const char side,
   index_t k = side == 'l' ? m : n;
 
   {
-    // The counters are double. We convert m, n, k and batch_size to double to
-    // avoid integer overflows for n_fl_ops and bytes_processed
+    // The counters are double. We convert dimensions, strides & batch_size to
+    // double to avoid integer overflows for n_fl_ops and bytes_processed
     const double m_d = static_cast<double>(m);
     const double n_d = static_cast<double>(n);
     const double k_d = static_cast<double>(k);
+    const double batch_size_d = static_cast<double>(batch_size);
 
     state.counters["m"] = m_d;
     state.counters["n"] = n_d;
@@ -75,7 +76,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, const char side,
     const double mem_readA = k_d * (k_d + 1) / 2;
     const double mem_readBwriteB = 2 * m_d * n_d;
     const double total_mem =
-        ((mem_readA + mem_readBwriteB) * sizeof(scalar_t)) * batch_size;
+        ((mem_readA + mem_readBwriteB) * sizeof(scalar_t)) * batch_size_d;
     state.counters["bytes_processed"] = total_mem;
     state.SetBytesProcessed(state.iterations() * total_mem);
 
@@ -83,7 +84,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, const char side,
         2 * k_d * (k_d + 1) / 2 * (side == 'l' ? n_d : m_d);
     const double nflops_timesAlpha = m_d * n_d;
     const double total_nflops =
-        (nflops_AtimesB + nflops_timesAlpha) * batch_size;
+        (nflops_AtimesB + nflops_timesAlpha) * batch_size_d;
     state.counters["n_fl_ops"] = total_nflops;
     state.SetItemsProcessed(state.iterations() * total_nflops);
   }

--- a/benchmark/rocblas/blas3/trsm_batched.cpp
+++ b/benchmark/rocblas/blas3/trsm_batched.cpp
@@ -92,13 +92,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, const char side,
   // Matrix options (rocBLAS)
   const rocblas_side side_rb =
       (side == 'l') ? rocblas_side_left : rocblas_side_right;
-
   const rocblas_fill uplo_rb =
       (uplo == 'u') ? rocblas_fill_upper : rocblas_fill_lower;
-
   const rocblas_operation trans_rb =
       (trans == 'n') ? rocblas_operation_none : rocblas_operation_transpose;
-
   const rocblas_diagonal diag_rb =
       (diag == 'u') ? rocblas_diagonal_unit : rocblas_diagonal_non_unit;
 
@@ -151,7 +148,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, const char side,
     {
       blas_benchmark::utils::HIPVectorBatchedStrided<scalar_t, true> x_temp_gpu(
           b_size, batch_size, stride_b, x_temp.data());
-
       rocblas_trsm_batched_f<scalar_t>(
           rb_handle, side_rb, uplo_rb, trans_rb, diag_rb, m, n, &alpha,
           a_batched_gpu, lda, stride_a, x_temp_gpu, ldb, stride_b, batch_size);

--- a/benchmark/rocblas/blas3/trsm_batched.cpp
+++ b/benchmark/rocblas/blas3/trsm_batched.cpp
@@ -1,0 +1,249 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename trsm_batched.cpp
+ *
+ **************************************************************************/
+
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(const char side, const char uplo, const char t,
+                     const char diag, int m, int n, int batch_size,
+                     int batch_type) {
+  std::ostringstream str{};
+  str << "BM_TrsmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
+      << ">/" << side << "/" << uplo << "/" << t << "/" << diag << "/" << m
+      << "/" << n << "/" << batch_size << "/"
+      << blas_benchmark::utils::batch_type_to_str(batch_type);
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_trsm_batched_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_strsm_batched(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dtrsm_batched(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, const char side,
+         const char uplo, const char trans, const char diag, index_t m,
+         index_t n, scalar_t alpha, index_t batch_size, int batch_type_i,
+         bool* success) {
+  // Standard test setup.
+  index_t lda = side == 'l' ? m : n;
+  index_t ldb = m;
+  index_t k = side == 'l' ? m : n;
+
+  auto batch_type = static_cast<blas::gemm_batch_type_t>(batch_type_i);
+
+  {
+    // The counters are double. We convert m, n, k and batch_size to double to
+    // avoid integer overflows for n_fl_ops and bytes_processed
+    const double m_d = static_cast<double>(m);
+    const double n_d = static_cast<double>(n);
+    const double batch_size_d = static_cast<double>(batch_size);
+    const double k_d = static_cast<double>(k);
+
+    state.counters["m"] = m_d;
+    state.counters["n"] = n_d;
+    state.counters["batch_size"] = batch_size_d;
+
+    const double mem_readA = k_d * (k_d + 1) / 2;
+    const double mem_readBwriteB = 2 * m_d * n_d;
+    const double total_mem =
+        ((mem_readA + mem_readBwriteB) * sizeof(scalar_t)) * batch_size;
+    state.counters["bytes_processed"] = total_mem;
+    state.SetBytesProcessed(state.iterations() * total_mem);
+
+    const double nflops_AtimesB =
+        2 * k_d * (k_d + 1) / 2 * (side == 'l' ? n_d : m_d);
+    const double nflops_timesAlpha = m_d * n_d;
+    const double total_nflops =
+        (nflops_AtimesB + nflops_timesAlpha) * batch_size;
+    state.counters["n_fl_ops"] = total_nflops;
+    state.SetItemsProcessed(state.iterations() * total_nflops);
+  }
+
+  // Matrix options (rocBLAS)
+  const rocblas_side side_rb =
+      (side == 'l') ? rocblas_side_left : rocblas_side_right;
+
+  const rocblas_fill uplo_rb =
+      (uplo == 'u') ? rocblas_fill_upper : rocblas_fill_lower;
+
+  const rocblas_operation trans_rb =
+      (trans == 'n') ? rocblas_operation_none : rocblas_operation_transpose;
+
+  const rocblas_diagonal diag_rb =
+      (diag == 'u') ? rocblas_diagonal_unit : rocblas_diagonal_non_unit;
+
+  // Data sizes
+  const int a_size = lda * k;
+  const int b_size = ldb * n;
+
+  // Matrices
+  std::vector<scalar_t> a(a_size * batch_size);
+  {
+    // Populate the main input diagonal for each batch.
+    std::vector<scalar_t> a_batch(a_size);
+    for (int i = 0; i < batch_size; ++i) {
+      const scalar_t diagValue =
+          diag == 'u' ? scalar_t{1}
+                      : blas_benchmark::utils::random_scalar<scalar_t>(
+                            scalar_t{1}, scalar_t{10});
+      blas_benchmark::utils::fill_trsm_matrix(a_batch, k, lda, uplo, diagValue,
+                                              scalar_t{0});
+
+      std::copy(a_batch.begin(), a_batch.end(), a.begin() + i * a_size);
+    }
+  }
+  std::vector<scalar_t> b =
+      blas_benchmark::utils::random_data<scalar_t>(b_size * batch_size);
+
+  {
+    // Device memory allocation & H2D copy
+    blas_benchmark::utils::HIPVectorBatched<scalar_t> a_batched_gpu(
+        a_size, batch_size, a.data());
+    blas_benchmark::utils::HIPVectorBatched<scalar_t> b_batched_gpu(
+        b_size, batch_size, b.data());
+
+#ifdef BLAS_VERIFY_BENCHMARK
+    // Reference batched trsm
+    std::vector<scalar_t> x_ref = b;
+    for (int batch = 0; batch < batch_size; batch++) {
+      reference_blas::trsm(&side, &uplo, &trans, &diag, m, n, alpha,
+                           a.data() + batch * a_size, lda,
+                           x_ref.data() + batch * b_size, ldb);
+    }
+
+    // Rocblas verification trsm_batched
+    std::vector<scalar_t> x_temp = b;
+    {
+      blas_benchmark::utils::HIPVectorBatched<scalar_t, true> x_temp_gpu(
+          b_size, batch_size, x_temp.data());
+
+      rocblas_trsm_batched_f<scalar_t>(rb_handle, side_rb, uplo_rb, trans_rb,
+                                       diag_rb, m, n, &alpha, a_batched_gpu,
+                                       lda, x_temp_gpu, ldb, batch_size);
+    }
+
+    std::ostringstream err_stream;
+    if (!utils::compare_vectors(x_temp, x_ref, err_stream, "")) {
+      const std::string& err_str = err_stream.str();
+      state.SkipWithError(err_str.c_str());
+      *success = false;
+    };
+
+#endif
+
+    auto blas_warmup = [&]() -> void {
+      rocblas_trsm_batched_f<scalar_t>(rb_handle, side_rb, uplo_rb, trans_rb,
+                                       diag_rb, m, n, &alpha, a_batched_gpu,
+                                       lda, b_batched_gpu, ldb, batch_size);
+      return;
+    };
+
+    hipEvent_t start, stop;
+    CHECK_HIP_ERROR(hipEventCreate(&start));
+    CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+    auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+      CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+      rocblas_trsm_batched_f<scalar_t>(rb_handle, side_rb, uplo_rb, trans_rb,
+                                       diag_rb, m, n, &alpha, a_batched_gpu,
+                                       lda, b_batched_gpu, ldb, batch_size);
+      CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+      CHECK_HIP_ERROR(hipEventSynchronize(stop));
+      return std::vector{start, stop};
+    };
+
+    // Warmup
+    blas_benchmark::utils::warmup(blas_method_def);
+    CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+
+    blas_benchmark::utils::init_counters(state);
+
+    // Measure
+    for (auto _ : state) {
+      // Run
+      std::tuple<double, double> times =
+          blas_benchmark::utils::timef_hip(blas_method_def);
+
+      // Report
+      blas_benchmark::utils::update_counters(state, times);
+    }
+
+    blas_benchmark::utils::calc_avg_counters(state);
+
+    CHECK_HIP_ERROR(hipEventDestroy(start));
+    CHECK_HIP_ERROR(hipEventDestroy(stop));
+  }  // release device memory via utils::DeviceVector destructors
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto trsm_batched_params =
+      blas_benchmark::utils::get_trsm_batched_params<scalar_t>(args);
+
+  for (auto p : trsm_batched_params) {
+    char s_side, s_uplo, s_t, s_diag;
+    index_t m, n, batch_size;
+    scalar_t alpha;
+    int batch_type;
+    std::tie(s_side, s_uplo, s_t, s_diag, m, n, alpha, batch_size, batch_type) =
+        p;
+
+    auto batch_type_enum = static_cast<blas::gemm_batch_type_t>(batch_type);
+    if (batch_type_enum == blas::gemm_batch_type_t::interleaved) {
+      std::cerr << "interleaved memory for trsm_batched operator is not "
+                   "supported by rocBLAS\n";
+      continue;
+    }
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         char side, char uplo, char t, char diag, index_t m,
+                         index_t n, scalar_t alpha, index_t batch_size,
+                         int batch_type, bool* success) {
+      run<scalar_t>(st, rb_handle, side, uplo, t, diag, m, n, alpha, batch_size,
+                    batch_type, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(s_side, s_uplo, s_t, s_diag, m, n, batch_size,
+                           batch_type)
+            .c_str(),
+        BM_lambda, rb_handle, s_side, s_uplo, s_t, s_diag, m, n, alpha,
+        batch_size, batch_type, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/blas3/trsm_batched.cpp
+++ b/benchmark/rocblas/blas3/trsm_batched.cpp
@@ -78,7 +78,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, const char side,
     const double total_mem =
         ((mem_readA + mem_readBwriteB) * sizeof(scalar_t)) * batch_size_d;
     state.counters["bytes_processed"] = total_mem;
-    state.SetBytesProcessed(state.iterations() * total_mem);
 
     const double nflops_AtimesB =
         2 * k_d * (k_d + 1) / 2 * (side == 'l' ? n_d : m_d);
@@ -86,7 +85,6 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, const char side,
     const double total_nflops =
         (nflops_AtimesB + nflops_timesAlpha) * batch_size_d;
     state.counters["n_fl_ops"] = total_nflops;
-    state.SetItemsProcessed(state.iterations() * total_nflops);
   }
 
   // Matrix options (rocBLAS)
@@ -201,6 +199,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, const char side,
       // Report
       blas_benchmark::utils::update_counters(state, times);
     }
+
+    state.SetBytesProcessed(state.iterations() *
+                            state.counters["bytes_processed"]);
+    state.SetItemsProcessed(state.iterations() * state.counters["n_fl_ops"]);
 
     blas_benchmark::utils::calc_avg_counters(state);
 

--- a/benchmark/rocblas/blas3/trsm_batched.cpp
+++ b/benchmark/rocblas/blas3/trsm_batched.cpp
@@ -188,7 +188,7 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, const char side,
     };
 
     // Warmup
-    blas_benchmark::utils::warmup(blas_method_def);
+    blas_benchmark::utils::warmup(blas_warmup);
     CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
 
     blas_benchmark::utils::init_counters(state);

--- a/benchmark/rocblas/utils.hpp
+++ b/benchmark/rocblas/utils.hpp
@@ -311,6 +311,7 @@ class HIPVectorBatchedStrided : private HIPDeviceMemory<T> {
       }
     }
   }
+
   // Destructor copies data back to host if specified & valid
   // & free-up device memory
   ~HIPVectorBatchedStrided() {

--- a/benchmark/rocblas/utils.hpp
+++ b/benchmark/rocblas/utils.hpp
@@ -254,8 +254,8 @@ class HIPVectorBatched : private HIPDeviceMemory<T*> {
   }
 
   // Decay into device array pointer wherever pointer is expected
-  operator T**() { return d_batch_data_; }
-  operator const T**() const { return d_batch_data_; }
+  operator T* *() { return d_batch_data_; }
+  operator const T* *() const { return d_batch_data_; }
 
   // Disallow copying or assigning
   HIPVectorBatched(const HIPVectorBatched&) = delete;

--- a/benchmark/syclblas/blas3/gemm_batched.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched.cpp
@@ -71,8 +71,8 @@ std::string get_name(std::string t1, std::string t2, int m, int k, int n,
 }
 
 template <typename scalar_t>
-void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1, int t2,
-         index_t m, index_t k, index_t n, scalar_t alpha, scalar_t beta,
+void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
+         int t2, index_t m, index_t k, index_t n, scalar_t alpha, scalar_t beta,
          index_t batch_size, int batch_type_i, bool* success) {
   // Standard test setup.
   std::string t1s = blas_benchmark::utils::from_transpose_enum(
@@ -183,8 +183,8 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1, int t2
 };
 
 template <typename scalar_t>
-void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_ptr,
-                        bool* success) {
+void register_benchmark(blas_benchmark::Args& args,
+                        blas::SB_Handle* sb_handle_ptr, bool* success) {
   auto gemm_params =
       blas_benchmark::utils::get_gemm_batched_params<scalar_t>(args);
 
@@ -197,8 +197,8 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
     int t1 = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t1s));
     int t2 = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t2s));
 
-    auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr, int t1,
-                         int t2, index_t m, index_t k, index_t n,
+    auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
+                         int t1, int t2, index_t m, index_t k, index_t n,
                          scalar_t alpha, scalar_t beta, index_t batch_size,
                          int batch_type, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
@@ -213,8 +213,8 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
 }
 
 namespace blas_benchmark {
-void create_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_ptr,
-                      bool* success) {
+void create_benchmark(blas_benchmark::Args& args,
+                      blas::SB_Handle* sb_handle_ptr, bool* success) {
   BLAS_REGISTER_BENCHMARK(args, sb_handle_ptr, success);
 }
 }  // namespace blas_benchmark

--- a/benchmark/syclblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched_strided.cpp
@@ -59,7 +59,8 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
 
   blas_benchmark::utils::init_level_3_counters<
       blas_benchmark::utils::Level3Op::gemm_batched_strided, scalar_t>(
-      state, beta, m, n, k, batch_size);
+      state, beta, m, n, k, batch_size, stride_a_mul, stride_b_mul,
+      stride_c_mul);
 
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
   auto q = sb_handle.get_queue();

--- a/benchmark/syclblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched_strided.cpp
@@ -27,19 +27,21 @@
 
 template <typename scalar_t>
 std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size) {
+                     int batch_size, int stride_a_mul, int stride_b_mul,
+                     int stride_c_mul) {
   std::ostringstream str{};
   str << "BM_GemmBatchedStrided<"
       << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
-      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size;
+      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
+      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul;
   return str.str();
 }
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
-         int t2, index_t m, index_t k, index_t n, index_t stride_a,
-         index_t stride_b, index_t stride_c, scalar_t alpha, scalar_t beta,
-         index_t batch_size, bool* success) {
+         int t2, index_t m, index_t k, index_t n, scalar_t alpha, scalar_t beta,
+         index_t batch_size, index_t stride_a_mul, index_t stride_b_mul,
+         index_t stride_c_mul, bool* success) {
   // Standard test setup.
   std::string t1s = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(t1));
@@ -62,47 +64,49 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
   auto q = sb_handle.get_queue();
 
-  // Matrices sizes
+  // Data sizes
+  // Elementary matrices
   const index_t a_size = m * k;
   const index_t b_size = k * n;
   const index_t c_size = m * n;
+  // Strides
+  const index_t stride_a = stride_a_mul * a_size;
+  const index_t stride_b = stride_b_mul * b_size;
+  const index_t stride_c = stride_c_mul * c_size;
+  // Batched matrices
+  const int size_a_batch = a_size + (batch_size - 1) * stride_a;
+  const int size_b_batch = b_size + (batch_size - 1) * stride_b;
+  const int size_c_batch = c_size + (batch_size - 1) * stride_c;
 
-  // Matrices (Total size is equal to matrix size x batch_size since we're using
-  // default striding values)
+  // Matrices
   std::vector<scalar_t> a =
-      blas_benchmark::utils::random_data<scalar_t>(a_size * batch_size);
+      blas_benchmark::utils::random_data<scalar_t>(size_a_batch);
   std::vector<scalar_t> b =
-      blas_benchmark::utils::random_data<scalar_t>(b_size * batch_size);
+      blas_benchmark::utils::random_data<scalar_t>(size_b_batch);
   std::vector<scalar_t> c =
-      blas_benchmark::utils::const_data<scalar_t>(c_size * batch_size, 0);
+      blas_benchmark::utils::const_data<scalar_t>(size_c_batch, 0);
 
 #ifdef BLAS_VERIFY_BENCHMARK
   // Run a first time with a verification of the results
   std::vector<scalar_t> c_ref = c;
-  auto _base = [=](index_t dim0, index_t dim1, index_t idx) {
-    return dim0 * dim1 * idx;
-  };
   for (int batch_idx = 0; batch_idx < batch_size; batch_idx++) {
     reference_blas::gemm(t_a, t_b, m, n, k, alpha,
-                         a.data() + _base(m, k, batch_idx), lda,
-                         b.data() + _base(k, n, batch_idx), ldb, beta,
-                         c_ref.data() + _base(m, n, batch_idx), ldc);
+                         a.data() + batch_idx * stride_a, lda,
+                         b.data() + batch_idx * stride_b, ldb, beta,
+                         c_ref.data() + batch_idx * stride_c, ldc);
   }
 
 #endif
 
-  auto a_gpu =
-      blas::make_sycl_iterator_buffer<scalar_t>(a, a_size * batch_size);
-  auto b_gpu =
-      blas::make_sycl_iterator_buffer<scalar_t>(b, b_size * batch_size);
-  auto c_gpu =
-      blas::make_sycl_iterator_buffer<scalar_t>(c, c_size * batch_size);
+  auto a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(a, size_a_batch);
+  auto b_gpu = blas::make_sycl_iterator_buffer<scalar_t>(b, size_b_batch);
+  auto c_gpu = blas::make_sycl_iterator_buffer<scalar_t>(c, size_c_batch);
 
 #ifdef BLAS_VERIFY_BENCHMARK
   std::vector<scalar_t> c_temp = c;
   {
     auto c_temp_gpu =
-        blas::make_sycl_iterator_buffer<scalar_t>(c_temp, c_size * batch_size);
+        blas::make_sycl_iterator_buffer<scalar_t>(c_temp, size_c_batch);
     auto event = _gemm_strided_batched(
         sb_handle, *t_a, *t_b, m, n, k, alpha, a_gpu, lda, stride_a, b_gpu, ldb,
         stride_b, beta, c_temp_gpu, ldc, stride_c, batch_size);
@@ -153,32 +157,31 @@ template <typename scalar_t>
 void register_benchmark(blas_benchmark::Args& args,
                         blas::SB_Handle* sb_handle_ptr, bool* success) {
   auto gemm_batched_strided_params =
-      blas_benchmark::utils::get_gemm_batched_params<scalar_t>(args);
+      blas_benchmark::utils::get_gemm_batched_strided_params<scalar_t>(args);
 
   for (auto p : gemm_batched_strided_params) {
     std::string t1s, t2s;
-    index_t m, n, k, batch_size;
+    index_t m, n, k, batch_size, stride_a_mul, stride_b_mul, stride_c_mul;
     scalar_t alpha, beta;
-    int batch_type;
-    std::tie(t1s, t2s, m, k, n, alpha, beta, batch_size, batch_type) = p;
+    std::tie(t1s, t2s, m, k, n, alpha, beta, batch_size, stride_a_mul,
+             stride_b_mul, stride_c_mul) = p;
     int t1 = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t1s));
     int t2 = static_cast<int>(blas_benchmark::utils::to_transpose_enum(t2s));
 
-    index_t stride_a = m * k;
-    index_t stride_b = k * n;
-    index_t stride_c = m * n;
-
     auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
                          int t1, int t2, index_t m, index_t k, index_t n,
-                         index_t stride_a, index_t stride_b, index_t stride_c,
                          scalar_t alpha, scalar_t beta, index_t batch_size,
-                         bool* success) {
-      run<scalar_t>(st, sb_handle_ptr, t1, t2, m, k, n, stride_a, stride_b,
-                    stride_c, alpha, beta, batch_size, success);
+                         index_t strd_a_mul, index_t strd_b_mul,
+                         index_t strd_c_mul, bool* success) {
+      run<scalar_t>(st, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
+                    strd_a_mul, strd_b_mul, strd_c_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size).c_str(), BM_lambda,
-        sb_handle_ptr, t1, t2, m, k, n, stride_a, stride_b, stride_c, alpha, beta, batch_size, success)
+        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, stride_a_mul,
+                           stride_b_mul, stride_c_mul)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
+        stride_a_mul, stride_b_mul, stride_c_mul, success)
         ->UseRealTime();
   }
 }

--- a/common/include/common/blas3_state_counters.hpp
+++ b/common/include/common/blas3_state_counters.hpp
@@ -47,7 +47,8 @@ inline typename std::enable_if<op == Level3Op::gemm_batched_strided ||
                                op == Level3Op::gemm>::type
 init_level_3_counters(benchmark::State& state, scalar_t beta = 0, index_t m = 0,
                       index_t n = 0, index_t k = 0, index_t batch_size = 1,
-                      char side = 'l') {
+                      index_t stride_a_mul = 1, index_t stride_b_mul = 1,
+                      index_t stride_c_mul = 1) {
   // Google-benchmark counters are double.
   double beta_d = static_cast<double>(beta);
   double m_d = static_cast<double>(m);
@@ -59,6 +60,15 @@ init_level_3_counters(benchmark::State& state, scalar_t beta = 0, index_t m = 0,
   state.counters["n"] = n_d;
   state.counters["k"] = k_d;
   state.counters["batch_size"] = batch_size_d;
+  if constexpr (op == Level3Op::gemm_batched_strided) {
+    double stride_a_mul_d = static_cast<double>(stride_a_mul);
+    double stride_b_mul_d = static_cast<double>(stride_b_mul);
+    double stride_c_mul_d = static_cast<double>(stride_c_mul);
+
+    state.counters["stride_a_mul"] = stride_a_mul_d;
+    state.counters["stride_b_mul"] = stride_b_mul_d;
+    state.counters["stride_c_mul"] = stride_c_mul_d;
+  }
   const double nflops_AtimesB = 2 * k_d * m_d * n_d;
   double nflops_timesAlpha = m_d * n_d;
   const double nflops_addBetaC = (beta != scalar_t{0}) ? 2 * m_d * n_d : 0;

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -595,8 +595,9 @@ static inline std::vector<syrk_param_t<scalar_t>> get_syrk_params(Args& args) {
 }
 /**
  * @fn get_trsm_params
- * @brief Returns a vector containing the trsm benchmark parameters, either
- * read from a file according to the command-line args, or the default ones.
+ * @brief Returns a vector containing the trsm benchmark parameters (also valid
+ * for trmm), either read from a file according to the command-line args, or the
+ * default ones.
  */
 template <typename scalar_t>
 static inline std::vector<trsm_param_t<scalar_t>> get_trsm_params(Args& args) {

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -521,12 +521,9 @@ get_trsm_batched_params(Args& args) {
                      stride_a_mul <= stride_a_mul_max; stride_a_mul += 1) {
                   for (index_t stride_b_mul = stride_b_mul_min;
                        stride_b_mul <= stride_b_mul_min; stride_b_mul += 1) {
-                    // Computed strides from stride mutipliers & matrices sizes
-                    auto stride_a = stride_a_mul * a_size;
-                    auto stride_b = stride_b_mul * b_size;
-                    trsm_batched_default.push_back(
-                        std::make_tuple(side, uplo, trans, diag, m, n, alpha,
-                                        batch_size, stride_a, stride_b));
+                    trsm_batched_default.push_back(std::make_tuple(
+                        side, uplo, trans, diag, m, n, alpha, batch_size,
+                        stride_a_mul, stride_b_mul));
                   }
                 }
               }

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -456,9 +456,9 @@ get_gemm_batched_strided_params(Args& args) {
               for (index_t stride_a_mul = stride_a_mul_min;
                    stride_a_mul <= stride_a_mul_max; stride_a_mul += 1) {
                 for (index_t stride_b_mul = stride_b_mul_min;
-                     stride_b_mul <= stride_b_mul_min; stride_b_mul += 1) {
+                     stride_b_mul <= stride_b_mul_max; stride_b_mul += 1) {
                   for (index_t stride_c_mul = stride_c_mul_min;
-                       stride_c_mul <= stride_c_mul_min; stride_c_mul += 1) {
+                       stride_c_mul <= stride_c_mul_max; stride_c_mul += 1) {
                     gemm_batched_strided_default.push_back(std::make_tuple(
                         t1, t2, m, k, n, alpha, beta, batch_size, stride_a_mul,
                         stride_b_mul, stride_c_mul));

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -505,8 +505,9 @@ get_trsm_batched_params(Args& args) {
     warning_no_csv();
     std::vector<trsm_batched_param_t<scalar_t>> trsm_batched_default;
     constexpr index_t dmin = 64, dmax = 1024;
-    constexpr index_t stride_a_mul_min = 0, stride_a_mul_max = 2;
-    constexpr index_t stride_b_mul_min = 1, stride_b_mul_max = 2;
+    // Stride Multipliers are set by default and correspond to default striding
+    constexpr index_t stride_a_mul = 1;
+    constexpr index_t stride_b_mul = 1;
     constexpr index_t batch_size = 8;
     constexpr scalar_t alpha = 1;
     for (char side : {'l', 'r'}) {
@@ -515,17 +516,9 @@ get_trsm_batched_params(Args& args) {
           for (char diag : {'u', 'n'}) {
             for (index_t m = dmin; m <= dmax; m *= 2) {
               for (index_t n = dmin; n <= dmax; n *= 2) {
-                auto a_size = (side == 'l') ? m * m : n * n;
-                auto b_size = m * n;
-                for (index_t stride_a_mul = stride_a_mul_min;
-                     stride_a_mul <= stride_a_mul_max; stride_a_mul += 1) {
-                  for (index_t stride_b_mul = stride_b_mul_min;
-                       stride_b_mul <= stride_b_mul_min; stride_b_mul += 1) {
-                    trsm_batched_default.push_back(std::make_tuple(
-                        side, uplo, trans, diag, m, n, alpha, batch_size,
-                        stride_a_mul, stride_b_mul));
-                  }
-                }
+                trsm_batched_default.push_back(
+                    std::make_tuple(side, uplo, trans, diag, m, n, alpha,
+                                    batch_size, stride_a_mul, stride_b_mul));
               }
             }
           }


### PR DESCRIPTION
This PR extends rocBLAS benchmarks to level 3 operators & batched extensions including : 

- gemm
- symm
- syrk
- syr2k
- trmm
- trsm
- trsm_batched
- gemm_batched
- gemm_batched_strided

