### PR TITLE
Add gtest_skip for USM tests

### DIFF
--- a/test/unittest/blas1/blas1_asum_test.cpp
+++ b/test/unittest/blas1/blas1_asum_test.cpp
@@ -92,6 +92,8 @@ static void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_axpy_test.cpp
+++ b/test/unittest/blas1/blas1_axpy_test.cpp
@@ -86,6 +86,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_copy_test.cpp
+++ b/test/unittest/blas1/blas1_copy_test.cpp
@@ -90,6 +90,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_dot_test.cpp
+++ b/test/unittest/blas1/blas1_dot_test.cpp
@@ -96,6 +96,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_iamax_test.cpp
+++ b/test/unittest/blas1/blas1_iamax_test.cpp
@@ -69,6 +69,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_iamin_test.cpp
+++ b/test/unittest/blas1/blas1_iamin_test.cpp
@@ -103,6 +103,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_nrm2_test.cpp
+++ b/test/unittest/blas1/blas1_nrm2_test.cpp
@@ -89,6 +89,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_rot_test.cpp
+++ b/test/unittest/blas1/blas1_rot_test.cpp
@@ -107,6 +107,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_rotg_test.cpp
+++ b/test/unittest/blas1/blas1_rotg_test.cpp
@@ -110,6 +110,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_rotm_test.cpp
+++ b/test/unittest/blas1/blas1_rotm_test.cpp
@@ -107,6 +107,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_rotmg_test.cpp
+++ b/test/unittest/blas1/blas1_rotmg_test.cpp
@@ -240,6 +240,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_scal_test.cpp
+++ b/test/unittest/blas1/blas1_scal_test.cpp
@@ -76,6 +76,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_sdsdot_test.cpp
+++ b/test/unittest/blas1/blas1_sdsdot_test.cpp
@@ -113,6 +113,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas1/blas1_swap_test.cpp
+++ b/test/unittest/blas1/blas1_swap_test.cpp
@@ -89,6 +89,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {  // buffer alloc
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas2/blas2_gbmv_test.cpp
+++ b/test/unittest/blas2/blas2_gbmv_test.cpp
@@ -121,6 +121,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas2/blas2_gemv_test.cpp
+++ b/test/unittest/blas2/blas2_gemv_test.cpp
@@ -112,6 +112,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas2/blas2_ger_test.cpp
+++ b/test/unittest/blas2/blas2_ger_test.cpp
@@ -103,6 +103,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas2/blas2_sbmv_test.cpp
+++ b/test/unittest/blas2/blas2_sbmv_test.cpp
@@ -113,6 +113,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas2/blas2_spr2_test.cpp
+++ b/test/unittest/blas2/blas2_spr2_test.cpp
@@ -104,6 +104,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas2/blas2_spr_test.cpp
+++ b/test/unittest/blas2/blas2_spr_test.cpp
@@ -98,6 +98,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas2/blas2_symv_test.cpp
+++ b/test/unittest/blas2/blas2_symv_test.cpp
@@ -106,6 +106,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas2/blas2_syr2_test.cpp
+++ b/test/unittest/blas2/blas2_syr2_test.cpp
@@ -101,6 +101,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas2/blas2_syr_test.cpp
+++ b/test/unittest/blas2/blas2_syr_test.cpp
@@ -90,6 +90,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas2/blas2_tbmv_test.cpp
+++ b/test/unittest/blas2/blas2_tbmv_test.cpp
@@ -107,6 +107,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas2/blas2_tbsv_test.cpp
+++ b/test/unittest/blas2/blas2_tbsv_test.cpp
@@ -120,7 +120,11 @@ void run_test(const combination_t<scalar_t> combi) {
   std::tie(alloc, n, k, is_upper, trans, is_unit, incX, ldaMul, wa) = combi;
 
   if (alloc == "usm") {
+#ifdef SB_ENABLE_USM
     run_test<scalar_t, blas::helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
+#endif
   } else {
     run_test<scalar_t, blas::helper::AllocType::buffer>(combi);
   }

--- a/test/unittest/blas2/blas2_trmv_test.cpp
+++ b/test/unittest/blas2/blas2_trmv_test.cpp
@@ -107,6 +107,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);

--- a/test/unittest/blas2/blas2_trsv_test.cpp
+++ b/test/unittest/blas2/blas2_trsv_test.cpp
@@ -123,7 +123,11 @@ void run_test(const combination_t<scalar_t> combi) {
   std::tie(alloc, n, is_upper, trans, is_unit, incX, lda_mul, wa) = combi;
 
   if (alloc == "usm") {
+#ifdef SB_ENABLE_USM
     run_test<scalar_t, blas::helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
+#endif
   } else {
     run_test<scalar_t, blas::helper::AllocType::buffer>(combi);
   }

--- a/test/unittest/reduction/reduction_test.cpp
+++ b/test/unittest/reduction/reduction_test.cpp
@@ -242,6 +242,8 @@ void run_test(const combination_t<scalar_t> combi) {
   if (alloc == "usm") {
 #ifdef SB_ENABLE_USM
     run_test<scalar_t, helper::AllocType::usm>(combi);
+#else
+    GTEST_SKIP();
 #endif
   } else {
     run_test<scalar_t, helper::AllocType::buffer>(combi);


### PR DESCRIPTION
This PR adds `GTEST_SKIP()` for tests when USM is not supported for better visibility.