### PR TITLE
Added OmatAdd operator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ For all these operations:
 |---|---|---|
 | `_omatcopy` | `sb_handle`, `transa`, `M`, `N`, `alpha`, `A`, `lda`, `B`, `ldb`  | Perform an out-of-place scaled matrix transpose or copy operation using a general dense matrix. |
 | `_omatcopy2`| `sb_handle`, `transa`, `M`, `N`, `alpha`, `A`, `lda`, `inc_a`, `B`, `ldb`, `inc_b`  | Computes two-strided scaling and out-of-place transposition or copying of general dense matrices. |
+| `_omatadd`| `sb_handle`, `transa`, `transb`, `M`, `N`, `alpha`, `A`, `lda`, `beta`, `B`, `ldb`, `C`,`ldc`  | Computes scaled general dense matrix addition with possibly transposed arguments. |
 | `_transpose` | `sb_handle`, `M`, `N`, `A`, `lda`, `B`, `ldb`  | Computes an out-of-place matrix transpose operation using a general dense matrix. |
 | `_transpose` | `sb_handle`, `M`, `N`, `A`, `ld_in`, `ld_out`  | Computes an in-place matrix transpose operation using a general dense matrix. |
 ### Experimental Joint Matrix Support

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ For all these operations:
 
 ### EXTENSION
 
-The following table sums up the interface that cab be found in
+The following table sums up the interface that can be found in
 [extension_interface.h](include/interface/extension_interface.h).
 
 For all these operations:
@@ -304,20 +304,24 @@ For all these operations:
   (cf BLAS 2). The leading dimension of a matrix must be greater than or equal
   to its number of rows. In the case of in-place transpose, the same matrix `A`
   is used with two different leading dimensions for input & output.
+* `stride_a`, `stride_b` and `stride_c` are the striding size between consecutive 
+matrices in a batched entry for inputs/outputs A, B and C. 
+* `inc_a` and `inc_b` are the distance between consecutive elements in A & B matrices.
 * `transa` and `transb` are the transpose modes of the matrices A and B
   (cf BLAS 2).
 * `M` and `N` are the dimensions of the matrices.
-* `alpha` and `beta` are scalars.
-* `batch_size` is an integer.
-* `inc_a` and `inc_b` are integers. The distance between element in the same column.
+* `alpha` and `beta` are scaling scalars.
+* `batch_size` is the number of batch matrices.
 
 | operation | arguments | description |
 |---|---|---|
 | `_omatcopy` | `sb_handle`, `transa`, `M`, `N`, `alpha`, `A`, `lda`, `B`, `ldb`  | Perform an out-of-place scaled matrix transpose or copy operation using a general dense matrix. |
 | `_omatcopy2`| `sb_handle`, `transa`, `M`, `N`, `alpha`, `A`, `lda`, `inc_a`, `B`, `ldb`, `inc_b`  | Computes two-strided scaling and out-of-place transposition or copying of general dense matrices. |
 | `_omatadd`| `sb_handle`, `transa`, `transb`, `M`, `N`, `alpha`, `A`, `lda`, `beta`, `B`, `ldb`, `C`,`ldc`  | Computes scaled general dense matrix addition with possibly transposed arguments. |
+
+Other non-official extension operators : 
 | `_transpose` | `sb_handle`, `M`, `N`, `A`, `lda`, `B`, `ldb`  | Computes an out-of-place matrix transpose operation using a general dense matrix. |
-| `_transpose` | `sb_handle`, `M`, `N`, `A`, `ld_in`, `ld_out`  | Computes an in-place matrix transpose operation using a general dense matrix. |
+| `_transpose` | `sb_handle`, `M`, `N`, `A`, `lda`, `ldb`  | Computes an in-place matrix transpose operation using a general dense matrix. |
 ### Experimental Joint Matrix Support
 
 SYCL-BLAS now supports sub-group based collective GEMM operation using the experimental 

--- a/README.md
+++ b/README.md
@@ -320,8 +320,10 @@ matrices in a batched entry for inputs/outputs A, B and C.
 | `_omatadd`| `sb_handle`, `transa`, `transb`, `M`, `N`, `alpha`, `A`, `lda`, `beta`, `B`, `ldb`, `C`,`ldc`  | Computes scaled general dense matrix addition with possibly transposed arguments. |
 
 Other non-official extension operators : 
+| operation | arguments | description |
+|---|---|---|
 | `_transpose` | `sb_handle`, `M`, `N`, `A`, `lda`, `B`, `ldb`  | Computes an out-of-place matrix transpose operation using a general dense matrix. |
-| `_transpose` | `sb_handle`, `M`, `N`, `A`, `lda`, `ldb`  | Computes an in-place matrix transpose operation using a general dense matrix. |
+| `_transpose*` | `sb_handle`, `M`, `N`, `A`, `lda`, `ldb`  | Computes an in-place matrix transpose operation using a general dense matrix, lda & ldb being input and output leading dimensions of A respectively _(*Not implemented)_. |
 ### Experimental Joint Matrix Support
 
 SYCL-BLAS now supports sub-group based collective GEMM operation using the experimental 

--- a/benchmark/cublas/CMakeLists.txt
+++ b/benchmark/cublas/CMakeLists.txt
@@ -71,6 +71,7 @@ set(sources
   blas3/trmm.cpp
   # extension blas
   extension/omatcopy.cpp
+  extension/omatadd.cpp
 ) 
 
 # Add individual benchmarks for each method

--- a/benchmark/cublas/extension/omatadd.cpp
+++ b/benchmark/cublas/extension/omatadd.cpp
@@ -1,0 +1,199 @@
+/* *************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename omatadd.cpp
+ *
+ **************************************************************************/
+
+#include "../../../test/unittest/extension/extension_reference.hpp"
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string ts_a, std::string ts_b, int m, int n,
+                     scalar_t alpha, scalar_t beta, index_t lda_mul,
+                     index_t ldb_mul, index_t ldc_mul) {
+  std::ostringstream str{};
+  str << "BM_omatadd<" << blas_benchmark::utils::get_type_name<scalar_t>()
+      << ">/" << ts_a << "/" << ts_b << "/" << m << "/" << n << "/" << alpha
+      << "/" << beta << "/" << lda_mul << "/" << ldb_mul << "/" << ldc_mul;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void cublas_routine(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CUBLAS_CHECK(cublasSgeam(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CUBLAS_CHECK(cublasDgeam(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, int ti_a,
+         int ti_b, index_t m, index_t n, scalar_t alpha, scalar_t beta,
+         index_t lda_mul, index_t ldb_mul, index_t ldc_mul, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(state);
+
+  // Standard test setup.
+  std::string ts_a = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(ti_a));
+  const char* t_str_a = ts_a.c_str();
+  std::string ts_b = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(ti_b));
+  const char* t_str_b = ts_b.c_str();
+
+  const auto lda = (*t_str_a == 't') ? lda_mul * n : lda_mul * m;
+  const auto ldb = (*t_str_b == 't') ? ldb_mul * n : ldb_mul * m;
+  const auto ldc = ldc_mul * m;
+
+  const auto size_a = lda * ((*t_str_a == 't') ? m : n);
+  const auto size_b = ldb * ((*t_str_b == 't') ? m : n);
+  const auto size_c = ldc * n;
+
+  blas_benchmark::utils::init_extension_counters<
+      blas_benchmark::utils::ExtensionOP::omatadd, scalar_t>(
+      state, t_str_a, t_str_b, m, n, lda_mul, ldb_mul, ldc_mul);
+
+  cublasHandle_t& cuda_handle = *cuda_handle_ptr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(size_a);
+  std::vector<scalar_t> m_b =
+      blas_benchmark::utils::random_data<scalar_t>(size_b);
+  std::vector<scalar_t> m_c =
+      blas_benchmark::utils::random_data<scalar_t>(size_c);
+
+  blas_benchmark::utils::CUDAVector<scalar_t> m_a_gpu(size_a, m_a.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> m_b_gpu(size_b, m_b.data());
+  blas_benchmark::utils::CUDAVector<scalar_t> m_c_gpu(size_c, m_c.data());
+
+  cublasOperation_t c_t_a = (*t_str_a == 'n') ? CUBLAS_OP_N : CUBLAS_OP_T;
+  cublasOperation_t c_t_b = (*t_str_b == 'n') ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> m_c_ref = m_c;
+
+  reference_blas::ext_omatadd(*t_str_a, *t_str_b, m, n, alpha, m_a, lda, beta,
+                              m_b, ldb, m_c_ref, ldc);
+
+  std::vector<scalar_t> m_c_temp = m_c;
+  {
+    blas_benchmark::utils::CUDAVector<scalar_t, true> m_c_temp_gpu(
+        size_c, m_c_temp.data());
+
+    cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, &alpha, m_a_gpu,
+                             lda, &beta, m_b_gpu, ldb, m_c_temp_gpu, ldc);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(m_c_temp, m_c_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+  auto blas_warmup = [&]() -> void {
+    cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, &alpha, m_a_gpu,
+                             lda, &beta, m_b_gpu, ldb, m_c_gpu, ldc);
+    return;
+  };
+
+  cudaEvent_t start;
+  cudaEvent_t stop;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
+
+  auto blas_method_def = [&]() -> std::vector<cudaEvent_t> {
+    CUDA_CHECK(cudaEventRecord(start));
+    cublas_routine<scalar_t>(cuda_handle, c_t_a, c_t_b, m, n, &alpha, m_a_gpu,
+                             lda, &beta, m_b_gpu, ldb, m_c_gpu, ldc);
+    CUDA_CHECK(cudaEventRecord(stop));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    return std::vector{start, stop};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_warmup);
+  CUDA_CHECK(cudaStreamSynchronize(NULL));
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef_cuda(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetItemsProcessed(state.iterations() * state.counters["n_fl_ops"]);
+  state.SetBytesProcessed(state.iterations() *
+                          state.counters["bytes_processed"]);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+
+  CUDA_CHECK(cudaEventDestroy(start));
+  CUDA_CHECK(cudaEventDestroy(stop));
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        cublasHandle_t* cublas_handle_ptr, bool* success) {
+  auto omatadd_params =
+      blas_benchmark::utils::get_omatadd_params<scalar_t>(args);
+
+  for (auto p : omatadd_params) {
+    std::string ts_a, ts_b;
+    index_t m, n, lda_mul, ldb_mul, ldc_mul;
+    scalar_t alpha, beta;
+    std::tie(ts_a, ts_b, m, n, alpha, beta, lda_mul, ldb_mul, ldc_mul) = p;
+    int t_a = static_cast<int>(blas_benchmark::utils::to_transpose_enum(ts_a));
+    int t_b = static_cast<int>(blas_benchmark::utils::to_transpose_enum(ts_b));
+
+    auto BM_lambda =
+        [&](benchmark::State& st, cublasHandle_t* cublas_handle_ptr, int t_a,
+            int t_b, index_t m, index_t n, scalar_t alpha, scalar_t beta,
+            index_t lda_mul, index_t ldb_mul, index_t ldc_mul, bool* success) {
+          run<scalar_t>(st, cublas_handle_ptr, t_a, t_b, m, n, alpha, beta,
+                        lda_mul, ldb_mul, ldc_mul, success);
+        };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(ts_a, ts_b, m, n, alpha, beta, lda_mul, ldb_mul,
+                           ldc_mul)
+            .c_str(),
+        BM_lambda, cublas_handle_ptr, t_a, t_b, m, n, alpha, beta, lda_mul,
+        ldb_mul, ldc_mul, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      cublasHandle_t* cuda_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, cuda_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/rocblas/CMakeLists.txt
+++ b/benchmark/rocblas/CMakeLists.txt
@@ -73,6 +73,7 @@ set(sources
 
   # Extension blas
   extension/omatcopy.cpp
+  extension/omatadd.cpp
 
 )
 

--- a/benchmark/rocblas/extension/omatadd.cpp
+++ b/benchmark/rocblas/extension/omatadd.cpp
@@ -1,0 +1,200 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename omatadd.cpp
+ *
+ **************************************************************************/
+
+#include "../../../../test/unittest/extension/extension_reference.hpp"
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string ts_a, std::string ts_b, int m, int n,
+                     scalar_t alpha, scalar_t beta, index_t lda_mul,
+                     index_t ldb_mul, index_t ldc_mul) {
+  std::ostringstream str{};
+  str << "BM_omatadd<" << blas_benchmark::utils::get_type_name<scalar_t>()
+      << ">/" << ts_a << "/" << ts_b << "/" << m << "/" << n << "/" << alpha
+      << "/" << beta << "/" << lda_mul << "/" << ldb_mul << "/" << ldc_mul;
+  return str.str();
+}
+
+template <typename scalar_t, typename... args_t>
+static inline void rocblas_geam_f(args_t&&... args) {
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    CHECK_ROCBLAS_STATUS(rocblas_sgeam(std::forward<args_t>(args)...));
+  } else if constexpr (std::is_same_v<scalar_t, double>) {
+    CHECK_ROCBLAS_STATUS(rocblas_dgeam(std::forward<args_t>(args)...));
+  }
+  return;
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, rocblas_handle& rb_handle, int ti_a, int ti_b,
+         index_t m, index_t n, scalar_t alpha, scalar_t beta, index_t lda_mul,
+         index_t ldb_mul, index_t ldc_mul, bool* success) {
+  // initialize the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(state);
+
+  // Standard test setup.
+  std::string ts_a = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(ti_a));
+  const char* t_str_a = ts_a.c_str();
+  std::string ts_b = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(ti_b));
+  const char* t_str_b = ts_b.c_str();
+
+  const auto lda = (*t_str_a == 't') ? lda_mul * n : lda_mul * m;
+  const auto ldb = (*t_str_b == 't') ? ldb_mul * n : ldb_mul * m;
+  const auto ldc = ldc_mul * m;
+
+  const auto size_a = lda * ((*t_str_a == 't') ? m : n);
+  const auto size_b = ldb * ((*t_str_b == 't') ? m : n);
+  const auto size_c = ldc * n;
+
+  blas_benchmark::utils::init_extension_counters<
+      blas_benchmark::utils::ExtensionOP::omatadd, scalar_t>(
+      state, t_str_a, t_str_b, m, n, lda_mul, ldb_mul, ldc_mul);
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(size_a);
+  std::vector<scalar_t> m_b =
+      blas_benchmark::utils::random_data<scalar_t>(size_b);
+  std::vector<scalar_t> m_c =
+      blas_benchmark::utils::random_data<scalar_t>(size_c);
+
+  blas_benchmark::utils::HIPVector<scalar_t> m_a_gpu(size_a, m_a.data());
+  blas_benchmark::utils::HIPVector<scalar_t> m_b_gpu(size_b, m_b.data());
+  blas_benchmark::utils::HIPVector<scalar_t> m_c_gpu(size_c, m_c.data());
+
+  // Matrix options (rocBLAS)
+  const rocblas_operation trans_a_rb =
+      t_str_a[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
+  const rocblas_operation trans_b_rb =
+      t_str_b[0] == 'n' ? rocblas_operation_none : rocblas_operation_transpose;
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> m_c_ref = m_c;
+
+  reference_blas::ext_omatadd(*t_str_a, *t_str_b, m, n, alpha, m_a, lda, beta,
+                              m_b, ldb, m_c_ref, ldc);
+
+  std::vector<scalar_t> m_c_temp = m_c;
+  {
+    blas_benchmark::utils::HIPVector<scalar_t, true> m_c_temp_gpu(
+        size_c, m_c_temp.data());
+
+    rocblas_geam_f<scalar_t>(rb_handle, trans_a_rb, trans_b_rb, m, n, &alpha,
+                             m_a_gpu, lda, &beta, m_b_gpu, ldb, m_c_temp_gpu,
+                             ldc);
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(m_c_temp, m_c_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+  auto blas_warmup = [&]() -> void {
+    rocblas_geam_f<scalar_t>(rb_handle, trans_a_rb, trans_b_rb, m, n, &alpha,
+                             m_a_gpu, lda, &beta, m_b_gpu, ldb, m_c_gpu, ldc);
+    return;
+  };
+
+  hipEvent_t start, stop;
+  CHECK_HIP_ERROR(hipEventCreate(&start));
+  CHECK_HIP_ERROR(hipEventCreate(&stop));
+
+  auto blas_method_def = [&]() -> std::vector<hipEvent_t> {
+    CHECK_HIP_ERROR(hipEventRecord(start, NULL));
+    rocblas_geam_f<scalar_t>(rb_handle, trans_a_rb, trans_b_rb, m, n, &alpha,
+                             m_a_gpu, lda, &beta, m_b_gpu, ldb, m_c_gpu, ldc);
+    CHECK_HIP_ERROR(hipEventRecord(stop, NULL));
+    CHECK_HIP_ERROR(hipEventSynchronize(stop));
+    return std::vector{start, stop};
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_warmup);
+  CHECK_HIP_ERROR(hipStreamSynchronize(NULL));
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef_hip(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetItemsProcessed(state.iterations() * state.counters["n_fl_ops"]);
+  state.SetBytesProcessed(state.iterations() *
+                          state.counters["bytes_processed"]);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+
+  CHECK_HIP_ERROR(hipEventDestroy(start));
+  CHECK_HIP_ERROR(hipEventDestroy(stop));
+};
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                        bool* success) {
+  auto omatadd_params =
+      blas_benchmark::utils::get_omatadd_params<scalar_t>(args);
+
+  for (auto p : omatadd_params) {
+    std::string ts_a, ts_b;
+    index_t m, n, lda_mul, ldb_mul, ldc_mul;
+    scalar_t alpha, beta;
+    std::tie(ts_a, ts_b, m, n, alpha, beta, lda_mul, ldb_mul, ldc_mul) = p;
+    int t_a = static_cast<int>(blas_benchmark::utils::to_transpose_enum(ts_a));
+    int t_b = static_cast<int>(blas_benchmark::utils::to_transpose_enum(ts_b));
+
+    auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
+                         int t_a, int t_b, index_t m, index_t n, scalar_t alpha,
+                         scalar_t beta, index_t lda_mul, index_t ldb_mul,
+                         index_t ldc_mul, bool* success) {
+      run<scalar_t>(st, rb_handle, t_a, t_b, m, n, alpha, beta, lda_mul,
+                    ldb_mul, ldc_mul, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(ts_a, ts_b, m, n, alpha, beta, lda_mul, ldb_mul,
+                           ldc_mul)
+            .c_str(),
+        BM_lambda, rb_handle, t_a, t_b, m, n, alpha, beta, lda_mul, ldb_mul,
+        ldc_mul, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
+                      bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, rb_handle, success);
+}
+}  // namespace blas_benchmark

--- a/benchmark/syclblas/CMakeLists.txt
+++ b/benchmark/syclblas/CMakeLists.txt
@@ -66,6 +66,7 @@ set(sources
   # blas Extension
   extension/omatcopy.cpp
   extension/omatcopy2.cpp
+  extension/omatadd.cpp
 )
 
 if(${BLAS_ENABLE_EXTENSIONS})

--- a/benchmark/syclblas/extension/omatadd.cpp
+++ b/benchmark/syclblas/extension/omatadd.cpp
@@ -1,0 +1,175 @@
+/**************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename omatadd.cpp
+ *
+ **************************************************************************/
+
+#include "../../../test/unittest/extension/extension_reference.hpp"
+#include "../utils.hpp"
+
+template <typename scalar_t>
+std::string get_name(std::string ts_a, std::string ts_b, int m, int n,
+                     scalar_t alpha, scalar_t beta, index_t lda_mul,
+                     index_t ldb_mul, index_t ldc_mul) {
+  std::ostringstream str{};
+  str << "BM_omatadd<" << blas_benchmark::utils::get_type_name<scalar_t>()
+      << ">/" << ts_a << "/" << ts_b << "/" << m << "/" << n << "/" << alpha
+      << "/" << beta << "/" << lda_mul << "/" << ldb_mul << "/" << ldc_mul;
+  return str.str();
+}
+
+template <typename scalar_t>
+void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int ti_a,
+         int ti_b, index_t m, index_t n, scalar_t alpha, scalar_t beta,
+         index_t lda_mul, index_t ldb_mul, index_t ldc_mul, bool* success) {
+  // initiliaze the state label
+  blas_benchmark::utils::set_benchmark_label<scalar_t>(
+      state, sb_handle_ptr->get_queue());
+
+  // Standard test setup.
+  std::string ts_a = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(ti_a));
+  const char* t_str_a = ts_a.c_str();
+  std::string ts_b = blas_benchmark::utils::from_transpose_enum(
+      static_cast<blas_benchmark::utils::Transposition>(ti_b));
+  const char* t_str_b = ts_b.c_str();
+
+  const auto lda = (*t_str_a == 't') ? lda_mul * n : lda_mul * m;
+  const auto ldb = (*t_str_b == 't') ? ldb_mul * n : ldb_mul * m;
+  const auto ldc = ldc_mul * m;
+
+  const auto size_a = lda * ((*t_str_a == 't') ? m : n);
+  const auto size_b = ldb * ((*t_str_b == 't') ? m : n);
+  const auto size_c = ldc * n;
+
+  blas_benchmark::utils::init_extension_counters<
+      blas_benchmark::utils::ExtensionOP::omatadd, scalar_t>(
+      state, t_str_a, t_str_b, m, n, lda_mul, ldb_mul, ldc_mul);
+
+  blas::SB_Handle& sb_handle = *sb_handle_ptr;
+
+  // Input matrix/vector, output vector.
+  std::vector<scalar_t> m_a =
+      blas_benchmark::utils::random_data<scalar_t>(size_a);
+  std::vector<scalar_t> m_b =
+      blas_benchmark::utils::random_data<scalar_t>(size_b);
+  std::vector<scalar_t> m_c =
+      blas_benchmark::utils::random_data<scalar_t>(size_c);
+
+  auto m_a_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_a, size_a);
+  auto m_b_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_b, size_b);
+  auto m_c_gpu = blas::make_sycl_iterator_buffer<scalar_t>(m_c, size_c);
+
+#ifdef BLAS_VERIFY_BENCHMARK
+  // Run a first time with a verification of the results
+  std::vector<scalar_t> m_c_ref = m_c;
+
+  reference_blas::ext_omatadd(*t_str_a, *t_str_b, m, n, alpha, m_a, lda, beta,
+                              m_b, ldb, m_c_ref, ldc);
+
+  std::vector<scalar_t> m_c_temp = m_c;
+  {
+    auto m_c_temp_gpu =
+        blas::make_sycl_iterator_buffer<scalar_t>(m_c_temp, size_c);
+
+    auto event =
+        blas::_omatadd(sb_handle, *t_str_a, *t_str_b, m, n, alpha, m_a_gpu, lda,
+                       beta, m_b_gpu, ldb, m_c_temp_gpu, ldc);
+
+    sb_handle.wait();
+  }
+
+  std::ostringstream err_stream;
+  if (!utils::compare_vectors(m_c_temp, m_c_ref, err_stream, "")) {
+    const std::string& err_str = err_stream.str();
+    state.SkipWithError(err_str.c_str());
+    *success = false;
+  };
+#endif
+
+  auto blas_method_def = [&]() -> std::vector<cl::sycl::event> {
+    auto event = blas::_omatadd(sb_handle, *t_str_a, *t_str_b, m, n, alpha,
+                                m_a_gpu, lda, beta, m_b_gpu, ldb, m_c_gpu, ldc);
+    sb_handle.wait(event);
+    return event;
+  };
+
+  // Warmup
+  blas_benchmark::utils::warmup(blas_method_def);
+  sb_handle.wait();
+
+  blas_benchmark::utils::init_counters(state);
+
+  // Measure
+  for (auto _ : state) {
+    // Run
+    std::tuple<double, double> times =
+        blas_benchmark::utils::timef(blas_method_def);
+
+    // Report
+    blas_benchmark::utils::update_counters(state, times);
+  }
+
+  state.SetItemsProcessed(state.iterations() * state.counters["n_fl_ops"]);
+  state.SetBytesProcessed(state.iterations() *
+                          state.counters["bytes_processed"]);
+
+  blas_benchmark::utils::calc_avg_counters(state);
+}
+
+template <typename scalar_t>
+void register_benchmark(blas_benchmark::Args& args,
+                        blas::SB_Handle* sb_handle_ptr, bool* success) {
+  auto omatadd_params =
+      blas_benchmark::utils::get_omatadd_params<scalar_t>(args);
+
+  for (auto p : omatadd_params) {
+    std::string ts_a, ts_b;
+    index_t m, n, lda_mul, ldb_mul, ldc_mul;
+    scalar_t alpha, beta;
+    std::tie(ts_a, ts_b, m, n, alpha, beta, lda_mul, ldb_mul, ldc_mul) = p;
+    int t_a = static_cast<int>(blas_benchmark::utils::to_transpose_enum(ts_a));
+    int t_b = static_cast<int>(blas_benchmark::utils::to_transpose_enum(ts_b));
+
+    auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
+                         int t_a, int t_b, index_t m, index_t n, scalar_t alpha,
+                         scalar_t beta, index_t lda_mul, index_t ldb_mul,
+                         index_t ldc_mul, bool* success) {
+      run<scalar_t>(st, sb_handle_ptr, t_a, t_b, m, n, alpha, beta, lda_mul,
+                    ldb_mul, ldc_mul, success);
+    };
+    benchmark::RegisterBenchmark(
+        get_name<scalar_t>(ts_a, ts_b, m, n, alpha, beta, lda_mul, ldb_mul,
+                           ldc_mul)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, t_a, t_b, m, n, alpha, beta, lda_mul, ldb_mul,
+        ldc_mul, success)
+        ->UseRealTime();
+  }
+}
+
+namespace blas_benchmark {
+void create_benchmark(blas_benchmark::Args& args,
+                      blas::SB_Handle* sb_handle_ptr, bool* success) {
+  BLAS_REGISTER_BENCHMARK(args, sb_handle_ptr, success);
+}
+}  // namespace blas_benchmark

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -470,6 +470,7 @@ function(generate_blas_rotmg_objects blas_level func)
   add_sycl_to_target(TARGET ${func} SOURCES ${FUNC_SRC})
 endfunction(generate_blas_rotmg_objects)
 
+
 # blas gemm function for generating source code
 function(generate_blas_gemm_objects blas_level func)
 set(LOCATION "${SYCLBLAS_GENERATED_SRC}/${blas_level}/${func}/")
@@ -827,7 +828,8 @@ function (build_library LIB_NAME ENABLE_EXTENSIONS)
                 $<TARGET_OBJECTS:symm>
                 $<TARGET_OBJECTS:trsm>
                 $<TARGET_OBJECTS:matcopy>
-                $<TARGET_OBJECTS:transpose>)
+                $<TARGET_OBJECTS:transpose>
+                $<TARGET_OBJECTS:omatadd>)
 
   if (${ENABLE_EXTENSIONS})
     list(APPEND LIB_SRCS $<TARGET_OBJECTS:reduction>)

--- a/include/interface/extension_interface.h
+++ b/include/interface/extension_interface.h
@@ -67,6 +67,15 @@ typename sb_handle_t::event_t _matcopy(sb_handle_t& sb_handle, char trans,
                                        index_t inc_in, out_t out_memory,
                                        index_t ld_out, index_t inc_out);
 
+template <typename sb_handle_t, typename element_t, typename index_t,
+          typename container_t>
+typename sb_handle_t::event_t _omatadd(sb_handle_t& sb_handle, char trans_a,
+                                       char trans_b, index_t m, index_t n,
+                                       element_t alpha, container_t a,
+                                       index_t lda, element_t beta,
+                                       container_t b, index_t ldb,
+                                       container_t c, index_t ldc);
+
 template <bool in_place, typename element_t, typename sb_handle_t,
           typename index_t, typename in_t, typename out_t>
 typename sb_handle_t::event_t _transpose(sb_handle_t& sb_handle, index_t m,
@@ -88,6 +97,16 @@ typename sb_handle_t::event_t _transpose_outplace_impl(
     sb_handle_t& sb_handle, index_t _M, index_t _N, element_t _alpha,
     container_0_t in_, index_t _ld_in, index_t _inc_in, container_1_t out_,
     index_t _ld_out, index_t _inc_out);
+
+template <bool both_trans, int Tile_size, int wg_size, int cl_size,
+          bool local_memory, typename sb_handle_t, typename container_0_t,
+          typename container_1_t, typename container_2_t, typename element_t,
+          typename index_t>
+typename sb_handle_t::event_t _transpose_add_impl(
+    sb_handle_t& sb_handle, index_t _M, index_t _N, element_t _alpha,
+    container_0_t a_, index_t _lda, index_t _nrows_a, index_t _ncols_a,
+    element_t _beta, container_1_t b_, index_t _ldb, index_t _nrows_b,
+    index_t _ncols_b, container_2_t c_, index_t _ldc);
 
 }  // namespace internal
 
@@ -153,6 +172,39 @@ typename sb_handle_t::event_t _omatcopy2(sb_handle_t& sb_handle, char trans,
                                          index_t ld_out, index_t inc_out) {
   return internal::_matcopy<false>(sb_handle, trans, m, n, alpha, in_memory,
                                    ld_in, inc_in, out_memory, ld_out, inc_out);
+}
+
+/**
+ * \brief Computes scaled addition of two matrices A & B with or without
+ * transpose and copying results back to an output matrix C.
+ *
+ * @tparam sb_handle_t SB_Handle type
+ * @tparam element_t Undelying element data type of the matrix container
+ * @tparam index_t Index type
+ * @tparam container_t Inputs/Output Container Type
+ * @param trans_a Apply or not matrix transpose to A.
+ * @param trans_b Apply or not matrix transpose to B.
+ * @param m Number of rows in output matrix C
+ * @param n Number of columns in output matrix C
+ * @param alpha Scaling factor of matrix A
+ * @param A Container Input matrix A
+ * @param lda Matrix A leading dimension
+ * @param beta scaling factor of matrix B
+ * @param B Container Input matrix B
+ * @param ldb Matrix B leading dimension
+ * @param C Container Output matrix C
+ * @param ldc Matrix C leading dimension
+ */
+template <typename sb_handle_t, typename element_t, typename index_t,
+          typename container_t>
+typename sb_handle_t::event_t _omatadd(sb_handle_t& sb_handle, char trans_a,
+                                       char trans_b, index_t m, index_t n,
+                                       element_t alpha, container_t A,
+                                       index_t lda, element_t beta,
+                                       container_t B, index_t ldb,
+                                       container_t C, index_t ldc) {
+  return internal::_omatadd(sb_handle, trans_a, trans_b, m, n, alpha, A, lda,
+                            beta, B, ldb, C, ldc);
 }
 
 namespace extension {

--- a/include/operations/extension/transpose.h
+++ b/include/operations/extension/transpose.h
@@ -145,7 +145,11 @@ make_transpose(in_t &A, index_t inc_a, out_t &At, index_t inc_a_t,
  * while remaining customizable Tiling-size wise.
  *
  * @tparam both_trans Whether both A & B matrices are transposed (or just the
- * first one)
+ * first one A). In fact, this kernel is implemented in such a way that if
+ * only one matrix is transposed in the OmatAdd operator, it should be placed
+ * as the first operand to this kernel (A & alpha). This reduces the original 4
+ * possible combinations of A and B transpose cases into only two cases depicted
+ * by the template parameter both_trans.
  * @tparam Tile_size Tiling size used explicitly in the local memory kernel, and
  * used to compute work-group size in the non-local memory case.
  * @tparam wg_size work group size

--- a/include/operations/extension/transpose.h
+++ b/include/operations/extension/transpose.h
@@ -136,6 +136,112 @@ make_transpose(in_t &A, index_t inc_a, out_t &At, index_t inc_a_t,
                    out_t, element_t>(A, inc_a, At, inc_a_t, alpha);
 }
 
+/*!
+ * @brief This class holds the kernel for the transpose-scale-add used in
+ * omatadd operator.
+ *
+ * This templated class is designed to support omatadd when either one or both
+ * input matrices are transposed, with and without the use of local memory,
+ * while remaining customizable Tiling-size wise.
+ *
+ * @tparam both_trans Whether both A & B matrices are transposed (or just the
+ * first one)
+ * @tparam Tile_size Tiling size used explicitly in the local memory kernel, and
+ * used to compute work-group size in the non-local memory case.
+ * @tparam wg_size work group size
+ * @tparam cl_size cache line size
+ * @tparam local_memory Whether to use local memory
+ * @tparam in1_t The input matrix A type
+ * @tparam in2_t The input matrix B type
+ * @tparam out_t The output matrix C type
+ * @tparam element_t The scaling factor type
+ *
+ */
+template <bool both_trans, int Tile_size, int wg_size, int cl_size,
+          bool local_memory, typename in1_t, typename in2_t, typename out_t,
+          typename element_t>
+class TransposeAdd {
+ public:
+  using index_t = typename in1_t::index_t;
+  using value_t = element_t;
+  in1_t A_;
+  in2_t B_;
+  out_t C_;
+  index_t N_;
+  index_t M_;
+  value_t alpha_;
+  value_t beta_;
+  // Leading dimensions
+  index_t lda_;
+  index_t ldb_;
+  index_t ldc_;
+  // Minimum number of tiles used to cover output matrix rows & columns
+  index_t tile_count_m_;
+  index_t tile_count_n_;
+  // Inner WG Tiles
+  static constexpr const index_t inner_tile_size_ = wg_size / Tile_size;
+  static constexpr const index_t inner_tile_count_ =
+      Tile_size / inner_tile_size_;
+  // Minimum number of Tile-mutliple rows & columns to cover the output matrix
+  index_t M_pad_;
+  index_t N_pad_;
+  // Number of contiguous elements to be used in local memory to avoid bank
+  // conflicts
+  static constexpr index_t get_non_bank_conflict_line_size() {
+    return std::max(Tile_size, static_cast<int>(cl_size / sizeof(element_t)));
+  }
+  // The number of Tiles in a contiguous local memory line (used to avoid bank
+  // conflicts)
+  static constexpr index_t get_num_tiles_per_line() {
+    return get_non_bank_conflict_line_size() / Tile_size;
+  }
+
+  TransposeAdd(in1_t &A, in2_t &B, out_t &C, value_t &alpha, value_t &beta)
+      : A_(A),
+        B_(B),
+        C_(C),
+        lda_(A_.getSizeL()),
+        ldb_(B_.getSizeL()),
+        ldc_(C_.getSizeL()),
+        M_(C_.get_size_row()),
+        N_(C_.get_size_col()),
+        alpha_(alpha),
+        beta_(beta),
+        tile_count_m_((M_ - 1) / Tile_size + 1),
+        tile_count_n_((N_ - 1) / Tile_size + 1),
+        M_pad_(tile_count_m_ * Tile_size),
+        N_pad_(tile_count_n_ * Tile_size) {}
+
+  index_t get_size() const;
+
+  bool valid_thread(cl::sycl::nd_item<1> item) const;
+  void bind(cl::sycl::handler &cgh);
+  void adjust_access_displacement();
+  void eval(cl::sycl::nd_item<1> item);
+  template <typename local_memory_t>
+  void eval(local_memory_t local_mem, cl::sycl::nd_item<1> id);
+  void get_indices(cl::sycl::nd_item<1> id, index_t &in_a_idx,
+                   index_t &in_b_idx, index_t &in_local_idx, index_t &out_idx,
+                   index_t &out_local_idx, index_t &i_block_start,
+                   index_t &j_block_start, index_t &il, index_t &jl);
+  void get_indices(cl::sycl::nd_item<1> id, index_t &in_a_idx,
+                   index_t &in_b_idx, index_t &out_idx, index_t &i, index_t &j);
+};
+
+/*!
+ * @brief Generator/factory for Transpose-Add trees.
+ */
+template <bool both_trans, int Tile_size, int wg_size, int cl_size,
+          bool local_memory, typename in1_t, typename in2_t, typename out_t,
+          typename element_t>
+TransposeAdd<both_trans, Tile_size, wg_size, cl_size, local_memory, in1_t,
+             in2_t, out_t, element_t>
+make_transpose_add(in1_t &A, in2_t &B, out_t &C, element_t &alpha,
+                   element_t &beta) {
+  return TransposeAdd<both_trans, Tile_size, wg_size, cl_size, local_memory,
+                      in1_t, in2_t, out_t, element_t>(A, B, C, alpha, beta);
+}
+
 }  // namespace blas
 
 #endif  // SYCL_BLAS_EXTENSION_TRANSPOSE_H

--- a/src/interface/extension/CMakeLists.txt
+++ b/src/interface/extension/CMakeLists.txt
@@ -25,6 +25,7 @@
 
 generate_blas_unary_objects(extension matcopy)
 generate_blas_unary_objects(extension transpose)
+generate_blas_unary_objects(extension omatadd)
 generate_blas_reduction_objects(extension reduction)
 
 if(BLAS_ENABLE_CONST_INPUT)

--- a/src/interface/extension/backend/amd_gpu.hpp
+++ b/src/interface/extension/backend/amd_gpu.hpp
@@ -48,6 +48,25 @@ typename sb_handle_t::event_t _transpose_outplace(
   }
 }
 
+template <bool both_trans, typename sb_handle_t, typename container_0_t,
+          typename container_1_t, typename container_2_t, typename element_t,
+          typename index_t>
+typename sb_handle_t::event_t _transpose_add(
+    sb_handle_t& sb_handle, index_t _M, index_t _N, element_t _alpha,
+    container_0_t a_, index_t _ld_a, index_t _a_rows, index_t _a_cols,
+    element_t _beta, container_1_t b_, index_t _ld_b, index_t _b_rows,
+    index_t _b_cols, container_2_t c_, index_t _ld_c) {
+  if (_M * _N > (1 << 18)) {
+    return blas::internal::_transpose_add_impl<both_trans, 16, 256, 64, true>(
+        sb_handle, _M, _N, _alpha, a_, _ld_a, _a_rows, _a_cols, _beta, b_,
+        _ld_b, _b_rows, _b_cols, c_, _ld_c);
+  } else {
+    return blas::internal::_transpose_add_impl<both_trans, 16, 64, 64, true>(
+        sb_handle, _M, _N, _alpha, a_, _ld_a, _a_rows, _a_cols, _beta, b_,
+        _ld_b, _b_rows, _b_cols, c_, _ld_c);
+  }
+}
+
 }  // namespace backend
 }  // namespace transpose
 }  // namespace blas

--- a/src/interface/extension/backend/default_cpu.hpp
+++ b/src/interface/extension/backend/default_cpu.hpp
@@ -47,6 +47,25 @@ typename sb_handle_t::event_t _transpose_outplace(
   }
 }
 
+template <bool both_trans, typename sb_handle_t, typename container_0_t,
+          typename container_1_t, typename container_2_t, typename element_t,
+          typename index_t>
+typename sb_handle_t::event_t _transpose_add(
+    sb_handle_t& sb_handle, index_t _M, index_t _N, element_t _alpha,
+    container_0_t a_, index_t _ld_a, index_t _a_rows, index_t _a_cols,
+    element_t _beta, container_1_t b_, index_t _ld_b, index_t _b_rows,
+    index_t _b_cols, container_2_t c_, index_t _ld_c) {
+  if (_M * _N < (1 << 20)) {
+    return blas::internal::_transpose_add_impl<both_trans, 16, 64, 64, false>(
+        sb_handle, _M, _N, _alpha, a_, _ld_a, _a_rows, _a_cols, _beta, b_,
+        _ld_b, _b_rows, _b_cols, c_, _ld_c);
+  } else {
+    return blas::internal::_transpose_add_impl<both_trans, 32, 128, 64, false>(
+        sb_handle, _M, _N, _alpha, a_, _ld_a, _a_rows, _a_cols, _beta, b_,
+        _ld_b, _b_rows, _b_cols, c_, _ld_c);
+  }
+}
+
 }  // namespace backend
 }  // namespace transpose
 }  // namespace blas

--- a/src/interface/extension/backend/intel_gpu.hpp
+++ b/src/interface/extension/backend/intel_gpu.hpp
@@ -48,6 +48,25 @@ typename sb_handle_t::event_t _transpose_outplace(
   }
 }
 
+template <bool both_trans, typename sb_handle_t, typename container_0_t,
+          typename container_1_t, typename container_2_t, typename element_t,
+          typename index_t>
+typename sb_handle_t::event_t _transpose_add(
+    sb_handle_t& sb_handle, index_t _M, index_t _N, element_t _alpha,
+    container_0_t a_, index_t _ld_a, index_t _a_rows, index_t _a_cols,
+    element_t _beta, container_1_t b_, index_t _ld_b, index_t _b_rows,
+    index_t _b_cols, container_2_t c_, index_t _ld_c) {
+  if (_M * _N > (1 << 18)) {
+    return blas::internal::_transpose_add_impl<both_trans, 32, 256, 128, true>(
+        sb_handle, _M, _N, _alpha, a_, _ld_a, _a_rows, _a_cols, _beta, b_,
+        _ld_b, _b_rows, _b_cols, c_, _ld_c);
+  } else {
+    return blas::internal::_transpose_add_impl<both_trans, 16, 64, 64, true>(
+        sb_handle, _M, _N, _alpha, a_, _ld_a, _a_rows, _a_cols, _beta, b_,
+        _ld_b, _b_rows, _b_cols, c_, _ld_c);
+  }
+}
+
 }  // namespace backend
 }  // namespace transpose
 }  // namespace blas

--- a/src/interface/extension/backend/nvidia_gpu.hpp
+++ b/src/interface/extension/backend/nvidia_gpu.hpp
@@ -48,6 +48,25 @@ typename sb_handle_t::event_t _transpose_outplace(
   }
 }
 
+template <bool both_trans, typename sb_handle_t, typename container_0_t,
+          typename container_1_t, typename container_2_t, typename element_t,
+          typename index_t>
+typename sb_handle_t::event_t _transpose_add(
+    sb_handle_t& sb_handle, index_t _M, index_t _N, element_t _alpha,
+    container_0_t a_, index_t _ld_a, index_t _a_rows, index_t _a_cols,
+    element_t _beta, container_1_t b_, index_t _ld_b, index_t _b_rows,
+    index_t _b_cols, container_2_t c_, index_t _ld_c) {
+  if (_M * _N > (1 << 18)) {
+    return blas::internal::_transpose_add_impl<both_trans, 32, 512, 128, true>(
+        sb_handle, _M, _N, _alpha, a_, _ld_a, _a_rows, _a_cols, _beta, b_,
+        _ld_b, _b_rows, _b_cols, c_, _ld_c);
+  } else {
+    return blas::internal::_transpose_add_impl<both_trans, 32, 128, 128, true>(
+        sb_handle, _M, _N, _alpha, a_, _ld_a, _a_rows, _a_cols, _beta, b_,
+        _ld_b, _b_rows, _b_cols, c_, _ld_c);
+  }
+}
+
 }  // namespace backend
 }  // namespace transpose
 }  // namespace blas

--- a/src/interface/extension/omatadd.cpp.in
+++ b/src/interface/extension/omatadd.cpp.in
@@ -1,0 +1,41 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename omatadd.cpp.in
+ *
+ **************************************************************************/
+
+#include "interface/extension_interface.hpp"
+#include "sb_handle/kernel_constructor.hpp"
+#include "sb_handle/sycl_blas_handle.hpp"
+#include "operations/extension/transpose.hpp" 
+
+namespace blas {
+namespace internal {
+
+template typename SB_Handle::event_t _omatadd(
+    SB_Handle& sb_handle, char transA, char transB, ${INDEX_TYPE} m,
+    ${INDEX_TYPE} N, ${DATA_TYPE} alpha, ${container_t0} a,
+    ${INDEX_TYPE} lda, ${DATA_TYPE} beta, ${container_t0} b,
+    ${INDEX_TYPE} ldb, ${container_t0} C, ${INDEX_TYPE} ldc);
+
+}  // namespace internal
+}  // namespace blas

--- a/src/interface/extension_interface.hpp
+++ b/src/interface/extension_interface.hpp
@@ -106,6 +106,7 @@ _matcopy_impl(sb_handle_t& sb_handle, index_t m, index_t n, element_t alpha,
 
   } else {
     // TODO
+    // In-place transpose not implemented.
     typename sb_handle_t::event_t ret;
     return ret;
   }
@@ -175,7 +176,8 @@ typename sb_handle_t::event_t _transpose_add_impl(
   if constexpr (local_memory) {
     index_t local_mem = static_cast<index_t>((num_line_elems + 1) * Tile_size /
                                              num_tiles_per_line);
-    return sb_handle.execute(trans_scale_tree, static_cast<index_t>(wg_size), global_size, local_mem);
+    return sb_handle.execute(trans_scale_tree, static_cast<index_t>(wg_size),
+                             global_size, local_mem);
   } else {
     return sb_handle.execute(trans_scale_tree, static_cast<index_t>(wg_size),
                              global_size);

--- a/src/interface/extension_interface.hpp
+++ b/src/interface/extension_interface.hpp
@@ -354,9 +354,10 @@ typename sb_handle_t::event_t _omatadd(sb_handle_t& sb_handle, char trans_a,
                                         ldb, c, ldc);
     }
   } else if (trans_b == 't') {
-    // In this case, (alpha,a) & (beta,b) parameters positions are swapped as
-    // the kernel implementation assumes the first input matrix is the
-    // transposed one for simplicity purposes.
+    // In this case, (alpha,a) & (beta,b) operands are swapped as the
+    // kernel implementation assumes the first input matrix is the
+    // transposed one for code simplification purposes (Refer to transose.h
+    // for more details about this).
     return _omatadd_impl<true, false>(sb_handle, m, n, beta, b, ldb, alpha, a,
                                       lda, c, ldc);
   } else {

--- a/src/interface/extension_interface.hpp
+++ b/src/interface/extension_interface.hpp
@@ -175,7 +175,7 @@ typename sb_handle_t::event_t _transpose_add_impl(
   if constexpr (local_memory) {
     index_t local_mem = static_cast<index_t>((num_line_elems + 1) * Tile_size /
                                              num_tiles_per_line);
-    return sb_handle.execute(trans_scale_tree, wg_size, global_size, local_mem);
+    return sb_handle.execute(trans_scale_tree, static_cast<index_t>(wg_size), global_size, local_mem);
   } else {
     return sb_handle.execute(trans_scale_tree, static_cast<index_t>(wg_size),
                              global_size);

--- a/src/operations/extension/transpose.hpp
+++ b/src/operations/extension/transpose.hpp
@@ -215,6 +215,275 @@ Transpose<in_place, Tile_size, wg_size, cl_size, local_memory, in_t, out_t,
   }
 }
 
+// Transpose-Add
+template <bool both_trans, int Tile_size, int wg_size, int cl_size,
+          bool local_memory, typename in1_t, typename in2_t, typename out_t,
+          typename element_t>
+SYCL_BLAS_INLINE bool TransposeAdd<
+    both_trans, Tile_size, wg_size, cl_size, local_memory, in1_t, in2_t, out_t,
+    element_t>::valid_thread(cl::sycl::nd_item<1> item) const {
+  auto idx = item.get_global_linear_id();
+  return idx < get_size();
+}
+
+template <bool both_trans, int Tile_size, int wg_size, int cl_size,
+          bool local_memory, typename in1_t, typename in2_t, typename out_t,
+          typename element_t>
+SYCL_BLAS_INLINE void
+TransposeAdd<both_trans, Tile_size, wg_size, cl_size, local_memory, in1_t,
+             in2_t, out_t, element_t>::bind(cl::sycl::handler &cgh) {
+  A_.bind(cgh);
+  B_.bind(cgh);
+  C_.bind(cgh);
+}
+
+template <bool both_trans, int Tile_size, int wg_size, int cl_size,
+          bool local_memory, typename in1_t, typename in2_t, typename out_t,
+          typename element_t>
+SYCL_BLAS_INLINE typename in1_t::index_t
+TransposeAdd<both_trans, Tile_size, wg_size, cl_size, local_memory, in1_t,
+             in2_t, out_t, element_t>::get_size() const {
+  // Smallest TileSize square-multiple containing input/output matrices
+  return (M_pad_ * N_pad_);
+}
+
+template <bool both_trans, int Tile_size, int wg_size, int cl_size,
+          bool local_memory, typename in1_t, typename in2_t, typename out_t,
+          typename element_t>
+SYCL_BLAS_INLINE void
+TransposeAdd<both_trans, Tile_size, wg_size, cl_size, local_memory, in1_t,
+             in2_t, out_t, element_t>::adjust_access_displacement() {
+  A_.adjust_access_displacement();
+  B_.adjust_access_displacement();
+  C_.adjust_access_displacement();
+}
+
+/*!
+ *@brief get_indices. This function is used in the non-local memory kernel to
+ *compute global input & output indices.
+ *
+ * @param id [input] the cl::sycl::nd_item<1> of the current work_item
+ * @param in_a_idx [output] the input A global-memory index
+ * @param in_b_idx [output] the input B global-memory index
+ * @param out_idx [output] the output C global-memory index
+ * @param i [output] the global row-index (A & B when both_trans -> [0,N_], B &
+ *C otherwise -> [0,M_])
+ * @param j [output] the global col-index (A & B when both_trans -> [0,M_], B &
+ *C otherwise -> [0,N_])
+ */
+template <bool both_trans, int Tile_size, int wg_size, int cl_size,
+          bool local_memory, typename in1_t, typename in2_t, typename out_t,
+          typename element_t>
+SYCL_BLAS_INLINE void
+TransposeAdd<both_trans, Tile_size, wg_size, cl_size, local_memory, in1_t,
+             in2_t, out_t, element_t>::get_indices(cl::sycl::nd_item<1> id,
+                                                   index_t &in_a_idx,
+                                                   index_t &in_b_idx,
+                                                   index_t &out_idx, index_t &i,
+                                                   index_t &j) {
+  const index_t m_tiles = both_trans ? tile_count_n_ : tile_count_m_;
+
+  index_t idg = id.get_group(0);
+  index_t idc = id.get_local_id(0);
+
+  const index_t jg = idg / m_tiles;
+  const index_t ig = idg - jg * m_tiles;
+
+  const index_t jl = idc / Tile_size;
+  const index_t il = idc - jl * Tile_size;
+
+  const index_t i_block_start = ig * Tile_size;
+  const index_t j_block_start = jg * Tile_size;
+
+  i = i_block_start + il;
+  j = j_block_start + jl;
+
+  if constexpr (both_trans) {
+    in_a_idx = i_block_start + j_block_start * lda_ + il + jl * lda_;
+    in_b_idx = i_block_start + j_block_start * ldb_ + il + jl * ldb_;
+    out_idx = i_block_start * ldc_ + j_block_start + jl + il * ldc_;
+  } else {
+    in_a_idx = i_block_start * lda_ + j_block_start + jl + il * lda_;
+    in_b_idx = i_block_start + j_block_start * ldb_ + il + jl * ldb_;
+    out_idx = i_block_start + j_block_start * ldc_ + il + jl * ldc_;
+  }
+}
+
+template <bool both_trans, int Tile_size, int wg_size, int cl_size,
+          bool local_memory, typename in1_t, typename in2_t, typename out_t,
+          typename element_t>
+SYCL_BLAS_INLINE void
+TransposeAdd<both_trans, Tile_size, wg_size, cl_size, local_memory, in1_t,
+             in2_t, out_t, element_t>::eval(cl::sycl::nd_item<1> id) {
+  auto A = A_.get_data().get_pointer();
+  auto B = B_.get_data().get_pointer();
+  auto C = C_.get_data().get_pointer();
+  index_t in_a_index, in_b_index, out_index, i_id, j_id;
+
+  get_indices(id, in_a_index, in_b_index, out_index, i_id, j_id);
+
+  if constexpr (both_trans) {
+    if (i_id < N_) {
+      for (index_t l = 0; l < inner_tile_count_; l++) {
+        if (j_id + l * inner_tile_size_ < M_) {
+          auto temp_sum = alpha_ * A[in_a_index + l * inner_tile_size_ * lda_] +
+                          beta_ * B[in_b_index + l * inner_tile_size_ * ldb_];
+          C[out_index + l * inner_tile_size_] = temp_sum;
+        }
+      }
+    }
+  } else {
+    if (i_id < M_) {
+      for (index_t l = 0; l < inner_tile_count_; l++) {
+        if (j_id + l * inner_tile_size_ < N_) {
+          auto temp_sum = alpha_ * A[in_a_index + l * inner_tile_size_] +
+                          beta_ * B[in_b_index + l * inner_tile_size_ * ldb_];
+          C[out_index + l * inner_tile_size_ * ldc_] = temp_sum;
+        }
+      }
+    }
+  }
+}
+
+/*!
+ *@brief get_indices. This function is used in the local-memory kernel to
+ *compute local & global input & output indices.
+ *
+ * @param id [input] the sycl::nd_item<1> of the current work_item
+ * @param in_a_idx [output] the global index for input matrix A
+ * @param in_b_idx [output] the global index for input matrix B
+ * @param out_idx [output] the output global index
+ * @param in_local_idx [output] the input local-memory index
+ * @param out_local_idx [output] the output local-memory index
+ * @param i_block_start [output] the input global memory block row-index
+ * @param j_block_start [output] the input global memory block col-index
+ * @param il [output] the local row-index
+ * @param jl [output] the local col-index
+ *
+ */
+template <bool both_trans, int Tile_size, int wg_size, int cl_size,
+          bool local_memory, typename in1_t, typename in2_t, typename out_t,
+          typename element_t>
+SYCL_BLAS_INLINE void TransposeAdd<
+    both_trans, Tile_size, wg_size, cl_size, local_memory, in1_t, in2_t, out_t,
+    element_t>::get_indices(cl::sycl::nd_item<1> id, index_t &in_a_idx,
+                            index_t &in_b_idx, index_t &in_local_idx,
+                            index_t &out_idx, index_t &out_local_idx,
+                            index_t &i_block_start, index_t &j_block_start,
+                            index_t &il, index_t &jl) {
+  const index_t m_tiles = both_trans ? tile_count_n_ : tile_count_m_;
+
+  index_t idg = id.get_group(0);
+  index_t idc = id.get_local_id(0);
+
+  const index_t jg = idg / m_tiles;
+  const index_t ig = idg - jg * m_tiles;
+
+  jl = idc / Tile_size;
+  il = idc - jl * Tile_size;
+
+  i_block_start = ig * Tile_size;
+  j_block_start = jg * Tile_size;
+
+  index_t jl_cl = idc / get_non_bank_conflict_line_size();
+  index_t il_cl = idc - jl_cl * get_non_bank_conflict_line_size();
+
+  if constexpr (both_trans) {
+    in_a_idx = i_block_start + j_block_start * lda_ + il + jl * lda_;
+    out_idx = i_block_start * ldc_ + j_block_start + il + jl * ldc_;
+
+  } else {
+    in_a_idx = j_block_start + i_block_start * lda_ + il + jl * lda_;
+    out_idx = i_block_start + j_block_start * ldc_ + il + jl * ldc_;
+  }
+
+  in_b_idx = i_block_start + j_block_start * ldb_ + il + jl * ldb_;
+
+  in_local_idx = jl_cl * (get_non_bank_conflict_line_size() + 1) + il_cl;
+
+  out_local_idx = il * Tile_size + jl + il / get_num_tiles_per_line();
+}
+
+template <bool both_trans, int Tile_size, int wg_size, int cl_size,
+          bool local_memory, typename in1_t, typename in2_t, typename out_t,
+          typename element_t>
+template <typename local_memory_t>
+SYCL_BLAS_INLINE void
+TransposeAdd<both_trans, Tile_size, wg_size, cl_size, local_memory, in1_t,
+             in2_t, out_t, element_t>::eval(local_memory_t local_mem,
+                                            cl::sycl::nd_item<1> id) {
+  value_t *local = local_mem.localAcc.get_pointer();
+
+  auto A = A_.get_data().get_pointer();
+  auto B = B_.get_data().get_pointer();
+  auto C = C_.get_data().get_pointer();
+
+  index_t in_a_idx, in_b_idx, in_local_id, out_idx, out_local_id;
+  index_t i_block_start, j_block_start;
+  index_t il, jl;
+
+  if constexpr (both_trans) {
+    get_indices(id, in_a_idx, in_b_idx, in_local_id, out_idx, out_local_id,
+                i_block_start, j_block_start, il, jl);
+
+    if (i_block_start + il < N_) {
+      // Compute & Copy sum/scaled input to local memory (before transpose)
+      for (index_t l = 0; l < inner_tile_count_; l++) {
+        if (j_block_start + jl + l * inner_tile_size_ < M_) {
+          // Compute & Copy sum/scaled input to local memory (before transpose)
+          local[in_local_id +
+                l * (get_non_bank_conflict_line_size() + 1) *
+                    (inner_tile_size_ / get_num_tiles_per_line())] =
+              alpha_ * A[in_a_idx + l * inner_tile_size_ * lda_] +
+              beta_ * B[in_b_idx + l * inner_tile_size_ * ldb_];
+        }
+      }
+    }
+
+    id.barrier(cl::sycl::access::fence_space::local_space);
+
+    // Transposed copy of previous output from local memory
+    if (j_block_start + il < M_) {
+      for (index_t l = 0; l < inner_tile_count_; l++) {
+        if (i_block_start + jl + l * inner_tile_size_ < N_) {
+          C[out_idx + l * inner_tile_size_ * ldc_] =
+              local[out_local_id + l * inner_tile_size_];
+        }
+      }
+    }
+
+  } else {
+    get_indices(id, in_a_idx, in_b_idx, in_local_id, out_idx, out_local_id,
+                i_block_start, j_block_start, il, jl);
+
+    if (j_block_start + il < N_) {
+      for (index_t l = 0; l < inner_tile_count_; l++) {
+        if (i_block_start + jl + l * inner_tile_size_ < M_) {
+          // Compute & Copy sum/scaled input to local memory (before transpose)
+          local[in_local_id +
+                l * (get_non_bank_conflict_line_size() + 1) *
+                    (inner_tile_size_ / get_num_tiles_per_line())] =
+              alpha_ * A[in_a_idx + l * inner_tile_size_ * lda_];
+        }
+      }
+    }
+
+    id.barrier(cl::sycl::access::fence_space::local_space);
+
+    // Transposed copy of previous output from local memory and scaled addition
+    // with 2nd non transposed matrix B
+    if (i_block_start + il < M_) {
+      for (index_t l = 0; l < inner_tile_count_; l++) {
+        if (j_block_start + jl + l * inner_tile_size_ < N_) {
+          C[out_idx + l * inner_tile_size_ * ldc_] =
+              local[out_local_id + l * inner_tile_size_] +
+              beta_ * B[in_b_idx + l * inner_tile_size_ * ldb_];
+        }
+      }
+    }
+  }
+}
+
 }  // namespace blas
 
 #endif  // SYCL_BLAS_EXTENSION_TRANSPOSE_HPP

--- a/src/operations/extension/transpose.hpp
+++ b/src/operations/extension/transpose.hpp
@@ -414,9 +414,9 @@ TransposeAdd<both_trans, Tile_size, wg_size, cl_size, local_memory, in1_t,
                                             cl::sycl::nd_item<1> id) {
   value_t *local = local_mem.localAcc.get_pointer();
 
-  auto A = A_.get_data().get_pointer();
-  auto B = B_.get_data().get_pointer();
-  auto C = C_.get_data().get_pointer();
+  auto A = A_.get_pointer();
+  auto B = B_.get_pointer();
+  auto C = C_.get_pointer();
 
   index_t in_a_idx, in_b_idx, in_local_id, out_idx, out_local_id;
   index_t i_block_start, j_block_start;

--- a/src/operations/extension/transpose.hpp
+++ b/src/operations/extension/transpose.hpp
@@ -315,9 +315,9 @@ template <bool both_trans, int Tile_size, int wg_size, int cl_size,
 SYCL_BLAS_INLINE void
 TransposeAdd<both_trans, Tile_size, wg_size, cl_size, local_memory, in1_t,
              in2_t, out_t, element_t>::eval(cl::sycl::nd_item<1> id) {
-  auto A = A_.get_data().get_pointer();
-  auto B = B_.get_data().get_pointer();
-  auto C = C_.get_data().get_pointer();
+  auto A = A_.get_pointer();
+  auto B = B_.get_pointer();
+  auto C = C_.get_pointer();
   index_t in_a_index, in_b_index, out_index, i_id, j_id;
 
   get_indices(id, in_a_index, in_b_index, out_index, i_id, j_id);

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SYCL_UNITTEST_SRCS
   # Blas extension
   ${SYCLBLAS_UNITTEST}/extension/omatcopy_test.cpp
   ${SYCLBLAS_UNITTEST}/extension/omatcopy2_test.cpp
+  ${SYCLBLAS_UNITTEST}/extension/omatadd_test.cpp
 )
 
 if(${BLAS_ENABLE_EXTENSIONS})

--- a/test/unittest/extension/extension_reference.hpp
+++ b/test/unittest/extension/extension_reference.hpp
@@ -139,40 +139,12 @@ void ext_omatadd(char transa, char transb, index_t m, index_t n, scalar_t alpha,
                  std::vector<scalar_t>& A, index_t lda, scalar_t beta,
                  std::vector<scalar_t>& B, index_t ldb,
                  std::vector<scalar_t>& C, index_t ldc) {
-  for (index_t j = 0; j < n; j++) {
-    for (index_t i = 0; i < m; i++) {
-      C[j * ldc + i] = 0.0;
-    }
-  }
-  if (transa != 't') {
-    for (index_t j = 0; j < n; j++) {
-      for (index_t i = 0; i < m; i++) {
-        C[j * ldc + i] += alpha * A[j * lda + i];
-      }
-    }
-
-  } else {
-    for (index_t j = 0; j < n; j++) {
-      for (index_t i = 0; i < m; i++) {
-        C[j * ldc + i] += alpha * A[i * lda + j];
-      }
-    }
-  }
-
-  if (transb != 't') {
-    for (index_t j = 0; j < n; j++) {
-      for (index_t i = 0; i < m; i++) {
-        C[j * ldc + i] += beta * B[j * ldb + i];
-      }
-    }
-
-  } else {
-    for (index_t j = 0; j < n; j++) {
-      for (index_t i = 0; i < m; i++) {
-        C[j * ldc + i] += beta * B[i * ldb + j];
-      }
-    }
-  }
+   for (index_t j = 0; j < n; j++) {
+     for (index_t i = 0; i < m; i++) {
+       C[j * ldc + i] = alpha * A[(transa != 't') ? j * lda + i : i * lda + j] +
+                        beta * B[(transb != 't') ? j * ldb + i : i * ldb + j];
+     }
+   }
 }
 
 }  // namespace reference_blas

--- a/test/unittest/extension/extension_reference.hpp
+++ b/test/unittest/extension/extension_reference.hpp
@@ -116,6 +116,65 @@ void Transpose(const T* in, const index_t& ld_in, T* out, const index_t& ld_out,
   }
 }
 
+/**
+ * @brief Reference omatadd implementation using reference omatcopy.
+ *
+ * @param trans_a (char) 'n' or 't' corresponding to non-transposed or
+ * transposed matrix A respectively.
+ * @param trans_b (char) 'n' or 't' corresponding to non-transposed or
+ * transposed matrix B respectively.
+ * @param m Number of rows in output matrix C
+ * @param n Number of columns in output matrix C
+ * @param alpha Scaling factor of matrix A
+ * @param A (vector) Input matrix A
+ * @param lda_m Matrix A leading dimension multiplier. (lda = lda_m * A_rows)
+ * @param beta scaling factor of matrix B
+ * @param B (vector) Input matrix B
+ * @param ldb_m Matrix B leading dimension multiplier. (ldb = ldb_m * B_rows)
+ * @param C (vector) Output matrix C
+ * @param ldc_m Matrix C leading dimension multiplier. (ldc = ldc_m * C_rows)
+ */
+template <typename index_t, typename scalar_t>
+void ext_omatadd(char transa, char transb, index_t m, index_t n, scalar_t alpha,
+                 std::vector<scalar_t>& A, index_t lda, scalar_t beta,
+                 std::vector<scalar_t>& B, index_t ldb,
+                 std::vector<scalar_t>& C, index_t ldc) {
+  for (index_t j = 0; j < n; j++) {
+    for (index_t i = 0; i < m; i++) {
+      C[j * ldc + i] = 0.0;
+    }
+  }
+  if (transa != 't') {
+    for (index_t j = 0; j < n; j++) {
+      for (index_t i = 0; i < m; i++) {
+        C[j * ldc + i] += alpha * A[j * lda + i];
+      }
+    }
+
+  } else {
+    for (index_t j = 0; j < n; j++) {
+      for (index_t i = 0; i < m; i++) {
+        C[j * ldc + i] += alpha * A[i * lda + j];
+      }
+    }
+  }
+
+  if (transb != 't') {
+    for (index_t j = 0; j < n; j++) {
+      for (index_t i = 0; i < m; i++) {
+        C[j * ldc + i] += beta * B[j * ldb + i];
+      }
+    }
+
+  } else {
+    for (index_t j = 0; j < n; j++) {
+      for (index_t i = 0; i < m; i++) {
+        C[j * ldc + i] += beta * B[i * ldb + j];
+      }
+    }
+  }
+}
+
 }  // namespace reference_blas
 
 #endif

--- a/test/unittest/extension/extension_reference.hpp
+++ b/test/unittest/extension/extension_reference.hpp
@@ -139,12 +139,12 @@ void ext_omatadd(char transa, char transb, index_t m, index_t n, scalar_t alpha,
                  std::vector<scalar_t>& A, index_t lda, scalar_t beta,
                  std::vector<scalar_t>& B, index_t ldb,
                  std::vector<scalar_t>& C, index_t ldc) {
-   for (index_t j = 0; j < n; j++) {
-     for (index_t i = 0; i < m; i++) {
-       C[j * ldc + i] = alpha * A[(transa != 't') ? j * lda + i : i * lda + j] +
-                        beta * B[(transb != 't') ? j * ldb + i : i * ldb + j];
-     }
-   }
+  for (index_t j = 0; j < n; j++) {
+    for (index_t i = 0; i < m; i++) {
+      C[j * ldc + i] = alpha * A[(transa != 't') ? j * lda + i : i * lda + j] +
+                       beta * B[(transb != 't') ? j * ldb + i : i * ldb + j];
+    }
+  }
 }
 
 }  // namespace reference_blas

--- a/test/unittest/extension/omatadd_test.cpp
+++ b/test/unittest/extension/omatadd_test.cpp
@@ -1,0 +1,119 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename omatadd_test.cpp
+ *
+ **************************************************************************/
+
+#include "blas_test.hpp"
+#include "extension_reference.hpp"
+
+template <typename scalar_t>
+using combination_t = std::tuple<char, char, index_t, index_t, scalar_t,
+                                 scalar_t, index_t, index_t, index_t>;
+
+template <typename scalar_t>
+void run_test(const combination_t<scalar_t> combi) {
+  char trans_a, trans_b;
+  index_t m, n, ld_a_mul, ld_b_mul, ld_c_mul;
+  scalar_t alpha, beta;
+
+  std::tie(trans_a, trans_b, m, n, alpha, beta, ld_a_mul, ld_b_mul, ld_c_mul) =
+      combi;
+
+  auto q = make_queue();
+  blas::SB_Handle sb_handle(q);
+
+  index_t base_size = m * n;
+
+  std::vector<scalar_t> A(base_size * ld_a_mul);
+  std::vector<scalar_t> B(base_size * ld_b_mul);
+  std::vector<scalar_t> C(base_size * ld_c_mul, (scalar_t)0);
+
+  fill_random(A);
+  fill_random(B);
+
+  std::vector<scalar_t> C_ref = C;
+
+  const index_t lda = (trans_a == 'n') ? m * ld_a_mul : n * ld_a_mul;
+  const index_t ldb = (trans_b == 'n') ? m * ld_b_mul : n * ld_b_mul;
+  const index_t ldc = m * ld_c_mul;
+
+  // Reference implementation
+  reference_blas::ext_omatadd(trans_a, trans_b, m, n, alpha, A, lda, beta, B,
+                              ldb, C_ref, ldc);
+
+  auto m_a_gpu =
+      blas::make_sycl_iterator_buffer<scalar_t>(A, base_size * ld_a_mul);
+  auto m_b_gpu =
+      blas::make_sycl_iterator_buffer<scalar_t>(B, base_size * ld_b_mul);
+  auto m_c_gpu =
+      blas::make_sycl_iterator_buffer<scalar_t>(C, base_size * ld_c_mul);
+
+  blas::_omatadd(sb_handle, trans_a, trans_b, m, n, alpha, m_a_gpu, lda, beta,
+                 m_b_gpu, ldb, m_c_gpu, ldc);
+
+  auto event = blas::helper::copy_to_host<scalar_t>(
+      sb_handle.get_queue(), m_c_gpu, C.data(), base_size * ld_c_mul);
+  sb_handle.wait(event);
+
+  // Validate the result
+  const bool isAlmostEqual = utils::compare_vectors(C, C_ref);
+  ASSERT_TRUE(isAlmostEqual);
+}
+
+#ifdef STRESS_TESTING
+template <typename scalar_t>
+const auto combi =
+    ::testing::Combine(::testing::Values<char>('n', 't'),  // trans_a
+                       ::testing::Values<char>('n', 't'),  // trans_b
+                       ::testing::Values<index_t>(1024, 4050, 16380),  // m
+                       ::testing::Values<index_t>(1024, 4050, 16380),  // n
+                       ::testing::Values<scalar_t>(0, 1.05, 2.01),     // alpha
+                       ::testing::Values<scalar_t>(0, 1.05, 2.01),     // beta
+                       ::testing::Values<index_t>(1, 2),      // lda_mul
+                       ::testing::Values<index_t>(1, 2),      // ldb_mul
+                       ::testing::Values<index_t>(1, 2, 3),   // ldc_mul
+#else
+template <typename scalar_t>
+const auto combi =
+    ::testing::Combine(::testing::Values<char>('n', 't'),         // trans_a
+                       ::testing::Values<char>('n', 't'),         // trans_b
+                       ::testing::Values<index_t>(64, 129, 255),  // m
+                       ::testing::Values<index_t>(64, 129, 255),  // n
+                       ::testing::Values<scalar_t>(0, 1, 2),      // alpha
+                       ::testing::Values<scalar_t>(0, 1, 2),      // beta
+                       ::testing::Values<index_t>(1, 2),          // lda_mul
+                       ::testing::Values<index_t>(1, 2),          // ldb_mul
+                       ::testing::Values<index_t>(1, 2, 3));      // ldc_mul
+#endif
+
+template <class T>
+static std::string generate_name(
+    const ::testing::TestParamInfo<combination_t<T>> &info) {
+  char trans_a, trans_b;
+  index_t m, n, lda_mul, ldb_mul, ldc_mul;
+  T alpha, beta;
+  BLAS_GENERATE_NAME(info.param, trans_a, trans_b, m, n, alpha, beta, lda_mul,
+                     ldb_mul, ldc_mul);
+}
+
+BLAS_REGISTER_TEST_ALL(OmatAdd, combination_t, combi, generate_name);


### PR DESCRIPTION
This PR builds upon the OmatCopy & OmatCopy2 [PR](https://github.com/codeplaysoftware/sycl-blas/pull/428) by adding support to OmatAdd as a separate operator with a separate implementation of its transpose kernel(s). 
OneMKL Specification used as reference for the interface & implementation : [Link](https://spec.oneapi.io/versions/latest/elements/oneMKL/source/domains/blas/omatadd.html#onemkl-blas-omatadd)  

Co-Author : @s-Nick 