### PR TITLE
Fix t?sv bug for index_t as long

### DIFF
--- a/include/interface/blas2_interface.h
+++ b/include/interface/blas2_interface.h
@@ -133,7 +133,7 @@ typename sb_handle_t::event_t _trsv(sb_handle_t& sb_handle, char _Uplo,
                                     container_0_t _mA, index_t _lda,
                                     container_1_t _vx, increment_t _incx);
 
-template <uint32_t x_range, uint32_t subgroups, uplo_type uplo,
+template <uint32_t subgroup_size, uint32_t subgroups, uplo_type uplo,
           transpose_type trn, diag_type diag, typename sb_handle_t,
           typename index_t, typename container_t0, typename container_t1,
           typename increment_t>
@@ -443,7 +443,7 @@ typename sb_handle_t::event_t _tbsv(sb_handle_t& sb_handle, char _Uplo,
                                     index_t _K, container_0_t _mA, index_t _lda,
                                     container_1_t _vx, increment_t _incx);
 
-template <uint32_t x_range, uint32_t subgroups, uplo_type uplo,
+template <uint32_t subgroup_size, uint32_t subgroups, uplo_type uplo,
           transpose_type trn, diag_type diag, typename sb_handle_t,
           typename index_t, typename container_t0, typename container_t1,
           typename increment_t>

--- a/include/operations/blas2_trees.h
+++ b/include/operations/blas2_trees.h
@@ -353,7 +353,7 @@ make_tbmv(lhs_t &lhs_, matrix_t &matrix_, typename vector_t::index_t k_,
  * multiplication.
  */
 template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
-          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          uint32_t subgroup_size, uint32_t subgroups, bool is_upper,
           bool is_transposed, bool is_unit>
 struct Trsv {
   using value_t = typename vector_t::value_t;
@@ -375,14 +375,14 @@ struct Trsv {
 /*!
  @brief Generator/factory for TRSV trees.
  */
-template <uint32_t x_range, uint32_t subgroups, bool is_upper,
+template <uint32_t subgroup_size, uint32_t subgroups, bool is_upper,
           bool is_transposed, bool is_unit, typename lhs_t, typename matrix_t,
           typename vector_t, typename sync_t>
-Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+Trsv<lhs_t, matrix_t, vector_t, sync_t, subgroup_size, subgroups, is_upper,
      is_transposed, is_unit>
 make_trsv(lhs_t &lhs_, matrix_t &matrix_, vector_t &vector_, sync_t &sync_) {
-  return Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
-              is_transposed, is_unit>(lhs_, matrix_, vector_, sync_);
+  return Trsv<lhs_t, matrix_t, vector_t, sync_t, subgroup_size, subgroups,
+              is_upper, is_transposed, is_unit>(lhs_, matrix_, vector_, sync_);
 }
 
 /**
@@ -391,7 +391,7 @@ make_trsv(lhs_t &lhs_, matrix_t &matrix_, vector_t &vector_, sync_t &sync_) {
  * multiplication.
  */
 template <typename vector_t, typename matrix_t, typename sync_t,
-          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          uint32_t subgroup_size, uint32_t subgroups, bool is_upper,
           bool is_transposed, bool is_unit>
 struct Tbsv {
   using value_t = typename vector_t::value_t;
@@ -413,14 +413,14 @@ struct Tbsv {
 /*!
  @brief Generator/factory for TBSV trees.
  */
-template <uint32_t x_range, uint32_t subgroups, bool is_upper,
+template <uint32_t subgroup_size, uint32_t subgroups, bool is_upper,
           bool is_transposed, bool is_unit, typename vector_t,
           typename matrix_t, typename sync_t>
-Tbsv<vector_t, matrix_t, sync_t, x_range, subgroups, is_upper, is_transposed,
-     is_unit>
+Tbsv<vector_t, matrix_t, sync_t, subgroup_size, subgroups, is_upper,
+     is_transposed, is_unit>
 make_tbsv(vector_t &lhs_, matrix_t &matrix_, typename vector_t::index_t k_,
           sync_t &sync_) {
-  return Tbsv<vector_t, matrix_t, sync_t, x_range, subgroups, is_upper,
+  return Tbsv<vector_t, matrix_t, sync_t, subgroup_size, subgroups, is_upper,
               is_transposed, is_unit>(lhs_, matrix_, k_, sync_);
 }
 

--- a/src/interface/blas2_interface.hpp
+++ b/src/interface/blas2_interface.hpp
@@ -318,7 +318,7 @@ typename sb_handle_t::event_t _trmv_impl(
 /*! _TRSV.
  * @brief Implementation of the Triangular Matrix Vector product.
  */
-template <uint32_t x_range, uint32_t subgroups, uplo_type uplo,
+template <uint32_t subgroup_size, uint32_t subgroups, uplo_type uplo,
           transpose_type trn, diag_type diag, typename sb_handle_t,
           typename index_t, typename container_t0, typename container_t1,
           typename increment_t>
@@ -341,21 +341,23 @@ typename sb_handle_t::event_t _trsv_impl(sb_handle_t& sb_handle, index_t _N,
 
   std::vector<index_t> sync_vec(2);
   sync_vec[0] =
-      is_forward ? 0 : ((roundUp<index_t>(_N, x_range) / x_range) - 1);
+      is_forward ? 0
+                 : ((roundUp<index_t>(_N, subgroup_size) / subgroup_size) - 1);
   sync_vec[1] = sync_vec[0];
 
   auto sync_buffer =
       blas::make_sycl_iterator_buffer<index_t>(sync_vec, sync_vec.size());
   auto sync = make_vector_view(sync_buffer, 1, sync_vec.size());
 
-  auto trsv = make_trsv<x_range, subgroups, is_upper, is_transposed, is_unit>(
-      vx, mA, vx, sync);
+  auto trsv =
+      make_trsv<subgroup_size, subgroups, is_upper, is_transposed, is_unit>(
+          vx, mA, vx, sync);
 
   const index_t sub_num = subgroups;
   return sb_handle.execute(
-      trsv, static_cast<index_t>(sub_num * x_range),
-      roundUp<index_t>(sub_num * _N, sub_num * x_range),
-      static_cast<index_t>(x_range * (x_range + 1 + sub_num)));
+      trsv, static_cast<index_t>(sub_num * subgroup_size),
+      roundUp<index_t>(sub_num * _N, sub_num * subgroup_size),
+      static_cast<index_t>(subgroup_size * (subgroup_size + 1 + sub_num)));
 }
 
 /*! _SYMV.
@@ -560,7 +562,7 @@ typename sb_handle_t::event_t _tbmv_impl(sb_handle_t& sb_handle, index_t _N,
                              sb_handle.execute(assignOp, local_range));
 }
 
-template <uint32_t x_range, uint32_t subgroups, uplo_type uplo,
+template <uint32_t subgroup_size, uint32_t subgroups, uplo_type uplo,
           transpose_type trn, diag_type diag, typename sb_handle_t,
           typename index_t, typename container_t0, typename container_t1,
           typename increment_t>
@@ -586,21 +588,23 @@ typename sb_handle_t::event_t _tbsv_impl(sb_handle_t& sb_handle, index_t _N,
 
   std::vector<index_t> sync_vec(2);
   sync_vec[0] =
-      is_forward ? 0 : ((roundUp<index_t>(_N, x_range) / x_range) - 1);
+      is_forward ? 0
+                 : ((roundUp<index_t>(_N, subgroup_size) / subgroup_size) - 1);
   sync_vec[1] = sync_vec[0];
 
   auto sync_buffer =
       blas::make_sycl_iterator_buffer<index_t>(sync_vec, sync_vec.size());
   auto sync = make_vector_view(sync_buffer, 1, sync_vec.size());
 
-  auto tbsv = make_tbsv<x_range, subgroups, is_upper, is_transposed, is_unit>(
-      vx, mA, _K, sync);
+  auto tbsv =
+      make_tbsv<subgroup_size, subgroups, is_upper, is_transposed, is_unit>(
+          vx, mA, _K, sync);
 
   const index_t sub_num = subgroups;
   return sb_handle.execute(
-      tbsv, static_cast<index_t>(sub_num * x_range),
-      roundUp<index_t>(sub_num * _N, sub_num * x_range),
-      static_cast<index_t>(x_range * (x_range + 1 + sub_num)));
+      tbsv, static_cast<index_t>(sub_num * subgroup_size),
+      roundUp<index_t>(sub_num * _N, sub_num * subgroup_size),
+      static_cast<index_t>(subgroup_size * (subgroup_size + 1 + sub_num)));
 }
 
 /**** RANK 1 MODIFICATION ****/

--- a/src/interface/blas2_interface.hpp
+++ b/src/interface/blas2_interface.hpp
@@ -329,6 +329,7 @@ typename sb_handle_t::event_t _trsv_impl(sb_handle_t& sb_handle, index_t _N,
   throw std::runtime_error("Unimplemented for ComputeCPP");
 #endif
 
+  using one = constant<increment_t, const_val::one>;
   constexpr bool is_upper = (uplo == uplo_type::Upper);
   constexpr bool is_transposed = (trn != transpose_type::Normal);
   constexpr bool is_unit = (diag == diag_type::Unit);
@@ -339,15 +340,15 @@ typename sb_handle_t::event_t _trsv_impl(sb_handle_t& sb_handle, index_t _N,
   auto mA = make_matrix_view<col_major>(_mA, _N, _N, _lda);
   auto vx = make_vector_view(_vx, _incx, _N);
 
-  std::vector<index_t> sync_vec(2);
+  std::vector<int32_t> sync_vec(2);
   sync_vec[0] =
       is_forward ? 0
                  : ((roundUp<index_t>(_N, subgroup_size) / subgroup_size) - 1);
   sync_vec[1] = sync_vec[0];
 
   auto sync_buffer =
-      blas::make_sycl_iterator_buffer<index_t>(sync_vec, sync_vec.size());
-  auto sync = make_vector_view(sync_buffer, 1, sync_vec.size());
+      blas::make_sycl_iterator_buffer<int32_t>(sync_vec, sync_vec.size());
+  auto sync = make_vector_view(sync_buffer, one::value(), sync_vec.size());
 
   auto trsv =
       make_trsv<subgroup_size, subgroups, is_upper, is_transposed, is_unit>(
@@ -576,6 +577,7 @@ typename sb_handle_t::event_t _tbsv_impl(sb_handle_t& sb_handle, index_t _N,
 
   if (_K >= _N) throw std::invalid_argument("Erroneous parameter: _K >= _N");
 
+  using one = constant<increment_t, const_val::one>;
   constexpr bool is_upper = (uplo == uplo_type::Upper);
   constexpr bool is_transposed = (trn != transpose_type::Normal);
   constexpr bool is_unit = (diag == diag_type::Unit);
@@ -586,15 +588,15 @@ typename sb_handle_t::event_t _tbsv_impl(sb_handle_t& sb_handle, index_t _N,
   auto mA = make_matrix_view<col_major>(_mA, _K + 1, _N, _lda);
   auto vx = make_vector_view(_vx, _incx, _N);
 
-  std::vector<index_t> sync_vec(2);
+  std::vector<int32_t> sync_vec(2);
   sync_vec[0] =
       is_forward ? 0
                  : ((roundUp<index_t>(_N, subgroup_size) / subgroup_size) - 1);
   sync_vec[1] = sync_vec[0];
 
   auto sync_buffer =
-      blas::make_sycl_iterator_buffer<index_t>(sync_vec, sync_vec.size());
-  auto sync = make_vector_view(sync_buffer, 1, sync_vec.size());
+      blas::make_sycl_iterator_buffer<int32_t>(sync_vec, sync_vec.size());
+  auto sync = make_vector_view(sync_buffer, one::value(), sync_vec.size());
 
   auto tbsv =
       make_tbsv<subgroup_size, subgroups, is_upper, is_transposed, is_unit>(

--- a/src/operations/blas2/tbsv.hpp
+++ b/src/operations/blas2/tbsv.hpp
@@ -112,7 +112,7 @@ SYCL_BLAS_INLINE
   value_t *const par_x = loc_x + x_range + x_range * _idy;
   value_t *const loc_recip = loc_x + x_range;
 
-  auto a = sycl::atomic_ref<index_t, sycl::memory_order::relaxed,
+  auto a = sycl::atomic_ref<int32_t, sycl::memory_order::relaxed,
                             sycl::memory_scope::device,
                             sycl::access::address_space::global_space>(
       sync_.eval(0));
@@ -155,8 +155,8 @@ SYCL_BLAS_INLINE
 
   // Solve extra-diagonal blocks
 
-  volatile index_t *p = &sync_.eval(1);
-  index_t ready_block =
+  volatile int32_t *p = &sync_.eval(1);
+  int32_t ready_block =
       (_idy == 0)
           ? sycl::group_broadcast(ndItem.get_sub_group(), not_wi0 ? 0 : *p)
           : 0;
@@ -261,7 +261,7 @@ SYCL_BLAS_INLINE
 
   sycl::atomic_fence(sycl::memory_order::seq_cst, sycl::memory_scope::device);
 
-  volatile index_t *sync = sync_.get_pointer() + 1;
+  volatile int32_t *sync = sync_.get_pointer() + 1;
   if (!not_wi0) *sync = wg_id + (is_forward ? 1 : -1);
 
   sycl::atomic_fence(sycl::memory_order::seq_cst, sycl::memory_scope::device);

--- a/src/operations/blas2/trsv.hpp
+++ b/src/operations/blas2/trsv.hpp
@@ -34,29 +34,29 @@ namespace blas {
  * multiplication.
  */
 template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
-          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          uint32_t subgroup_size, uint32_t subgroups, bool is_upper,
           bool is_transposed, bool is_unitdiag>
 SYCL_BLAS_INLINE
-Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+Trsv<lhs_t, matrix_t, vector_t, sync_t, subgroup_size, subgroups, is_upper,
      is_transposed, is_unitdiag>::Trsv(lhs_t &_l, matrix_t &_matrix,
                                        vector_t &_vector, sync_t &_sync)
     : lhs_(_l), matrix_(_matrix), vector_(_vector), sync_(_sync) {}
 
 template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
-          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          uint32_t subgroup_size, uint32_t subgroups, bool is_upper,
           bool is_transposed, bool is_unitdiag>
 SYCL_BLAS_INLINE
-    typename Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups,
+    typename Trsv<lhs_t, matrix_t, vector_t, sync_t, subgroup_size, subgroups,
                   is_upper, is_transposed, is_unitdiag>::index_t
-    Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+    Trsv<lhs_t, matrix_t, vector_t, sync_t, subgroup_size, subgroups, is_upper,
          is_transposed, is_unitdiag>::get_size() const {
   return matrix_.get_size();
 }
 template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
-          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          uint32_t subgroup_size, uint32_t subgroups, bool is_upper,
           bool is_transposed, bool is_unitdiag>
 SYCL_BLAS_INLINE bool
-Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+Trsv<lhs_t, matrix_t, vector_t, sync_t, subgroup_size, subgroups, is_upper,
      is_transposed, is_unitdiag>::valid_thread(cl::sycl::nd_item<1> ndItem)
     const {
   // Valid threads are established by ::eval.
@@ -64,13 +64,13 @@ Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
 }
 
 template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
-          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          uint32_t subgroup_size, uint32_t subgroups, bool is_upper,
           bool is_transposed, bool is_unitdiag>
 template <typename local_memory_t>
 SYCL_BLAS_INLINE
-    typename Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups,
+    typename Trsv<lhs_t, matrix_t, vector_t, sync_t, subgroup_size, subgroups,
                   is_upper, is_transposed, is_unitdiag>::value_t
-    Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+    Trsv<lhs_t, matrix_t, vector_t, sync_t, subgroup_size, subgroups, is_upper,
          is_transposed, is_unitdiag>::eval(local_memory_t local_mem,
                                            cl::sycl::nd_item<1> ndItem) {
 #ifndef __COMPUTECPP__
@@ -80,6 +80,7 @@ SYCL_BLAS_INLINE
 
   // Number of sub-groups per work-group
   constexpr index_t sub_num = subgroups;
+  constexpr index_t x_range = subgroup_size;
   constexpr index_t y_range = x_range / sub_num;
 
   const index_t _N = lhs_.get_size();
@@ -153,16 +154,19 @@ SYCL_BLAS_INLINE
 
   // Solve extra-diagonal blocks
 
-  volatile int *p = &sync_.eval(1);
+  volatile index_t *p = &sync_.eval(1);
   index_t ready_block =
       (_idy == 0)
           ? sycl::group_broadcast(ndItem.get_sub_group(), not_wi0 ? 0 : *p)
           : 0;
 
-  int steps = is_forward ? wg_id : (curr_block - wg_id);
-  for (int s = 0; s < steps; ++s) {
+  index_t steps = is_forward ? wg_id : (curr_block - wg_id);
+  for (index_t s = 0; s < steps; ++s) {
     const index_t next_offset = curr_offset + (is_forward ? x_range : -x_range);
     const index_t next_block = curr_block + (is_forward ? 1 : -1);
+    const short jump =
+        (is_transposed ? x_range * 1l : x_range * matrix_.getSizeL());
+
     if (is_forward)
       glo_A += x_range * (is_transposed ? 1 : matrix_.getSizeL());
     else
@@ -263,7 +267,7 @@ SYCL_BLAS_INLINE
 
   sycl::atomic_fence(sycl::memory_order::seq_cst, sycl::memory_scope::device);
 
-  volatile int *sync = sync_.get_pointer() + 1;
+  volatile index_t *sync = sync_.get_pointer() + 1;
   if (!not_wi0) *sync = wg_id + (is_forward ? 1 : -1);
 
   sycl::atomic_fence(sycl::memory_order::seq_cst, sycl::memory_scope::device);
@@ -273,10 +277,10 @@ SYCL_BLAS_INLINE
 }
 
 template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
-          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          uint32_t subgroup_size, uint32_t subgroups, bool is_upper,
           bool is_transposed, bool is_unitdiag>
 SYCL_BLAS_INLINE void
-Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+Trsv<lhs_t, matrix_t, vector_t, sync_t, subgroup_size, subgroups, is_upper,
      is_transposed, is_unitdiag>::bind(cl::sycl::handler &h) {
   lhs_.bind(h);
   matrix_.bind(h);
@@ -284,10 +288,10 @@ Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
   sync_.bind(h);
 }
 template <typename lhs_t, typename matrix_t, typename vector_t, typename sync_t,
-          uint32_t x_range, uint32_t subgroups, bool is_upper,
+          uint32_t subgroup_size, uint32_t subgroups, bool is_upper,
           bool is_transposed, bool is_unitdiag>
 SYCL_BLAS_INLINE void
-Trsv<lhs_t, matrix_t, vector_t, sync_t, x_range, subgroups, is_upper,
+Trsv<lhs_t, matrix_t, vector_t, sync_t, subgroup_size, subgroups, is_upper,
      is_transposed, is_unitdiag>::adjust_access_displacement() {
   lhs_.adjust_access_displacement();
   matrix_.adjust_access_displacement();

--- a/src/operations/blas2/trsv.hpp
+++ b/src/operations/blas2/trsv.hpp
@@ -110,7 +110,7 @@ SYCL_BLAS_INLINE
   value_t *const par_x = loc_x + x_range + x_range * _idy;
   value_t *const loc_recip = loc_x + x_range;
 
-  auto a = sycl::atomic_ref<index_t, sycl::memory_order::relaxed,
+  auto a = sycl::atomic_ref<int32_t, sycl::memory_order::relaxed,
                             sycl::memory_scope::device,
                             sycl::access::address_space::global_space>(
       sync_.eval(0));
@@ -154,8 +154,8 @@ SYCL_BLAS_INLINE
 
   // Solve extra-diagonal blocks
 
-  volatile index_t *p = &sync_.eval(1);
-  index_t ready_block =
+  volatile int32_t *p = &sync_.eval(1);
+  int32_t ready_block =
       (_idy == 0)
           ? sycl::group_broadcast(ndItem.get_sub_group(), not_wi0 ? 0 : *p)
           : 0;
@@ -267,7 +267,7 @@ SYCL_BLAS_INLINE
 
   sycl::atomic_fence(sycl::memory_order::seq_cst, sycl::memory_scope::device);
 
-  volatile index_t *sync = sync_.get_pointer() + 1;
+  volatile int32_t *sync = sync_.get_pointer() + 1;
   if (!not_wi0) *sync = wg_id + (is_forward ? 1 : -1);
 
   sycl::atomic_fence(sycl::memory_order::seq_cst, sycl::memory_scope::device);


### PR DESCRIPTION
This patch fixes a bug for `trsv` and `tbsv` routines in case of `index_t` is equal to `long`.
Moreover, it changes the `x_range` template parameter name to `subgroup_size`, and enforces the atomic synchronization data type to be `int32_t`.