### PR TITLE
 Added device/compiler info and commit hash to state label in cublas benchmarks

### DIFF
--- a/benchmark/cublas/CMakeLists.txt
+++ b/benchmark/cublas/CMakeLists.txt
@@ -79,7 +79,7 @@ set(sources
 foreach(cublas_bench ${sources})
   get_filename_component(bench_cublas_exec ${cublas_bench} NAME_WE)
   add_executable(bench_cublas_${bench_cublas_exec} ${cublas_bench} main.cpp)
-  target_link_libraries(bench_cublas_${bench_cublas_exec} PRIVATE benchmark CUDA::toolkit CUDA::cublas CUDA::cudart sycl_blas Clara::Clara )
+  target_link_libraries(bench_cublas_${bench_cublas_exec} PRIVATE benchmark CUDA::toolkit CUDA::cublas CUDA::cudart sycl_blas Clara::Clara bench_info)
   target_compile_definitions(bench_cublas_${bench_cublas_exec} PRIVATE -DBLAS_INDEX_T=${BLAS_BENCHMARK_INDEX_TYPE})
   add_sycl_to_target(
     TARGET bench_cublas_${bench_cublas_exec}

--- a/benchmark/cublas/blas1/asum.cpp
+++ b/benchmark/cublas/blas1/asum.cpp
@@ -46,6 +46,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // init Google-benchmark counters.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::asum, scalar_t>(state, size);

--- a/benchmark/cublas/blas1/axpy.cpp
+++ b/benchmark/cublas/blas1/axpy.cpp
@@ -46,6 +46,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // init Google-benchmark counters.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::axpy, scalar_t>(state, size);

--- a/benchmark/cublas/blas1/dot.cpp
+++ b/benchmark/cublas/blas1/dot.cpp
@@ -46,6 +46,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // init Google-benchmark counters.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::dot, scalar_t>(state, size);

--- a/benchmark/cublas/blas1/iamax.cpp
+++ b/benchmark/cublas/blas1/iamax.cpp
@@ -47,6 +47,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // init Google-benchmark counters.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::iamax, scalar_t>(state, size);

--- a/benchmark/cublas/blas1/iamin.cpp
+++ b/benchmark/cublas/blas1/iamin.cpp
@@ -47,6 +47,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // init Google-benchmark counters.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::iamin, scalar_t>(state, size);

--- a/benchmark/cublas/blas1/nrm2.cpp
+++ b/benchmark/cublas/blas1/nrm2.cpp
@@ -47,6 +47,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // init Google-benchmark counters.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::nrm2, scalar_t>(state, size);

--- a/benchmark/cublas/blas1/rotg.cpp
+++ b/benchmark/cublas/blas1/rotg.cpp
@@ -45,6 +45,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Create data
   scalar_t a = blas_benchmark::utils::random_data<scalar_t>(1)[0];
   scalar_t b = blas_benchmark::utils::random_data<scalar_t>(1)[0];

--- a/benchmark/cublas/blas1/rotm.cpp
+++ b/benchmark/cublas/blas1/rotm.cpp
@@ -46,6 +46,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // init Google-benchmark counters.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::rotm, scalar_t>(state, size);

--- a/benchmark/cublas/blas1/rotmg.cpp
+++ b/benchmark/cublas/blas1/rotmg.cpp
@@ -47,6 +47,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // init Google-benchmark counters.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::rotmg, scalar_t>(state, 1);

--- a/benchmark/cublas/blas1/scal.cpp
+++ b/benchmark/cublas/blas1/scal.cpp
@@ -46,6 +46,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // init Google-benchmark counters.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::scal, scalar_t>(state, size);

--- a/benchmark/cublas/blas2/gbmv.cpp
+++ b/benchmark/cublas/blas2/gbmv.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int ti,
          index_t m, index_t n, index_t kl, index_t ku, scalar_t alpha,
          scalar_t beta, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   std::string ts = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(ti));

--- a/benchmark/cublas/blas2/gemv.cpp
+++ b/benchmark/cublas/blas2/gemv.cpp
@@ -46,6 +46,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int ti,
          index_t m, index_t n, scalar_t alpha, scalar_t beta, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   std::string ts = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(ti));

--- a/benchmark/cublas/blas2/ger.cpp
+++ b/benchmark/cublas/blas2/ger.cpp
@@ -46,6 +46,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, index_t m,
          index_t n, scalar_t alpha, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
 
   index_t xlen = m;

--- a/benchmark/cublas/blas2/sbmv.cpp
+++ b/benchmark/cublas/blas2/sbmv.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          std::string uplo, index_t n, index_t k, scalar_t alpha, scalar_t beta,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
 

--- a/benchmark/cublas/blas2/spmv.cpp
+++ b/benchmark/cublas/blas2/spmv.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          std::string uplo, index_t n, scalar_t alpha, scalar_t beta,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   const char* uplo_str = uplo.c_str();
 
   index_t xlen = n;

--- a/benchmark/cublas/blas2/spr.cpp
+++ b/benchmark/cublas/blas2/spr.cpp
@@ -46,6 +46,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
          int n, scalar_t alpha, int incX, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   blas_benchmark::utils::init_level_2_counters<
       blas_benchmark::utils::Level2Op::spr, scalar_t>(state, "n", 0, 0, n);
 

--- a/benchmark/cublas/blas2/spr2.cpp
+++ b/benchmark/cublas/blas2/spr2.cpp
@@ -46,6 +46,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
          int n, scalar_t alpha, int incX, int incY, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   blas_benchmark::utils::init_level_2_counters<
       blas_benchmark::utils::Level2Op::spr2, scalar_t>(state, "n", 0, 0, n);
 

--- a/benchmark/cublas/blas2/symv.cpp
+++ b/benchmark/cublas/blas2/symv.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          std::string uplo, index_t n, scalar_t alpha, scalar_t beta,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
 

--- a/benchmark/cublas/blas2/syr.cpp
+++ b/benchmark/cublas/blas2/syr.cpp
@@ -46,6 +46,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          std::string uplo, index_t n, scalar_t alpha, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
 

--- a/benchmark/cublas/blas2/syr2.cpp
+++ b/benchmark/cublas/blas2/syr2.cpp
@@ -46,6 +46,10 @@ static inline void cublas_routine(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          std::string uplo, index_t n, scalar_t alpha, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
 

--- a/benchmark/cublas/blas2/tbmv.cpp
+++ b/benchmark/cublas/blas2/tbmv.cpp
@@ -48,6 +48,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          std::string uplo, std::string t, std::string diag, index_t n,
          index_t k, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();

--- a/benchmark/cublas/blas2/tbsv.cpp
+++ b/benchmark/cublas/blas2/tbsv.cpp
@@ -48,6 +48,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          std::string uplo, std::string t, std::string diag, index_t n,
          index_t k, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();

--- a/benchmark/cublas/blas2/tpmv.cpp
+++ b/benchmark/cublas/blas2/tpmv.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          std::string uplo, std::string t, std::string diag, index_t n,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();

--- a/benchmark/cublas/blas2/tpsv.cpp
+++ b/benchmark/cublas/blas2/tpsv.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          std::string uplo, std::string t, std::string diag, index_t n,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();

--- a/benchmark/cublas/blas2/trmv.cpp
+++ b/benchmark/cublas/blas2/trmv.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          std::string uplo, std::string t, std::string diag, index_t n,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();

--- a/benchmark/cublas/blas2/trsv.cpp
+++ b/benchmark/cublas/blas2/trsv.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          std::string uplo, std::string t, std::string diag, index_t n,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();

--- a/benchmark/cublas/blas3/gemm.cpp
+++ b/benchmark/cublas/blas3/gemm.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int t1,
          int t2, index_t m, index_t k, index_t n, scalar_t alpha, scalar_t beta,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   std::string t1s = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(t1));

--- a/benchmark/cublas/blas3/gemm_batched.cpp
+++ b/benchmark/cublas/blas3/gemm_batched.cpp
@@ -50,6 +50,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, index_t t1,
          index_t t2, index_t m, index_t k, index_t n, scalar_t alpha,
          scalar_t beta, index_t batch_count, int batch_type_i, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard setup
   std::string t1s = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(t1));

--- a/benchmark/cublas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/cublas/blas3/gemm_batched_strided.cpp
@@ -53,6 +53,10 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int t1,
          int t2, index_t m, index_t k, index_t n, scalar_t alpha, scalar_t beta,
          index_t batch_size, index_t stride_a_mul, index_t stride_b_mul,
          index_t stride_c_mul, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   std::string t1s = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(t1));

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -49,6 +49,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
          char uplo, index_t m, index_t n, scalar_t alpha, scalar_t beta,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   index_t lda = side == 'l' ? m : n;
   index_t ldb = m;
   index_t ldc = ldb;

--- a/benchmark/cublas/blas3/syr2k.cpp
+++ b/benchmark/cublas/blas3/syr2k.cpp
@@ -49,6 +49,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
          char trans, index_t n, index_t k, scalar_t alpha, scalar_t beta,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   const index_t lda = (trans == 'n') ? n : k;
   const index_t ldc = n;
 

--- a/benchmark/cublas/blas3/syrk.cpp
+++ b/benchmark/cublas/blas3/syrk.cpp
@@ -49,6 +49,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char uplo,
          char trans, index_t n, index_t k, scalar_t alpha, scalar_t beta,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   index_t lda = (trans == 'n') ? n : k;
   index_t ldc = n;
 

--- a/benchmark/cublas/blas3/trmm.cpp
+++ b/benchmark/cublas/blas3/trmm.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
          char uplo, char t, char diag, index_t m, index_t n, scalar_t alpha,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   index_t lda = side == 'l' ? m : n;
   index_t ldb = m;
   index_t ldc = ldb;

--- a/benchmark/cublas/blas3/trsm.cpp
+++ b/benchmark/cublas/blas3/trsm.cpp
@@ -49,6 +49,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, char side,
          char uplo, char trans, char diag, index_t m, index_t n, scalar_t alpha,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   index_t lda = side == 'l' ? m : n;
   index_t ldb = m;

--- a/benchmark/cublas/blas3/trsm_batched.cpp
+++ b/benchmark/cublas/blas3/trsm_batched.cpp
@@ -51,6 +51,10 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr,
          const char side, const char uplo, const char t, const char diag,
          index_t m, index_t n, scalar_t alpha, index_t batch_count, index_t,
          index_t, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   index_t lda = side == 'l' ? m : n;
   index_t ldb = m;

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -77,7 +77,7 @@ set(sources
 foreach(rocblas_benchmark ${sources})
   get_filename_component(rocblas_bench_exec ${rocblas_benchmark} NAME_WE)
   add_executable(bench_rocblas_${rocblas_bench_exec} ${rocblas_benchmark} main.cpp)
-  target_link_libraries(bench_rocblas_${rocblas_bench_exec} PRIVATE benchmark Clara::Clara roc::rocblas) 
+  target_link_libraries(bench_rocblas_${rocblas_bench_exec} PRIVATE benchmark Clara::Clara roc::rocblas bench_info) 
   target_compile_definitions(bench_rocblas_${rocblas_bench_exec} PRIVATE -DBLAS_INDEX_T=${BLAS_BENCHMARK_INDEX_TYPE})
   target_include_directories(bench_rocblas_${rocblas_bench_exec} PRIVATE  ${SYCLBLAS_INCLUDE} ${rocblas_INCLUDE_DIRS} ${CBLAS_INCLUDE} ${BLAS_BENCH} ${SYCLBLAS_COMMON_INCLUDE_DIR})
 

--- a/benchmark/rocblas/blas1/asum.cpp
+++ b/benchmark/rocblas/blas1/asum.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_asum_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Google-benchmark counters are double.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::asum, scalar_t>(state, size);

--- a/benchmark/rocblas/blas1/axpy.cpp
+++ b/benchmark/rocblas/blas1/axpy.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_saxpy_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Google-benchmark counters are double.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::axpy, scalar_t>(state, size);

--- a/benchmark/rocblas/blas1/dot.cpp
+++ b/benchmark/rocblas/blas1/dot.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_dot_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Google-benchmark counters are double.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::dot, scalar_t>(state, size);

--- a/benchmark/rocblas/blas1/iamax.cpp
+++ b/benchmark/rocblas/blas1/iamax.cpp
@@ -47,6 +47,10 @@ static inline void rocblas_iamax_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Google-benchmark counters are double.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::iamax, scalar_t>(state, size);

--- a/benchmark/rocblas/blas1/iamin.cpp
+++ b/benchmark/rocblas/blas1/iamin.cpp
@@ -47,6 +47,10 @@ static inline void rocblas_iamin_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Google-benchmark counters are double.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::iamin, scalar_t>(state, size);

--- a/benchmark/rocblas/blas1/nrm2.cpp
+++ b/benchmark/rocblas/blas1/nrm2.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_nrm2_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Google-benchmark counters are double.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::nrm2, scalar_t>(state, size);

--- a/benchmark/rocblas/blas1/rotg.cpp
+++ b/benchmark/rocblas/blas1/rotg.cpp
@@ -44,6 +44,10 @@ static inline void rocblas_rotg_f(args_t&&... args) {
 
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Create data
   scalar_t a = blas_benchmark::utils::random_data<scalar_t>(1)[0];
   scalar_t b = blas_benchmark::utils::random_data<scalar_t>(1)[0];

--- a/benchmark/rocblas/blas1/rotm.cpp
+++ b/benchmark/rocblas/blas1/rotm.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_rotm_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Google-benchmark counters are double.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::rotm, scalar_t>(state, size);

--- a/benchmark/rocblas/blas1/rotmg.cpp
+++ b/benchmark/rocblas/blas1/rotmg.cpp
@@ -45,6 +45,10 @@ static inline void rocblas_rotmg_f(args_t&&... args) {
 
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Google-benchmark counters are double.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::rotmg, scalar_t>(state, 1);

--- a/benchmark/rocblas/blas1/scal.cpp
+++ b/benchmark/rocblas/blas1/scal.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_scal_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, index_t size,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Google-benchmark counters are double.
   blas_benchmark::utils::init_level_1_counters<
       blas_benchmark::utils::Level1Op::scal, scalar_t>(state, size);

--- a/benchmark/rocblas/blas2/gbmv.cpp
+++ b/benchmark/rocblas/blas2/gbmv.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
          index_t n, index_t kl, index_t ku, scalar_t alpha, scalar_t beta,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   std::string ts = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(ti));

--- a/benchmark/rocblas/blas2/gemv.cpp
+++ b/benchmark/rocblas/blas2/gemv.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_gemv_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, int ti, index_t m,
          index_t n, scalar_t alpha, scalar_t beta, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   std::string ts = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(ti));

--- a/benchmark/rocblas/blas2/ger.cpp
+++ b/benchmark/rocblas/blas2/ger.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_ger_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, index_t m,
          index_t n, scalar_t alpha, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   index_t xlen = m;
   index_t ylen = n;

--- a/benchmark/rocblas/blas2/sbmv.cpp
+++ b/benchmark/rocblas/blas2/sbmv.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_sbmv_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
          index_t n, index_t k, scalar_t alpha, scalar_t beta, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
 

--- a/benchmark/rocblas/blas2/spmv.cpp
+++ b/benchmark/rocblas/blas2/spmv.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_spmv_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
          index_t n, scalar_t alpha, scalar_t beta, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   const char* uplo_str = uplo.c_str();
 
   index_t xlen = n;

--- a/benchmark/rocblas/blas2/spr.cpp
+++ b/benchmark/rocblas/blas2/spr.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_spr_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo, int n,
          scalar_t alpha, int incX, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   blas_benchmark::utils::init_level_2_counters<
       blas_benchmark::utils::Level2Op::spr, scalar_t>(state, "n", 0, 0, n);
 

--- a/benchmark/rocblas/blas2/spr2.cpp
+++ b/benchmark/rocblas/blas2/spr2.cpp
@@ -47,6 +47,10 @@ static inline void rocblas_spr2_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
          index_t n, scalar_t alpha, index_t incX, index_t incY, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
 
   index_t xlen = n;

--- a/benchmark/rocblas/blas2/symv.cpp
+++ b/benchmark/rocblas/blas2/symv.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_symv_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
          index_t n, scalar_t alpha, scalar_t beta, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
 

--- a/benchmark/rocblas/blas2/syr.cpp
+++ b/benchmark/rocblas/blas2/syr.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_syr_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
          index_t n, scalar_t alpha, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
 

--- a/benchmark/rocblas/blas2/syr2.cpp
+++ b/benchmark/rocblas/blas2/syr2.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_syr2_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
          index_t n, scalar_t alpha, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
 

--- a/benchmark/rocblas/blas2/tbmv.cpp
+++ b/benchmark/rocblas/blas2/tbmv.cpp
@@ -47,6 +47,10 @@ static inline void rocblas_tbmv_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
          std::string t, std::string diag, index_t n, index_t k, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();

--- a/benchmark/rocblas/blas2/tbsv.cpp
+++ b/benchmark/rocblas/blas2/tbsv.cpp
@@ -47,6 +47,10 @@ static inline void rocblas_tbsv_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
          std::string t, std::string diag, index_t n, index_t k, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();

--- a/benchmark/rocblas/blas2/tpmv.cpp
+++ b/benchmark/rocblas/blas2/tpmv.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_tpmv_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
          std::string t, std::string diag, index_t n, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();

--- a/benchmark/rocblas/blas2/tpsv.cpp
+++ b/benchmark/rocblas/blas2/tpsv.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_tpsv_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
          std::string t, std::string diag, index_t n, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();

--- a/benchmark/rocblas/blas2/trmv.cpp
+++ b/benchmark/rocblas/blas2/trmv.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_trmv_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
          std::string t, std::string diag, index_t n, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -46,6 +46,10 @@ static inline void rocblas_trsv_f(args_t&&... args) {
 template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, std::string uplo,
          std::string t, std::string diag, index_t n, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const char* uplo_str = uplo.c_str();
   const char* t_str = t.c_str();

--- a/benchmark/rocblas/blas3/gemm.cpp
+++ b/benchmark/rocblas/blas3/gemm.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
          int t_b_i, index_t m, index_t k, index_t n, scalar_t alpha,
          scalar_t beta, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   std::string t_a = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(t_a_i));

--- a/benchmark/rocblas/blas3/gemm_batched.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched.cpp
@@ -50,6 +50,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, index_t t_a_i,
          index_t t_b_i, index_t m, index_t k, index_t n, scalar_t alpha,
          scalar_t beta, index_t batch_size, int batch_type_i, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard setup
   std::string t_a = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(t_a_i));

--- a/benchmark/rocblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched_strided.cpp
@@ -55,6 +55,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, int t_a_i,
          int t_b_i, index_t m, index_t k, index_t n, scalar_t alpha,
          scalar_t beta, index_t batch_size, index_t stride_a_mul,
          index_t stride_b_mul, index_t stride_c_mul, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   std::string t_a = blas_benchmark::utils::from_transpose_enum(
       static_cast<blas_benchmark::utils::Transposition>(t_a_i));

--- a/benchmark/rocblas/blas3/symm.cpp
+++ b/benchmark/rocblas/blas3/symm.cpp
@@ -49,6 +49,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
          char uplo, index_t m, index_t n, scalar_t alpha, scalar_t beta,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   index_t lda = (side == 'l') ? m : n;
   index_t ldb = m;

--- a/benchmark/rocblas/blas3/syr2k.cpp
+++ b/benchmark/rocblas/blas3/syr2k.cpp
@@ -49,6 +49,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
          char trans, index_t n, index_t k, scalar_t alpha, scalar_t beta,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   const index_t lda = (trans == 'n') ? n : k;
   const index_t ldc = n;

--- a/benchmark/rocblas/blas3/syrk.cpp
+++ b/benchmark/rocblas/blas3/syrk.cpp
@@ -49,6 +49,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, char uplo,
          char trans, index_t n, index_t k, scalar_t alpha, scalar_t beta,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   index_t lda = (trans == 'n') ? n : k;
   index_t ldc = n;

--- a/benchmark/rocblas/blas3/trmm.cpp
+++ b/benchmark/rocblas/blas3/trmm.cpp
@@ -47,6 +47,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
          char uplo, char trans, char diag, index_t m, index_t n, scalar_t alpha,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   index_t lda = side == 'l' ? m : n;
   index_t ldb = m;

--- a/benchmark/rocblas/blas3/trsm.cpp
+++ b/benchmark/rocblas/blas3/trsm.cpp
@@ -49,6 +49,10 @@ template <typename scalar_t>
 void run(benchmark::State& state, rocblas_handle& rb_handle, char side,
          char uplo, char trans, char diag, index_t m, index_t n, scalar_t alpha,
          bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   index_t lda = (side == 'l') ? m : n;
   index_t ldb = m;

--- a/benchmark/rocblas/blas3/trsm_batched.cpp
+++ b/benchmark/rocblas/blas3/trsm_batched.cpp
@@ -54,6 +54,10 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, const char side,
          const char uplo, const char trans, const char diag, index_t m,
          index_t n, scalar_t alpha, index_t batch_size, index_t stride_a_mul,
          index_t stride_b_mul, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
   // Standard test setup.
   index_t lda = side == 'l' ? m : n;
   index_t ldb = m;


### PR DESCRIPTION
This PR adds `device` info, `compiler` info and `commit` info to the `state` object in the `cublas` benchmarks and sets the `state` object's `label` accordingly.