### PR TITLE
Refactor get_name for BLAS Level 1 benchmarks

### DIFF
--- a/benchmark/cublas/blas1/asum.cpp
+++ b/benchmark/cublas/blas1/asum.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Asum<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::asum;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -140,8 +135,9 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t size, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 cuda_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas1/asum.cpp
+++ b/benchmark/cublas/blas1/asum.cpp
@@ -136,7 +136,9 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas1/axpy.cpp
+++ b/benchmark/cublas/blas1/axpy.cpp
@@ -135,7 +135,9 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas1/axpy.cpp
+++ b/benchmark/cublas/blas1/axpy.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Axpy<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::axpy;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -50,8 +45,8 @@ void run(benchmark::State& state, cublasHandle_t* cuda_handle_ptr, index_t size,
   blas_benchmark::utils::set_benchmark_label<scalar_t>(state);
 
   // init Google-benchmark counters.
-  blas_benchmark::utils::init_level_1_counters<
-      blas_benchmark::utils::Level1Op::axpy, scalar_t>(state, size);
+  blas_benchmark::utils::init_level_1_counters<benchmark_op, scalar_t>(state,
+                                                                       size);
 
   cublasHandle_t& cuda_handle = *cuda_handle_ptr;
 
@@ -139,8 +134,9 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t size, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 cuda_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas1/dot.cpp
+++ b/benchmark/cublas/blas1/dot.cpp
@@ -137,7 +137,9 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas1/dot.cpp
+++ b/benchmark/cublas/blas1/dot.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Dot<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::dot;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -141,8 +136,9 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t size, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 cuda_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas1/iamax.cpp
+++ b/benchmark/cublas/blas1/iamax.cpp
@@ -143,7 +143,9 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas1/iamax.cpp
+++ b/benchmark/cublas/blas1/iamax.cpp
@@ -26,13 +26,8 @@
 #include "../utils.hpp"
 #include "common/common_utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Iamax<" << blas_benchmark::utils::get_type_name<scalar_t>();
-  str << ">/" << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::iamax;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -147,8 +142,9 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t size, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 cuda_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas1/iamin.cpp
+++ b/benchmark/cublas/blas1/iamin.cpp
@@ -26,13 +26,8 @@
 #include "../utils.hpp"
 #include "common/common_utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Iamin<" << blas_benchmark::utils::get_type_name<scalar_t>();
-  str << ">/" << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::iamin;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -146,8 +141,9 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t size, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 cuda_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas1/iamin.cpp
+++ b/benchmark/cublas/blas1/iamin.cpp
@@ -142,7 +142,9 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas1/nrm2.cpp
+++ b/benchmark/cublas/blas1/nrm2.cpp
@@ -26,13 +26,8 @@
 #include "../utils.hpp"
 #include <type_traits>
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Nrm2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::nrm2;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -141,8 +136,9 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t size, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 cuda_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas1/nrm2.cpp
+++ b/benchmark/cublas/blas1/nrm2.cpp
@@ -137,7 +137,9 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas1/rotg.cpp
+++ b/benchmark/cublas/blas1/rotg.cpp
@@ -155,7 +155,9 @@ void register_benchmark(blas_benchmark::Args& args,
     run<scalar_t>(st, cuda_handle_ptr, success);
   };
   benchmark::RegisterBenchmark(
-      blas_benchmark::utils::get_name<benchmark_op, scalar_t>().c_str(),
+      blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+          blas_benchmark::utils::MEM_TYPE_USM)
+          .c_str(),
       BM_lambda, cuda_handle_ptr, success)
       ->UseRealTime();
 }

--- a/benchmark/cublas/blas1/rotg.cpp
+++ b/benchmark/cublas/blas1/rotg.cpp
@@ -25,12 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name() {
-  std::ostringstream str{};
-  str << "BM_Rotg<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::rotg;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -158,8 +154,9 @@ void register_benchmark(blas_benchmark::Args& args,
                        bool* success) {
     run<scalar_t>(st, cuda_handle_ptr, success);
   };
-  benchmark::RegisterBenchmark(get_name<scalar_t>().c_str(), BM_lambda,
-                               cuda_handle_ptr, success)
+  benchmark::RegisterBenchmark(
+      blas_benchmark::utils::get_name<benchmark_op, scalar_t>().c_str(),
+      BM_lambda, cuda_handle_ptr, success)
       ->UseRealTime();
 }
 

--- a/benchmark/cublas/blas1/rotm.cpp
+++ b/benchmark/cublas/blas1/rotm.cpp
@@ -156,7 +156,9 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas1/rotm.cpp
+++ b/benchmark/cublas/blas1/rotm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Rotm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::rotm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -160,8 +155,9 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t size, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 cuda_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas1/rotmg.cpp
+++ b/benchmark/cublas/blas1/rotmg.cpp
@@ -26,13 +26,8 @@
 #include "../utils.hpp"
 #include "common/float_comparison.hpp"
 
-template <typename scalar_t>
-std::string get_name() {
-  std::ostringstream str{};
-  str << "BM_Rotmg<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/";
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::rotmg;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,8 +159,9 @@ void register_benchmark(blas_benchmark::Args& args,
                        bool* success) {
     run<scalar_t>(st, cuda_handle_ptr, success);
   };
-  benchmark::RegisterBenchmark(get_name<scalar_t>().c_str(), BM_lambda,
-                               cuda_handle_ptr, success)
+  benchmark::RegisterBenchmark(
+      blas_benchmark::utils::get_name<benchmark_op, scalar_t>().c_str(),
+      BM_lambda, cuda_handle_ptr, success)
       ->UseRealTime();
 }
 

--- a/benchmark/cublas/blas1/rotmg.cpp
+++ b/benchmark/cublas/blas1/rotmg.cpp
@@ -160,7 +160,9 @@ void register_benchmark(blas_benchmark::Args& args,
     run<scalar_t>(st, cuda_handle_ptr, success);
   };
   benchmark::RegisterBenchmark(
-      blas_benchmark::utils::get_name<benchmark_op, scalar_t>().c_str(),
+      blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+          blas_benchmark::utils::MEM_TYPE_USM)
+          .c_str(),
       BM_lambda, cuda_handle_ptr, success)
       ->UseRealTime();
 }

--- a/benchmark/cublas/blas1/scal.cpp
+++ b/benchmark/cublas/blas1/scal.cpp
@@ -134,7 +134,9 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas1/scal.cpp
+++ b/benchmark/cublas/blas1/scal.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Scal<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::scal;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -138,8 +133,9 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t size, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 cuda_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/gbmv.cpp
+++ b/benchmark/cublas/blas2/gbmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t, int m, int n, int kl, int ku) {
-  std::ostringstream str{};
-  str << "BM_Gbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n << "/" << kl << "/" << ku;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::gbmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -166,9 +161,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, t, m, n, kl, ku, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n, kl, ku).c_str(),
-                                 BM_lambda, cuda_handle_ptr, t, m, n, kl, ku,
-                                 alpha, beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            ts, m, n, kl, ku, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, t, m, n, kl, ku, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/gemv.cpp
+++ b/benchmark/cublas/blas2/gemv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::gemv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,9 +159,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t beta, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, t, m, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n).c_str(),
-                                 BM_lambda, cuda_handle_ptr, t, m, n, alpha,
-                                 beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            ts, m, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, t, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/ger.cpp
+++ b/benchmark/cublas/blas2/ger.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Ger<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::ger;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -158,8 +153,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t m, index_t n, scalar_t alpha, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, m, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(m, n).c_str(), BM_lambda,
-                                 cuda_handle_ptr, m, n, alpha, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            m, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/sbmv.cpp
+++ b/benchmark/cublas/blas2/sbmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, int k) {
-  std::ostringstream str{};
-  str << "BM_Sbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::sbmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,9 +159,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, uplos, n, k, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplos, n, k).c_str(),
-                                 BM_lambda, cuda_handle_ptr, uplos, n, k, alpha,
-                                 beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, k, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/spmv.cpp
+++ b/benchmark/cublas/blas2/spmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha, scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Spmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha << "/" << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -163,8 +158,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, n, alpha, beta).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, n, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/spr.cpp
+++ b/benchmark/cublas/blas2/spr.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, int n, scalar_t alpha, int incX) {
-  std::ostringstream str{};
-  str << "BM_Spr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha << "/" << incX;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spr;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -157,8 +152,10 @@ void register_benchmark(blas_benchmark::Args& args,
           run<scalar_t>(st, cuda_handle_ptr, uplo, n, alpha, incX, success);
         };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo_c, n, alpha, incX).c_str(), BM_lambda_col,
-        cuda_handle_ptr, uplo_c, n, alpha, incX, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo_c, n, alpha, incX, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda_col, cuda_handle_ptr, uplo_c, n, alpha, incX, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/spr.cpp
+++ b/benchmark/cublas/blas2/spr.cpp
@@ -153,7 +153,7 @@ void register_benchmark(blas_benchmark::Args& args,
         };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            uplo_c, n, alpha, incX, blas_benchmark::utils::MEM_TYPE_USM)
+            uplo, n, alpha, incX, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda_col, cuda_handle_ptr, uplo_c, n, alpha, incX, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/spr2.cpp
+++ b/benchmark/cublas/blas2/spr2.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, int size, scalar_t alpha, int incX, int incY) {
-  std::ostringstream str{};
-  str << "BM_Spr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << size << "/" << alpha << "/" << incX << "/" << incY;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spr2;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -160,8 +155,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplo, n, alpha, incX, incY, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo_c, n, alpha, incX, incY).c_str(), BM_lambda_col,
-        cuda_handle_ptr, uplo_c, n, alpha, incX, incY, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo_c, n, alpha, incX, incY, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda_col, cuda_handle_ptr, uplo_c, n, alpha, incX, incY, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/spr2.cpp
+++ b/benchmark/cublas/blas2/spr2.cpp
@@ -156,7 +156,7 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            uplo_c, n, alpha, incX, incY, blas_benchmark::utils::MEM_TYPE_USM)
+            uplo, n, alpha, incX, incY, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda_col, cuda_handle_ptr, uplo_c, n, alpha, incX, incY, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/symv.cpp
+++ b/benchmark/cublas/blas2/symv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha, scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Symv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha << "/" << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::symv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -165,8 +160,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, n, alpha, beta).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, n, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/syr.cpp
+++ b/benchmark/cublas/blas2/syr.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha) {
-  std::ostringstream str{};
-  str << "BM_Syr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::syr;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -156,9 +151,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, uplo, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, alpha).c_str(),
-                                 BM_lambda, cuda_handle_ptr, uplo, n, alpha,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, alpha, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplo, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/syr2.cpp
+++ b/benchmark/cublas/blas2/syr2.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha) {
-  std::ostringstream str{};
-  str << "BM_Syr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::syr2;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -165,9 +160,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, uplo, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, alpha).c_str(),
-                                 BM_lambda, cuda_handle_ptr, uplo, n, alpha,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, alpha, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplo, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/tbmv.cpp
+++ b/benchmark/cublas/blas2/tbmv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n,
-                     int k) {
-  std::ostringstream str{};
-  str << "BM_Tbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tbmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -167,8 +161,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, ts, diags, n, k, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, k, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, k, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/tbsv.cpp
+++ b/benchmark/cublas/blas2/tbsv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag,
-                     const int n, const int k) {
-  std::ostringstream str{};
-  str << "BM_Tbsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tbsv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -177,8 +171,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, ts, diags, n, k, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, k, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, k, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/tpmv.cpp
+++ b/benchmark/cublas/blas2/tpmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Tpmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tpmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,8 +159,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/tpsv.cpp
+++ b/benchmark/cublas/blas2/tpsv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Tpsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tpsv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -175,8 +170,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/trmv.cpp
+++ b/benchmark/cublas/blas2/trmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Trmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::trmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -177,8 +172,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/trsv.cpp
+++ b/benchmark/cublas/blas2/trsv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Trsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::trsv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -173,8 +168,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas3/gemm.cpp
+++ b/benchmark/cublas/blas3/gemm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,9 +159,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(t1s, t2s, m, k, n).c_str(),
-                                 BM_lambda, cuda_handle_ptr, t1, t2, m, k, n,
-                                 alpha, beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas3/gemm_batched.cpp
+++ b/benchmark/cublas/blas3/gemm_batched.cpp
@@ -25,16 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_count, int batch_type) {
-  std::ostringstream str{};
-  str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
-      << batch_count << "/"
-      << blas_benchmark::utils::batch_type_to_str(batch_type);
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -207,7 +199,10 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_count, batch_type, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_count, batch_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, batch_count, batch_type,
+            blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_count,
         batch_type, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/cublas/blas3/gemm_batched_strided.cpp
@@ -25,18 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int stride_a_mul, int stride_b_mul,
-                     int stride_c_mul) {
-  std::ostringstream str{};
-  str << "BM_GemmBatchedStrided<"
-      << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
-      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
-      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul;
-
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched_strided;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -208,8 +198,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_size, strd_a_mul, strd_b_mul, strd_c_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, stride_a_mul,
-                           stride_b_mul, stride_c_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, batch_size, stride_a_mul, stride_b_mul,
+            stride_c_mul, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         stride_a_mul, stride_b_mul, stride_c_mul, success)

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -156,7 +156,7 @@ void register_benchmark(blas_benchmark::Args& args,
     auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
                          char side_c, char uplo_c, index_t m, index_t n,
                          scalar_t alpha, scalar_t beta, bool* success) {
-      run<scalar_t>(st, cuda_handle_ptr, side_c, uplo_c, m, n, alpha, beta,
+      run<scalar_t>(st, cuda_handle_ptr, side, uplo, m, n, alpha, beta,
                     success);
     };
     benchmark::RegisterBenchmark(

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -154,7 +154,7 @@ void register_benchmark(blas_benchmark::Args& args,
     char uplo_c = uplo[0];
 
     auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
-                         char side_c, char uplo_c, index_t m, index_t n,
+                         char side, char uplo, index_t m, index_t n,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, side, uplo, m, n, alpha, beta,
                     success);
@@ -163,7 +163,7 @@ void register_benchmark(blas_benchmark::Args& args,
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
             side, uplo, m, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
-        BM_lambda, cuda_handle_ptr, side, uplo, m, n, alpha, beta, success)
+        BM_lambda, cuda_handle_ptr, side_c, uplo_c, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, int m, int n, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Symm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << m << "/" << n << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::symm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,7 +157,10 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_side, s_uplo, m, n, alpha, beta).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_side, s_uplo, m, n, alpha, beta,
+            blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, s_side, s_uplo, m, n, alpha, beta, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -156,7 +156,7 @@ void register_benchmark(blas_benchmark::Args& args,
     auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
                          char side_c, char uplo_c, index_t m, index_t n,
                          scalar_t alpha, scalar_t beta, bool* success) {
-      run<scalar_t>(st, cuda_handle_ptr, side, uplo, m, n, alpha, beta,
+      run<scalar_t>(st, cuda_handle_ptr, side_c, uplo_c, m, n, alpha, beta,
                     success);
     };
     benchmark::RegisterBenchmark(

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -145,23 +145,25 @@ void register_benchmark(blas_benchmark::Args& args,
   auto symm_params = blas_benchmark::utils::get_symm_params<scalar_t>(args);
 
   for (auto p : symm_params) {
-    char s_side, s_uplo;
+    std::string side, uplo;
     index_t m, n;
     scalar_t alpha, beta;
-    std::tie(s_side, s_uplo, m, n, alpha, beta) = p;
+    std::tie(side, uplo, m, n, alpha, beta) = p;
+
+    char side_c = side[0];
+    char uplo_c = uplo[0];
 
     auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
-                         char side, char uplo, index_t m, index_t n,
+                         char side_c, char uplo_c, index_t m, index_t n,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, side, uplo, m, n, alpha, beta,
                     success);
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            s_side, s_uplo, m, n, alpha, beta,
-            blas_benchmark::utils::MEM_TYPE_USM)
+            side, uplo, m, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
-        BM_lambda, cuda_handle_ptr, s_side, s_uplo, m, n, alpha, beta, success)
+        BM_lambda, cuda_handle_ptr, side, uplo, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas3/syr2k.cpp
+++ b/benchmark/cublas/blas3/syr2k.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Syr2k<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::syr2k;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -163,7 +156,10 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_uplo, s_trans, n, k, alpha, beta).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_uplo, s_trans, n, k, alpha, beta,
+            blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, s_uplo, s_trans, n, k, alpha, beta, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas3/syr2k.cpp
+++ b/benchmark/cublas/blas3/syr2k.cpp
@@ -144,10 +144,13 @@ void register_benchmark(blas_benchmark::Args& args,
   auto syr2k_params = blas_benchmark::utils::get_syrk_params<scalar_t>(args);
 
   for (auto p : syr2k_params) {
-    char s_uplo, s_trans;
+    std::string uplo, trans;
     index_t n, k;
     scalar_t alpha, beta;
-    std::tie(s_uplo, s_trans, n, k, alpha, beta) = p;
+    std::tie(uplo, trans, n, k, alpha, beta) = p;
+
+    char uplo_c = uplo[0];
+    char trans_c = trans[0];
 
     auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
                          char uplo, char trans, index_t n, index_t k,
@@ -157,10 +160,9 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            s_uplo, s_trans, n, k, alpha, beta,
-            blas_benchmark::utils::MEM_TYPE_USM)
+            uplo, trans, n, k, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
-        BM_lambda, cuda_handle_ptr, s_uplo, s_trans, n, k, alpha, beta, success)
+        BM_lambda, cuda_handle_ptr, uplo_c, trans_c, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas3/syrk.cpp
+++ b/benchmark/cublas/blas3/syrk.cpp
@@ -140,10 +140,13 @@ void register_benchmark(blas_benchmark::Args& args,
   auto syrk_params = blas_benchmark::utils::get_syrk_params<scalar_t>(args);
 
   for (auto p : syrk_params) {
-    char s_uplo, s_trans;
+    std::string uplo, trans;
     index_t n, k;
     scalar_t alpha, beta;
-    std::tie(s_uplo, s_trans, n, k, alpha, beta) = p;
+    std::tie(uplo, trans, n, k, alpha, beta) = p;
+
+    char uplo_c = uplo[0];
+    char trans_c = trans[0];
 
     auto BM_lambda = [&](benchmark::State& st, cublasHandle_t* cuda_handle_ptr,
                          char uplo, char trans, index_t n, index_t k,
@@ -153,10 +156,9 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            s_uplo, s_trans, n, k, alpha, beta,
-            blas_benchmark::utils::MEM_TYPE_USM)
+            uplo, trans, n, k, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
-        BM_lambda, cuda_handle_ptr, s_uplo, s_trans, n, k, alpha, beta, success)
+        BM_lambda, cuda_handle_ptr, uplo_c, trans_c, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas3/syrk.cpp
+++ b/benchmark/cublas/blas3/syrk.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Syrk<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::syrk;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -159,7 +152,10 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_uplo, s_trans, n, k, alpha, beta).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_uplo, s_trans, n, k, alpha, beta,
+            blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, s_uplo, s_trans, n, k, alpha, beta, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas3/trmm.cpp
+++ b/benchmark/cublas/blas3/trmm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char t, char diag, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Trmm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << t << "/" << diag << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trmm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -176,7 +171,10 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_side, s_uplo, s_t, s_diag, m, n).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_side, s_uplo, s_t, s_diag, m, n,
+            blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, s_side, s_uplo, s_t, s_diag, m, n, alpha,
         success)
         ->UseRealTime();

--- a/benchmark/cublas/blas3/trsm.cpp
+++ b/benchmark/cublas/blas3/trsm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char trans, char diag, index_t m,
-                     index_t n) {
-  std::ostringstream str{};
-  str << "BM_Trsm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << trans << "/" << diag << "/" << m << "/"
-      << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -178,8 +171,11 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
-        cuda_handle_ptr, side, uplo, trans, diag, m, n, alpha, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, trans, diag, m, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, side, uplo, trans, diag, m, n, alpha,
+        success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas3/trsm_batched.cpp
+++ b/benchmark/cublas/blas3/trsm_batched.cpp
@@ -25,16 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(const char side, const char uplo, const char t,
-                     const char diag, int m, int n, int batch_count,
-                     int stride_a_mul, int stride_b_mul) {
-  std::ostringstream str{};
-  str << "BM_TrsmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << side << "/" << uplo << "/" << t << "/" << diag << "/" << m
-      << "/" << n << "/" << batch_count;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm_batched;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -216,8 +208,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_count, strd_a_mul, strd_b_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_side, s_uplo, s_t, s_diag, m, n, batch_count,
-                           stride_a_mul, stride_b_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_side, s_uplo, s_t, s_diag, m, n, batch_count, stride_a_mul,
+            stride_b_mul, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, s_side, s_uplo, s_t, s_diag, m, n, alpha,
         batch_count, stride_a_mul, stride_b_mul, success)

--- a/benchmark/rocblas/blas1/asum.cpp
+++ b/benchmark/rocblas/blas1/asum.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Asum<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::asum;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_asum_f(args_t&&... args) {
@@ -50,8 +45,8 @@ void run(benchmark::State& state, rocblas_handle& rb_handle, index_t size,
   blas_benchmark::utils::set_benchmark_label<scalar_t>(state);
 
   // Google-benchmark counters are double.
-  blas_benchmark::utils::init_level_1_counters<
-      blas_benchmark::utils::Level1Op::asum, scalar_t>(state, size);
+  blas_benchmark::utils::init_level_1_counters<benchmark_op, scalar_t>(state,
+                                                                       size);
 
   using data_t = scalar_t;
 
@@ -140,8 +135,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t size, bool* success) {
       run<scalar_t>(st, rb_handle, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 rb_handle, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas1/asum.cpp
+++ b/benchmark/rocblas/blas1/asum.cpp
@@ -136,7 +136,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }

--- a/benchmark/rocblas/blas1/axpy.cpp
+++ b/benchmark/rocblas/blas1/axpy.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Axpy" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::axpy;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_saxpy_f(args_t&&... args) {
@@ -143,8 +138,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t size, bool* success) {
       run<scalar_t>(st, rb_handle, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 rb_handle, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas1/axpy.cpp
+++ b/benchmark/rocblas/blas1/axpy.cpp
@@ -139,7 +139,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }

--- a/benchmark/rocblas/blas1/dot.cpp
+++ b/benchmark/rocblas/blas1/dot.cpp
@@ -136,7 +136,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }

--- a/benchmark/rocblas/blas1/dot.cpp
+++ b/benchmark/rocblas/blas1/dot.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Dot<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::dot;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_dot_f(args_t&&... args) {
@@ -140,8 +135,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t size, bool* success) {
       run<scalar_t>(st, rb_handle, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 rb_handle, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas1/iamax.cpp
+++ b/benchmark/rocblas/blas1/iamax.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Iamax<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::iamax;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_iamax_f(args_t&&... args) {
@@ -144,8 +138,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t size, bool* success) {
       run<scalar_t>(st, rb_handle, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 rb_handle, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas1/iamax.cpp
+++ b/benchmark/rocblas/blas1/iamax.cpp
@@ -139,7 +139,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }

--- a/benchmark/rocblas/blas1/iamin.cpp
+++ b/benchmark/rocblas/blas1/iamin.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Iamin<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::iamin;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_iamin_f(args_t&&... args) {
@@ -144,8 +138,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t size, bool* success) {
       run<scalar_t>(st, rb_handle, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 rb_handle, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas1/iamin.cpp
+++ b/benchmark/rocblas/blas1/iamin.cpp
@@ -139,7 +139,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }

--- a/benchmark/rocblas/blas1/nrm2.cpp
+++ b/benchmark/rocblas/blas1/nrm2.cpp
@@ -134,7 +134,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }

--- a/benchmark/rocblas/blas1/nrm2.cpp
+++ b/benchmark/rocblas/blas1/nrm2.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Nrm2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::nrm2;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_nrm2_f(args_t&&... args) {
@@ -138,8 +133,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t size, bool* success) {
       run<scalar_t>(st, rb_handle, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 rb_handle, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas1/rotg.cpp
+++ b/benchmark/rocblas/blas1/rotg.cpp
@@ -156,7 +156,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     run<scalar_t>(st, rb_handle, success);
   };
   benchmark::RegisterBenchmark(
-      blas_benchmark::utils::get_name<benchmark_op, scalar_t>().c_str(),
+      blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+          blas_benchmark::utils::MEM_TYPE_USM)
+          .c_str(),
       BM_lambda, rb_handle, success)
       ->UseRealTime();
 }

--- a/benchmark/rocblas/blas1/rotg.cpp
+++ b/benchmark/rocblas/blas1/rotg.cpp
@@ -25,12 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name() {
-  std::ostringstream str{};
-  str << "BM_Rotg<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::rotg;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_rotg_f(args_t&&... args) {
@@ -159,8 +155,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                        bool* success) {
     run<scalar_t>(st, rb_handle, success);
   };
-  benchmark::RegisterBenchmark(get_name<scalar_t>().c_str(), BM_lambda,
-                               rb_handle, success)
+  benchmark::RegisterBenchmark(
+      blas_benchmark::utils::get_name<benchmark_op, scalar_t>().c_str(),
+      BM_lambda, rb_handle, success)
       ->UseRealTime();
 }
 

--- a/benchmark/rocblas/blas1/rotm.cpp
+++ b/benchmark/rocblas/blas1/rotm.cpp
@@ -159,7 +159,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }

--- a/benchmark/rocblas/blas1/rotm.cpp
+++ b/benchmark/rocblas/blas1/rotm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Rotm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::rotm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_rotm_f(args_t&&... args) {
@@ -163,8 +158,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t size, bool* success) {
       run<scalar_t>(st, rb_handle, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 rb_handle, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas1/rotmg.cpp
+++ b/benchmark/rocblas/blas1/rotmg.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name() {
-  std::ostringstream str{};
-  str << "BM_Rotmg<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/";
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::rotmg;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_rotmg_f(args_t&&... args) {
@@ -166,8 +161,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                        bool* success) {
     run<scalar_t>(st, rb_handle, success);
   };
-  benchmark::RegisterBenchmark(get_name<scalar_t>().c_str(), BM_lambda,
-                               rb_handle, success)
+  benchmark::RegisterBenchmark(
+      blas_benchmark::utils::get_name<benchmark_op, scalar_t>().c_str(),
+      BM_lambda, rb_handle, success)
       ->UseRealTime();
 }
 

--- a/benchmark/rocblas/blas1/rotmg.cpp
+++ b/benchmark/rocblas/blas1/rotmg.cpp
@@ -162,7 +162,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     run<scalar_t>(st, rb_handle, success);
   };
   benchmark::RegisterBenchmark(
-      blas_benchmark::utils::get_name<benchmark_op, scalar_t>().c_str(),
+      blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+          blas_benchmark::utils::MEM_TYPE_USM)
+          .c_str(),
       BM_lambda, rb_handle, success)
       ->UseRealTime();
 }

--- a/benchmark/rocblas/blas1/scal.cpp
+++ b/benchmark/rocblas/blas1/scal.cpp
@@ -136,7 +136,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }

--- a/benchmark/rocblas/blas1/scal.cpp
+++ b/benchmark/rocblas/blas1/scal.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Scal<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::scal;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_scal_f(args_t&&... args) {
@@ -140,8 +135,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t size, bool* success) {
       run<scalar_t>(st, rb_handle, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 rb_handle, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, rb_handle, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/gbmv.cpp
+++ b/benchmark/rocblas/blas2/gbmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t, int m, int n, int kl, int ku) {
-  std::ostringstream str{};
-  str << "BM_Gbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n << "/" << kl << "/" << ku;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::gbmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gbmv_f(args_t&&... args) {
@@ -180,9 +175,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, t, m, n, kl, ku, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n, kl, ku).c_str(),
-                                 BM_lambda, rb_handle, t, m, n, kl, ku, alpha,
-                                 beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            ts, m, n, kl, ku, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, t, m, n, kl, ku, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/gemv.cpp
+++ b/benchmark/rocblas/blas2/gemv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::gemv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gemv_f(args_t&&... args) {
@@ -179,9 +174,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          bool* success) {
       run<scalar_t>(st, rb_handle, t, m, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n).c_str(),
-                                 BM_lambda, rb_handle, t, m, n, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            ts, m, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, t, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/ger.cpp
+++ b/benchmark/rocblas/blas2/ger.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Ger<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::ger;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_ger_f(args_t&&... args) {
@@ -167,8 +162,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t m, index_t n, scalar_t alpha, bool* success) {
       run<scalar_t>(st, rb_handle, m, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(m, n).c_str(), BM_lambda,
-                                 rb_handle, m, n, alpha, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            m, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/sbmv.cpp
+++ b/benchmark/rocblas/blas2/sbmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, int k) {
-  std::ostringstream str{};
-  str << "BM_Sbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::sbmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_sbmv_f(args_t&&... args) {
@@ -176,9 +171,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, uplo, n, k, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, k).c_str(),
-                                 BM_lambda, rb_handle, uplo, n, k, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, k, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/spmv.cpp
+++ b/benchmark/rocblas/blas2/spmv.cpp
@@ -170,7 +170,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            uplos, n, blas_benchmark::utils::MEM_TYPE_USM)
+            uplos, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplos, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/spmv.cpp
+++ b/benchmark/rocblas/blas2/spmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n) {
-  std::ostringstream str{};
-  str << "BM_Spmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_spmv_f(args_t&&... args) {
@@ -173,9 +168,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, uplos, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplos, n).c_str(),
-                                 BM_lambda, rb_handle, uplos, n, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplos, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/spr.cpp
+++ b/benchmark/rocblas/blas2/spr.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, int n, scalar_t alpha, int incX) {
-  std::ostringstream str{};
-  str << "BM_Spr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha << "/" << incX;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spr;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_spr_f(args_t&&... args) {
@@ -165,8 +160,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, n, alpha, incX, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo_str, n, alpha, incX).c_str(), BM_lambda_col,
-        rb_handle, uplo_str, n, alpha, incX, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo_str, n, alpha, incX, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda_col, rb_handle, uplo_str, n, alpha, incX, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/spr.cpp
+++ b/benchmark/rocblas/blas2/spr.cpp
@@ -161,7 +161,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            uplo_str, n, alpha, incX, blas_benchmark::utils::MEM_TYPE_USM)
+            uplo, n, alpha, incX, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda_col, rb_handle, uplo_str, n, alpha, incX, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/spr2.cpp
+++ b/benchmark/rocblas/blas2/spr2.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, int size, scalar_t alpha, index_t incX,
-                     index_t incY) {
-  std::ostringstream str{};
-  str << "BM_Spr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << size << "/" << alpha << "/" << incX << "/" << incY;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spr2;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_spr2_f(args_t&&... args) {
@@ -174,8 +168,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, n, alpha, incX, incY, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo_c, n, alpha, incX, incY).c_str(), BM_lambda,
-        rb_handle, uplo_c, n, alpha, incX, incY, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo_c, n, alpha, incX, incY, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplo_c, n, alpha, incX, incY, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/spr2.cpp
+++ b/benchmark/rocblas/blas2/spr2.cpp
@@ -169,7 +169,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            uplo_c, n, alpha, incX, incY, blas_benchmark::utils::MEM_TYPE_USM)
+            uplo, n, alpha, incX, incY, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplo_c, n, alpha, incX, incY, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/symv.cpp
+++ b/benchmark/rocblas/blas2/symv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n) {
-  std::ostringstream str{};
-  str << "BM_Symv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::symv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_symv_f(args_t&&... args) {
@@ -176,9 +171,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, uplos, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplos, n).c_str(),
-                                 BM_lambda, rb_handle, uplos, n, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplos, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/symv.cpp
+++ b/benchmark/rocblas/blas2/symv.cpp
@@ -173,7 +173,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            uplos, n, blas_benchmark::utils::MEM_TYPE_USM)
+            uplos, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplos, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/syr.cpp
+++ b/benchmark/rocblas/blas2/syr.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n) {
-  std::ostringstream str{};
-  str << "BM_Syr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::syr;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_syr_f(args_t&&... args) {
@@ -169,8 +164,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          bool* success) {
       run<scalar_t>(st, rb_handle, uplo, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n).c_str(), BM_lambda,
-                                 rb_handle, uplo, n, alpha, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/syr.cpp
+++ b/benchmark/rocblas/blas2/syr.cpp
@@ -166,7 +166,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            uplo, n, blas_benchmark::utils::MEM_TYPE_USM)
+            uplo, n, alpha, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplo, n, alpha, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/syr2.cpp
+++ b/benchmark/rocblas/blas2/syr2.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n) {
-  std::ostringstream str{};
-  str << "BM_Syr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::syr2;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_syr2_f(args_t&&... args) {
@@ -175,8 +170,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          bool* success) {
       run<scalar_t>(st, rb_handle, uplo, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n).c_str(), BM_lambda,
-                                 rb_handle, uplo, n, alpha, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/syr2.cpp
+++ b/benchmark/rocblas/blas2/syr2.cpp
@@ -172,7 +172,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            uplo, n, blas_benchmark::utils::MEM_TYPE_USM)
+            uplo, n, alpha, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplo, n, alpha, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/tbmv.cpp
+++ b/benchmark/rocblas/blas2/tbmv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n,
-                     int k) {
-  std::ostringstream str{};
-  str << "BM_Tbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tbmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_tbmv_f(args_t&&... args) {
@@ -175,8 +169,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
-        rb_handle, uplos, ts, diags, n, k, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, k, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplos, ts, diags, n, k, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/tbsv.cpp
+++ b/benchmark/rocblas/blas2/tbsv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n,
-                     int k) {
-  std::ostringstream str{};
-  str << "BM_Tbsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tbsv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_tbsv_f(args_t&&... args) {
@@ -185,8 +179,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo, ts, diags, n, k).c_str(), BM_lambda, rb_handle,
-        uplo, ts, diags, n, k, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, ts, diags, n, k, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, ts, diags, n, k, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/tpmv.cpp
+++ b/benchmark/rocblas/blas2/tpmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Tpmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tpmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_tpmv_f(args_t&&... args) {
@@ -171,9 +166,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t n, bool* success) {
       run<scalar_t>(st, rb_handle, uplo, ts, diags, n, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, ts, diags, n).c_str(),
-                                 BM_lambda, rb_handle, uplo, ts, diags, n,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/tpsv.cpp
+++ b/benchmark/rocblas/blas2/tpsv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Tpsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tpsv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_tpsv_f(args_t&&... args) {
@@ -181,9 +176,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t n, bool* success) {
       run<scalar_t>(st, rb_handle, uplo, ts, diags, n, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, ts, diags, n).c_str(),
-                                 BM_lambda, rb_handle, uplo, ts, diags, n,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/trmv.cpp
+++ b/benchmark/rocblas/blas2/trmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Trmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::trmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trmv_f(args_t&&... args) {
@@ -173,8 +168,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda, rb_handle,
-        uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Trsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::trsv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trsv_f(args_t&&... args) {
@@ -181,8 +176,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda, rb_handle,
-        uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/gemm.cpp
+++ b/benchmark/rocblas/blas3/gemm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t_a, std::string t_b, int m, int k, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t_a << "/" << t_b << "/" << m << "/" << k << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gemm_f(args_t&&... args) {
@@ -179,9 +174,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, t1i, t2i, m, k, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(t_a, t_b, m, k, n).c_str(),
-                                 BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n,
-                                 alpha, beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t_a, t_b, m, k, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/gemm_batched.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched.cpp
@@ -25,16 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int batch_type) {
-  std::ostringstream str{};
-  str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
-      << batch_size << "/"
-      << blas_benchmark::utils::batch_type_to_str(batch_type);
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gemm_batched_f(args_t&&... args) {
@@ -207,7 +199,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                     batch_size, batch_type, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t_a, t_b, m, k, n, batch_size, batch_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t_a, t_b, m, k, n, batch_size, batch_type,
+            blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, batch_size,
         batch_type, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched_strided.cpp
@@ -25,18 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int stride_a_mul, int stride_b_mul,
-                     int stride_c_mul) {
-  std::ostringstream str{};
-  str << "BM_GemmBatchedStrided<"
-      << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
-      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
-      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul;
-
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched_strided;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gemm_strided_batched(args_t&&... args) {
@@ -219,8 +209,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                     strd_a_mul, strd_b_mul, strd_c_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t_a, t_b, m, k, n, batch_size, stride_a_mul,
-                           stride_b_mul, stride_c_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t_a, t_b, m, k, n, batch_size, stride_a_mul, stride_b_mul,
+            stride_c_mul, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, batch_size,
         stride_a_mul, stride_b_mul, stride_c_mul, success)

--- a/benchmark/rocblas/blas3/symm.cpp
+++ b/benchmark/rocblas/blas3/symm.cpp
@@ -154,13 +154,16 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
   auto symm_params = blas_benchmark::utils::get_symm_params<scalar_t>(args);
 
   for (auto p : symm_params) {
-    char side, uplo;
+    std::string side, uplo;
     index_t m, n;
     scalar_t alpha, beta;
     std::tie(side, uplo, m, n, alpha, beta) = p;
 
+    char side_c = side[0];
+    char uplo_c = uplo[0];
+
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
-                         char side, char uplo, index_t m, index_t n,
+                         char side_c, char uplo_c, index_t m, index_t n,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, side, uplo, m, n, alpha, beta, success);
     };

--- a/benchmark/rocblas/blas3/symm.cpp
+++ b/benchmark/rocblas/blas3/symm.cpp
@@ -163,7 +163,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     char uplo_c = uplo[0];
 
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
-                         char side_c, char uplo_c, index_t m, index_t n,
+                         char side, char uplo, index_t m, index_t n,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, side, uplo, m, n, alpha, beta, success);
     };
@@ -171,7 +171,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
             side, uplo, m, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
-        BM_lambda, rb_handle, side, uplo, m, n, alpha, beta, success)
+        BM_lambda, rb_handle, side_c, uplo_c, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/symm.cpp
+++ b/benchmark/rocblas/blas3/symm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, int m, int n, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Symm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << m << "/" << n << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::symm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_symm_f(args_t&&... args) {
@@ -172,8 +165,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, side, uplo, m, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, m, n, alpha, beta).c_str(), BM_lambda,
-        rb_handle, side, uplo, m, n, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, m, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, side, uplo, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/syr2k.cpp
+++ b/benchmark/rocblas/blas3/syr2k.cpp
@@ -151,10 +151,13 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
   auto syr2k_params = blas_benchmark::utils::get_syrk_params<scalar_t>(args);
 
   for (auto p : syr2k_params) {
-    char uplo, trans;
+    std::string uplo, trans;
     index_t n, k;
     scalar_t alpha, beta;
     std::tie(uplo, trans, n, k, alpha, beta) = p;
+
+    char uplo_c = uplo[0];
+    char trans_c = trans[0];
 
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
                          char uplo, char trans, index_t n, index_t k,
@@ -165,7 +168,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
             uplo, trans, n, k, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
-        BM_lambda, rb_handle, uplo, trans, n, k, alpha, beta, success)
+        BM_lambda, rb_handle, uplo_c, trans_c, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/syr2k.cpp
+++ b/benchmark/rocblas/blas3/syr2k.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Syr2k<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::syr2k;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_syr2k_f(args_t&&... args) {
@@ -169,8 +162,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, trans, n, k, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo, trans, n, k, alpha, beta).c_str(), BM_lambda,
-        rb_handle, uplo, trans, n, k, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, trans, n, k, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, trans, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/syrk.cpp
+++ b/benchmark/rocblas/blas3/syrk.cpp
@@ -148,10 +148,13 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
   auto syrk_params = blas_benchmark::utils::get_syrk_params<scalar_t>(args);
 
   for (auto p : syrk_params) {
-    char uplo, trans;
+    std::string uplo, trans;
     index_t n, k;
     scalar_t alpha, beta;
     std::tie(uplo, trans, n, k, alpha, beta) = p;
+
+    char uplo_c = uplo[0];
+    char trans_c = trans[0];
 
     auto BM_lambda = [&](benchmark::State& st, rocblas_handle rb_handle,
                          char uplo, char trans, index_t n, index_t k,
@@ -162,7 +165,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
             uplo, trans, n, k, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
-        BM_lambda, rb_handle, uplo, trans, n, k, alpha, beta, success)
+        BM_lambda, rb_handle, uplo_c, trans_c, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/syrk.cpp
+++ b/benchmark/rocblas/blas3/syrk.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Syrk<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::syrk;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_syrk_f(args_t&&... args) {
@@ -166,8 +159,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, trans, n, k, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo, trans, n, k, alpha, beta).c_str(), BM_lambda,
-        rb_handle, uplo, trans, n, k, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, trans, n, k, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, trans, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/trmm.cpp
+++ b/benchmark/rocblas/blas3/trmm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char t, char diag, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Trmm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << t << "/" << diag << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trmm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trmm_f(args_t&&... args) {
@@ -177,8 +172,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, side, uplo, t, diag, m, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
-        rb_handle, side, uplo, trans, diag, m, n, alpha, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, trans, diag, m, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, side, uplo, trans, diag, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/trsm.cpp
+++ b/benchmark/rocblas/blas3/trsm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char trans, char diag, index_t m,
-                     index_t n) {
-  std::ostringstream str{};
-  str << "BM_Trsm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << trans << "/" << diag << "/" << m << "/"
-      << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trsm_f(args_t&&... args) {
@@ -181,8 +174,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
-        rb_handle, side, uplo, trans, diag, m, n, alpha, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, trans, diag, m, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, side, uplo, trans, diag, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/trsm_batched.cpp
+++ b/benchmark/rocblas/blas3/trsm_batched.cpp
@@ -25,17 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(const char side, const char uplo, const char t,
-                     const char diag, int m, int n, int batch_size,
-                     int stride_a_mul, int stride_b_mul) {
-  std::ostringstream str{};
-  str << "BM_TrsmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << side << "/" << uplo << "/" << t << "/" << diag << "/" << m
-      << "/" << n << "/" << batch_size << "/" << stride_a_mul << "/"
-      << stride_b_mul << "/";
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm_batched;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trsm_batched_f(args_t&&... args) {
@@ -215,8 +206,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                     strd_a_mul, strd_b_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_side, s_uplo, s_t, s_diag, m, n, batch_size,
-                           stride_a_mul, stride_b_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_side, s_uplo, s_t, s_diag, m, n, batch_size, stride_a_mul,
+            stride_b_mul, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, s_side, s_uplo, s_t, s_diag, m, n, alpha,
         batch_size, stride_a_mul, stride_b_mul, success)

--- a/benchmark/syclblas/blas1/asum.cpp
+++ b/benchmark/syclblas/blas1/asum.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Asum<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::asum;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
@@ -41,8 +36,8 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
       state, sb_handle_ptr->get_queue());
 
   // Google-benchmark counters are double.
-  blas_benchmark::utils::init_level_1_counters<
-      blas_benchmark::utils::Level1Op::asum, scalar_t>(state, size);
+  blas_benchmark::utils::init_level_1_counters<benchmark_op, scalar_t>(state,
+                                                                       size);
 
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
 
@@ -117,8 +112,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          index_t size, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 sb_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas1/asum.cpp
+++ b/benchmark/syclblas/blas1/asum.cpp
@@ -113,7 +113,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/syclblas/blas1/axpy.cpp
+++ b/benchmark/syclblas/blas1/axpy.cpp
@@ -110,7 +110,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/syclblas/blas1/axpy.cpp
+++ b/benchmark/syclblas/blas1/axpy.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Axpy<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::axpy;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
@@ -41,8 +36,8 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
       state, sb_handle_ptr->get_queue());
 
   // Google-benchmark counters are double.
-  blas_benchmark::utils::init_level_1_counters<
-      blas_benchmark::utils::Level1Op::axpy, scalar_t>(state, size);
+  blas_benchmark::utils::init_level_1_counters<benchmark_op, scalar_t>(state,
+                                                                       size);
 
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
 
@@ -114,8 +109,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          index_t size, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 sb_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas1/copy.cpp
+++ b/benchmark/syclblas/blas1/copy.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size, int incx, int incy) {
-  std::ostringstream str{};
-  str << "BM_Copy<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << size << "/" << incx << "/" << incy;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::copy;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
@@ -119,9 +114,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          bool* success) {
       run<scalar_t>(st, sb_handle_ptr, size, incx, incy, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size, incx, incy).c_str(),
-                                 BM_lambda, sb_handle_ptr, size, incx, incy,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size, incx,
+                                                                incy)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, size, incx, incy, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas1/copy.cpp
+++ b/benchmark/syclblas/blas1/copy.cpp
@@ -115,8 +115,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, size, incx, incy, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size, incx,
-                                                                incy)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, incx, incy, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, size, incx, incy, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas1/dot.cpp
+++ b/benchmark/syclblas/blas1/dot.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Dot<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::dot;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
@@ -118,8 +113,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          index_t size, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 sb_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas1/dot.cpp
+++ b/benchmark/syclblas/blas1/dot.cpp
@@ -114,7 +114,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/syclblas/blas1/iamax.cpp
+++ b/benchmark/syclblas/blas1/iamax.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Iamax<" << blas_benchmark::utils::get_type_name<scalar_t>();
-  str << ">/" << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::iamax;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
@@ -122,8 +117,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          index_t size, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 sb_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas1/iamax.cpp
+++ b/benchmark/syclblas/blas1/iamax.cpp
@@ -118,7 +118,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/syclblas/blas1/iamin.cpp
+++ b/benchmark/syclblas/blas1/iamin.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Iamin<" << blas_benchmark::utils::get_type_name<scalar_t>();
-  str << ">/" << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::iamin;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
@@ -121,8 +116,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          index_t size, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 sb_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas1/iamin.cpp
+++ b/benchmark/syclblas/blas1/iamin.cpp
@@ -117,7 +117,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/syclblas/blas1/nrm2.cpp
+++ b/benchmark/syclblas/blas1/nrm2.cpp
@@ -111,7 +111,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/syclblas/blas1/nrm2.cpp
+++ b/benchmark/syclblas/blas1/nrm2.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Nrm2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::nrm2;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
@@ -115,8 +110,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          index_t size, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 sb_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas1/rotg.cpp
+++ b/benchmark/syclblas/blas1/rotg.cpp
@@ -136,7 +136,9 @@ void register_benchmark(blas_benchmark::Args& args,
     run<scalar_t>(st, sb_handle_ptr, success);
   };
   benchmark::RegisterBenchmark(
-      blas_benchmark::utils::get_name<benchmark_op, scalar_t>().c_str(),
+      blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+          blas_benchmark::utils::MEM_TYPE_BUFFER)
+          .c_str(),
       BM_lambda, sb_handle_ptr, success)
       ->UseRealTime();
 }

--- a/benchmark/syclblas/blas1/rotg.cpp
+++ b/benchmark/syclblas/blas1/rotg.cpp
@@ -25,12 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name() {
-  std::ostringstream str{};
-  str << "BM_Rotg<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::rotg;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -139,8 +135,9 @@ void register_benchmark(blas_benchmark::Args& args,
                        bool* success) {
     run<scalar_t>(st, sb_handle_ptr, success);
   };
-  benchmark::RegisterBenchmark(get_name<scalar_t>().c_str(), BM_lambda,
-                               sb_handle_ptr, success)
+  benchmark::RegisterBenchmark(
+      blas_benchmark::utils::get_name<benchmark_op, scalar_t>().c_str(),
+      BM_lambda, sb_handle_ptr, success)
       ->UseRealTime();
 }
 

--- a/benchmark/syclblas/blas1/rotm.cpp
+++ b/benchmark/syclblas/blas1/rotm.cpp
@@ -131,7 +131,9 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/syclblas/blas1/rotm.cpp
+++ b/benchmark/syclblas/blas1/rotm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Rotm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::rotm;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
@@ -135,8 +130,9 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t size, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 sb_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas1/rotmg.cpp
+++ b/benchmark/syclblas/blas1/rotmg.cpp
@@ -142,7 +142,9 @@ void register_benchmark(blas_benchmark::Args& args,
     run<scalar_t>(st, sb_handle_ptr, success);
   };
   benchmark::RegisterBenchmark(
-      blas_benchmark::utils::get_name<benchmark_op, scalar_t>().c_str(),
+      blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+          blas_benchmark::utils::MEM_TYPE_BUFFER)
+          .c_str(),
       BM_lambda, sb_handle_ptr, success)
       ->UseRealTime();
 }

--- a/benchmark/syclblas/blas1/rotmg.cpp
+++ b/benchmark/syclblas/blas1/rotmg.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name() {
-  std::ostringstream str{};
-  str << "BM_Rotmg<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/";
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::rotmg;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -146,8 +141,9 @@ void register_benchmark(blas_benchmark::Args& args,
                        bool* success) {
     run<scalar_t>(st, sb_handle_ptr, success);
   };
-  benchmark::RegisterBenchmark(get_name<scalar_t>().c_str(), BM_lambda,
-                               sb_handle_ptr, success)
+  benchmark::RegisterBenchmark(
+      blas_benchmark::utils::get_name<benchmark_op, scalar_t>().c_str(),
+      BM_lambda, sb_handle_ptr, success)
       ->UseRealTime();
 }
 

--- a/benchmark/syclblas/blas1/scal.cpp
+++ b/benchmark/syclblas/blas1/scal.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Scal<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::scal;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
@@ -111,8 +106,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          index_t size, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 sb_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas1/scal.cpp
+++ b/benchmark/syclblas/blas1/scal.cpp
@@ -107,7 +107,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/syclblas/blas1/sdsdot.cpp
+++ b/benchmark/syclblas/blas1/sdsdot.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int size) {
-  std::ostringstream str{};
-  str << "BM_Sdsdot<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/";
-  str << size;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level1Op benchmark_op =
+    blas_benchmark::utils::Level1Op::sdsdot;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
@@ -119,8 +113,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          index_t size, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 sb_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas1/sdsdot.cpp
+++ b/benchmark/syclblas/blas1/sdsdot.cpp
@@ -114,7 +114,9 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }

--- a/benchmark/syclblas/blas2/gbmv.cpp
+++ b/benchmark/syclblas/blas2/gbmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t, int m, int n, int kl, int ku) {
-  std::ostringstream str{};
-  str << "BM_Gbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n << "/" << kl << "/" << ku;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::gbmv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int ti,
@@ -140,9 +135,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, t, m, n, kl, ku, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n, kl, ku).c_str(),
-                                 BM_lambda, sb_handle_ptr, t, m, n, kl, ku,
-                                 alpha, beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            ts, m, n, kl, ku, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, t, m, n, kl, ku, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/gemv.cpp
+++ b/benchmark/syclblas/blas2/gemv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::gemv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int ti,
@@ -139,9 +134,11 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          bool* success) {
       run<scalar_t>(st, sb_handle_ptr, t, m, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n).c_str(),
-                                 BM_lambda, sb_handle_ptr, t, m, n, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            ts, m, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, t, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/ger.cpp
+++ b/benchmark/syclblas/blas2/ger.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Ger<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::ger;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t m,
@@ -134,8 +129,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t m, index_t n, scalar_t alpha, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, m, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(m, n).c_str(), BM_lambda,
-                                 sb_handle_ptr, m, n, alpha, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            m, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/sbmv.cpp
+++ b/benchmark/syclblas/blas2/sbmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, int k) {
-  std::ostringstream str{};
-  str << "BM_Sbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::sbmv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -137,9 +132,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, uplos, n, k, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplos, n, k).c_str(),
-                                 BM_lambda, sb_handle_ptr, uplos, n, k, alpha,
-                                 beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, k, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/spmv.cpp
+++ b/benchmark/syclblas/blas2/spmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha, scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Spmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha << "/" << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spmv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -136,8 +131,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, n, alpha, beta).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, n, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/spr.cpp
+++ b/benchmark/syclblas/blas2/spr.cpp
@@ -115,7 +115,7 @@ void register_benchmark(blas_benchmark::Args& args,
   auto spr_params = blas_benchmark::utils::get_spr_params<scalar_t>(args);
 
   for (auto p : spr_params) {
-    int n, incX;
+    index_t n, incX;
     std::string uplo;
     scalar_t alpha;
     std::tie(uplo, n, alpha, incX) = p;

--- a/benchmark/syclblas/blas2/spr.cpp
+++ b/benchmark/syclblas/blas2/spr.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, int size, scalar_t alpha, int incX) {
-  std::ostringstream str{};
-  str << "BM_Spr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << size << "/" << alpha << "/" << incX;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spr;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char uplo,
@@ -133,8 +128,10 @@ void register_benchmark(blas_benchmark::Args& args,
           run<scalar_t>(st, sb_handle_ptr, uplo, size, alpha, incX, success);
         };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo_c, n, alpha, incX).c_str(), BM_lambda_col,
-        sb_handle_ptr, uplo_c, n, alpha, incX, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, alpha, incX, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda_col, sb_handle_ptr, uplo_c, n, alpha, incX, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/spr2.cpp
+++ b/benchmark/syclblas/blas2/spr2.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, int size, scalar_t alpha, int incX, int incY) {
-  std::ostringstream str{};
-  str << "BM_Spr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << size << "/" << alpha << "/" << incX << "/" << incY;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spr2;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char uplo,
@@ -123,7 +118,7 @@ void register_benchmark(blas_benchmark::Args& args,
   auto spr2_params = blas_benchmark::utils::get_spr2_params<scalar_t>(args);
 
   for (auto p : spr2_params) {
-    int n, incX, incY;
+    index_t n, incX, incY;
     std::string uplo;
     scalar_t alpha;
     std::tie(uplo, n, alpha, incX, incY) = p;
@@ -136,8 +131,10 @@ void register_benchmark(blas_benchmark::Args& args,
           run<scalar_t>(st, sb_handle_ptr, uplo, n, alpha, incX, incY, success);
         };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo_c, n, alpha, incX, incY).c_str(), BM_lambda_col,
-        sb_handle_ptr, uplo_c, n, alpha, incX, incY, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, alpha, incX, incY, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda_col, sb_handle_ptr, uplo_c, n, alpha, incX, incY, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/symv.cpp
+++ b/benchmark/syclblas/blas2/symv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha, scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Symv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha << "/" << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::symv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -137,8 +132,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, n, alpha, beta).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, n, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/syr.cpp
+++ b/benchmark/syclblas/blas2/syr.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha) {
-  std::ostringstream str{};
-  str << "BM_Syr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::syr;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -129,9 +124,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          bool* success) {
       run<scalar_t>(st, sb_handle_ptr, uplo, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, alpha).c_str(),
-                                 BM_lambda, sb_handle_ptr, uplo, n, alpha,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, alpha, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplo, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/syr2.cpp
+++ b/benchmark/syclblas/blas2/syr2.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha) {
-  std::ostringstream str{};
-  str << "BM_Syr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::syr2;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -138,9 +133,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          bool* success) {
       run<scalar_t>(st, sb_handle_ptr, uplo, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, alpha).c_str(),
-                                 BM_lambda, sb_handle_ptr, uplo, n, alpha,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, alpha, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplo, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/tbmv.cpp
+++ b/benchmark/syclblas/blas2/tbmv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n,
-                     int k) {
-  std::ostringstream str{};
-  str << "BM_Tbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tbmv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -136,8 +130,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, ts, diags, n, k, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, k, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, ts, diags, n, k, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/tbsv.cpp
+++ b/benchmark/syclblas/blas2/tbsv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag,
-                     const int n, const int k) {
-  std::ostringstream str{};
-  str << "BM_Tbsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tbsv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -146,8 +140,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, ts, diags, n, k, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, k, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, ts, diags, n, k, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/tpmv.cpp
+++ b/benchmark/syclblas/blas2/tpmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Tpmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tpmv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -130,8 +125,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/tpsv.cpp
+++ b/benchmark/syclblas/blas2/tpsv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag,
-                     const int n) {
-  std::ostringstream str{};
-  str << "BM_Tpsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tpsv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -50,8 +44,8 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
   index_t incX = 1;
   index_t xlen = 1 + (n - 1) * incX;
 
-  blas_benchmark::utils::init_level_2_counters<
-      blas_benchmark::utils::Level2Op::tpsv, scalar_t>(state, "n", 0, 0, n);
+  blas_benchmark::utils::init_level_2_counters<benchmark_op, scalar_t>(
+      state, "n", 0, 0, n);
 
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
 
@@ -146,8 +140,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/trmv.cpp
+++ b/benchmark/syclblas/blas2/trmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Trmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::trmv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -135,8 +130,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/trsv.cpp
+++ b/benchmark/syclblas/blas2/trsv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Trsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::trsv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -142,8 +137,11 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, ts, diags, n, success)->UseRealTime();
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, ts, diags, n, success)
+        ->UseRealTime();
   }
 }
 

--- a/benchmark/syclblas/blas3/gemm.cpp
+++ b/benchmark/syclblas/blas3/gemm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1, int t2,
@@ -137,9 +132,11 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(t1s, t2s, m, k, n).c_str(),
-                                 BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas3/gemm_batched.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched.cpp
@@ -25,6 +25,9 @@
 
 #include "../utils.hpp"
 
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched;
+
 // Convert batch_type=strided to interleaved on the host
 template <typename scalar_t>
 std::vector<scalar_t> strided_to_interleaved(const std::vector<scalar_t>& input,
@@ -57,17 +60,6 @@ std::vector<scalar_t> interleaved_to_strided(const std::vector<scalar_t>& input,
     }
   }
   return output;
-}
-
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int batch_type) {
-  std::ostringstream str{};
-  str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
-      << batch_size << "/"
-      << blas_benchmark::utils::batch_type_to_str(batch_type);
-  return str.str();
 }
 
 template <typename scalar_t>
@@ -209,7 +201,10 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_type, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, batch_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, batch_size, batch_type,
+            blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         batch_type, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched_strided.cpp
@@ -25,17 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int stride_a_mul, int stride_b_mul,
-                     int stride_c_mul) {
-  std::ostringstream str{};
-  str << "BM_GemmBatchedStrided<"
-      << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
-      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
-      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched_strided;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
@@ -182,8 +173,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     strd_a_mul, strd_b_mul, strd_c_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, stride_a_mul,
-                           stride_b_mul, stride_c_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, batch_size, stride_a_mul, stride_b_mul,
+            stride_c_mul, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         stride_a_mul, stride_b_mul, stride_c_mul, success)

--- a/benchmark/syclblas/blas3/trsm.cpp
+++ b/benchmark/syclblas/blas3/trsm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char trans, char diag, index_t m,
-                     index_t n) {
-  std::ostringstream str{};
-  str << "BM_Trsm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << trans << "/" << diag << "/" << m << "/"
-      << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char side,
@@ -174,8 +167,11 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, side, uplo, trans, diag, m, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
-        sb_handle_ptr, side, uplo, trans, diag, m, n, alpha, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, trans, diag, m, n,
+            blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, side, uplo, trans, diag, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/extension/reduction.cpp
+++ b/benchmark/syclblas/extension/reduction.cpp
@@ -27,14 +27,8 @@
 
 using namespace blas;
 
-template <typename scalar_t>
-std::string get_name(int rows, int cols, reduction_dim_t reduction_dim) {
-  std::ostringstream str{};
-  str << "BM_Reduction<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << rows << "/" << cols << "/"
-      << (reduction_dim == reduction_dim_t::inner ? "inner" : "outer");
-  return str.str();
-}
+constexpr blas_benchmark::utils::ExtensionOp benchmark_op =
+    blas_benchmark::utils::ExtensionOp::reduction;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t rows,
@@ -147,10 +141,14 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, rows, cols, dim, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(rows, cols, reduction_dim_t::inner).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            rows, cols, "inner", blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, rows, cols, reduction_dim_t::inner, success);
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(rows, cols, reduction_dim_t::outer).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            rows, cols, "outer", blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, rows, cols, reduction_dim_t::outer, success);
   }
 }

--- a/common/include/common/benchmark_identifier.hpp
+++ b/common/include/common/benchmark_identifier.hpp
@@ -1,0 +1,110 @@
+/*
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename benchmark_identifier.hpp
+ *
+ */
+
+#ifndef SYCL_BLAS_BENCHMARK_IDENTIFIER_HPP
+#define SYCL_BLAS_BENCHMARK_IDENTIFIER_HPP
+
+namespace blas_benchmark {
+namespace utils {
+
+enum class Level1Op : int {
+  asum = 0,
+  axpy = 1,
+  dot = 2,
+  iamax = 3,
+  iamin = 4,
+  nrm2 = 5,
+  rotm = 6,
+  rotmg = 7,
+  scal = 8,
+  sdsdot = 9,
+  copy = 10,
+  rotg = 11
+};
+
+enum class Level2Op : int {
+  gbmv = 0,
+  gemv = 1,
+  ger = 2,
+  sbmv = 3,
+  spmv = 4,
+  spr = 5,
+  spr2 = 6,
+  symv = 7,
+  syr = 8,
+  syr2 = 9,
+  tbmv = 10,
+  tbsv = 11,
+  tpmv = 12,
+  tpsv = 13,
+  trmv = 14,
+  trsv = 15
+};
+
+enum class Level3Op : int {
+  gemm_batched_strided = 0,
+  gemm_batched = 1,
+  gemm = 2,
+  symm = 3,
+  syr2k = 4,
+  syrk = 5,
+  trmm = 6,
+  trsm_batched = 7,
+  trsm = 8
+};
+
+template <Level1Op op>
+std::string get_operator_name() {
+  if constexpr (op == Level1Op::asum)
+    return "Asum";
+  else if constexpr (op == Level1Op::axpy)
+    return "Axpy";
+  else if constexpr (op == Level1Op::dot)
+    return "Dot";
+  else if constexpr (op == Level1Op::iamax)
+    return "Iamax";
+  else if constexpr (op == Level1Op::iamin)
+    return "Iamin";
+  else if constexpr (op == Level1Op::nrm2)
+    return "Nrm2";
+  else if constexpr (op == Level1Op::rotm)
+    return "Rotm";
+  else if constexpr (op == Level1Op::rotmg)
+    return "Rotmg";
+  else if constexpr (op == Level1Op::scal)
+    return "Scal";
+  else if constexpr (op == Level1Op::sdsdot)
+    return "Sdsdot";
+  else if constexpr (op == Level1Op::copy)
+    return "Copy";
+  else if constexpr (op == Level1Op::rotg)
+    return "Rotg";
+  else
+    throw std::runtime_error("Unknown BLAS 1 operator");
+}
+
+}  // namespace utils
+}  // namespace blas_benchmark
+
+#endif  // SYCL_BLAS_BENCHMARK_IDENTIFIER_HPP

--- a/common/include/common/benchmark_identifier.hpp
+++ b/common/include/common/benchmark_identifier.hpp
@@ -74,6 +74,8 @@ enum class Level3Op : int {
   trsm = 8
 };
 
+enum class ExtensionOp : int { reduction = 0 };
+
 template <Level1Op op>
 std::string get_operator_name() {
   if constexpr (op == Level1Op::asum)
@@ -102,6 +104,76 @@ std::string get_operator_name() {
     return "Rotg";
   else
     throw std::runtime_error("Unknown BLAS 1 operator");
+}
+
+template <Level2Op op>
+std::string get_operator_name() {
+  if constexpr (op == Level2Op::gbmv)
+    return "Gbmv";
+  else if constexpr (op == Level2Op::gemv)
+    return "Gemv";
+  else if constexpr (op == Level2Op::ger)
+    return "Ger";
+  else if constexpr (op == Level2Op::sbmv)
+    return "Sbmv";
+  else if constexpr (op == Level2Op::spmv)
+    return "Spmv";
+  else if constexpr (op == Level2Op::spr)
+    return "Spr";
+  else if constexpr (op == Level2Op::spr2)
+    return "Spr2";
+  else if constexpr (op == Level2Op::symv)
+    return "Symv";
+  else if constexpr (op == Level2Op::syr)
+    return "Syr";
+  else if constexpr (op == Level2Op::syr2)
+    return "Syr2";
+  else if constexpr (op == Level2Op::tbmv)
+    return "Tbmv";
+  else if constexpr (op == Level2Op::tbsv)
+    return "Tbsv";
+  else if constexpr (op == Level2Op::tpmv)
+    return "Tpmv";
+  else if constexpr (op == Level2Op::tpsv)
+    return "Tpsv";
+  else if constexpr (op == Level2Op::trmv)
+    return "Trmv";
+  else if constexpr (op == Level2Op::trsv)
+    return "Trsv";
+  else
+    throw std::runtime_error("Unknown BLAS 2 operator");
+}
+
+template <Level3Op op>
+std::string get_operator_name() {
+  if constexpr (op == Level3Op::gemm_batched_strided)
+    return "Gemm_batched_strided";
+  else if constexpr (op == Level3Op::gemm_batched)
+    return "Gemm_batched";
+  else if constexpr (op == Level3Op::gemm)
+    return "Gemm";
+  else if constexpr (op == Level3Op::symm)
+    return "Symm";
+  else if constexpr (op == Level3Op::syr2k)
+    return "Syr2k";
+  else if constexpr (op == Level3Op::syrk)
+    return "Syrk";
+  else if constexpr (op == Level3Op::trmm)
+    return "Trmm";
+  else if constexpr (op == Level3Op::trsm_batched)
+    return "Trsm_batched";
+  else if constexpr (op == Level3Op::trsm)
+    return "Trsm";
+  else
+    throw std::runtime_error("Unknown BLAS 3 operator");
+}
+
+template <ExtensionOp op>
+std::string get_operator_name() {
+  if constexpr (op == ExtensionOp::reduction)
+    return "Reduction";
+  else
+    throw std::runtime_error("Unknown BLAS extension operator");
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -73,8 +73,8 @@ inline std::string get_name(Args... args) {
 template <Level1Op op, typename scalar_t>
 inline typename std::enable_if<op == Level1Op::rotg || op == Level1Op::rotmg,
                                std::string>::type
-get_name() {
-  return internal::get_name<op, scalar_t>();
+get_name(std::string mem_type) {
+  return internal::get_name<op, scalar_t>(mem_type);
 }
 
 template <Level1Op op, typename scalar_t, typename index_t>
@@ -85,14 +85,14 @@ inline
                                 op == Level1Op::rotm || op == Level1Op::scal ||
                                 op == Level1Op::sdsdot,
                             std::string>::type
-    get_name(index_t size) {
-  return internal::get_name<op, scalar_t>(size);
+    get_name(index_t size, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(size, mem_type);
 }
 
 template <Level1Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level1Op::copy, std::string>::type
-get_name(index_t size, index_t incx, index_t incy) {
-  return internal::get_name<op, scalar_t>(size, incx, incy);
+get_name(index_t size, index_t incx, index_t incy, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(size, incx, incy, mem_type);
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -32,6 +32,7 @@ namespace utils {
 
 template <typename scalar_t>
 static inline std::string get_type_name();
+inline std::string batch_type_to_str(int batch_type);
 
 namespace internal {
 
@@ -68,6 +69,31 @@ inline std::string get_name(Args... args) {
   str << get_parameters_as_string(args...);
   return str.str();
 }
+
+template <Level2Op op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
+  str << get_parameters_as_string(args...);
+  return str.str();
+}
+
+template <Level3Op op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
+  str << get_parameters_as_string(args...);
+  return str.str();
+}
+
+template <ExtensionOp op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
+  str << get_parameters_as_string(args...);
+  return str.str();
+}
+
 }  // namespace internal
 
 template <Level1Op op, typename scalar_t>
@@ -93,6 +119,133 @@ template <Level1Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level1Op::copy, std::string>::type
 get_name(index_t size, index_t incx, index_t incy, std::string mem_type) {
   return internal::get_name<op, scalar_t>(size, incx, incy, mem_type);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::gbmv, std::string>::type
+get_name(std::string t, index_t m, index_t n, index_t kl, index_t ku,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(t, m, n, kl, ku, mem_type);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::gemv || op == Level2Op::sbmv,
+                               std::string>::type
+get_name(std::string t, index_t m, index_t n, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(t, m, n, mem_type);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::ger, std::string>::type get_name(
+    index_t m, index_t n, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(m, n, mem_type);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::syr || op == Level2Op::syr2,
+                               std::string>::type
+get_name(std::string uplo, index_t n, scalar_t alpha, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, mem_type);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::spr, std::string>::type get_name(
+    std::string uplo, index_t n, scalar_t alpha, index_t incx,
+    std::string mem_type) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, incx, mem_type);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::spmv || op == Level2Op::symv,
+                               std::string>::type
+get_name(std::string uplo, index_t n, scalar_t alpha, scalar_t beta,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, beta, mem_type);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::spr2, std::string>::type
+get_name(std::string uplo, index_t n, scalar_t alpha, index_t incx,
+         index_t incy, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, incx, incy, mem_type);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::tbmv || op == Level2Op::tbsv,
+                               std::string>::type
+get_name(std::string uplo, std::string t, std::string diag, index_t n,
+         index_t k, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(uplo, t, diag, n, k, mem_type);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::tpmv || op == Level2Op::trmv ||
+                                   op == Level2Op::trsv,
+                               std::string>::type
+get_name(std::string uplo, std::string t, std::string diag, index_t n,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(uplo, t, diag, n, mem_type);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::gemm, std::string>::type
+get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(t1, t2, m, k, n, mem_type);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::gemm_batched, std::string>::type
+get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n,
+         index_t batch_size, int batch_type, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(
+      t1, t2, m, k, n, batch_size, batch_type_to_str(batch_type), mem_type);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::gemm_batched_strided,
+                               std::string>::type
+get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n,
+         index_t batch_size, index_t stride_a_mul, index_t stride_b_mul,
+         index_t stride_c_mul, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(t1, t2, m, k, n, batch_size,
+                                          stride_a_mul, stride_b_mul,
+                                          stride_c_mul, mem_type);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::symm || op == Level3Op::syr2k ||
+                                   op == Level3Op::syrk,
+                               std::string>::type
+get_name(std::string s1, std::string s2, index_t m, index_t n, scalar_t alpha,
+         scalar_t beta, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(s1, s2, m, n, alpha, beta, mem_type);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::trsm || op == Level3Op::trmm,
+                               std::string>::type
+get_name(char side, char uplo, char trans, char diag, index_t m, index_t n,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(side, uplo, trans, diag, m, n,
+                                          mem_type);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::trsm_batched, std::string>::type
+get_name(char side, char uplo, char trans, char diag, index_t m, index_t n,
+         index_t batch_size, index_t stride_a_mul, index_t stride_b_mul,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(side, uplo, trans, diag, m, n,
+                                          batch_size, stride_a_mul,
+                                          stride_b_mul, mem_type);
+}
+
+template <ExtensionOp op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == ExtensionOp::reduction, std::string>::type
+get_name(index_t rows, index_t cols, std::string reduction_dim,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(rows, cols, reduction_dim, mem_type);
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -180,7 +180,7 @@ get_name(std::string uplo, std::string t, std::string diag, index_t n,
 
 template <Level2Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level2Op::tpmv || op == Level2Op::trmv ||
-                                   op == Level2Op::trsv,
+                                   op == Level2Op::trsv || op == Level2Op::tpsv,
                                std::string>::type
 get_name(std::string uplo, std::string t, std::string diag, index_t n,
          std::string mem_type) {

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -1,0 +1,76 @@
+/*
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL-BLAS: BLAS implementation using SYCL
+ *
+ *  @filename benchmark_names.hpp
+ *
+ */
+
+#ifndef SYCL_BLAS_BENCHMARK_NAMES_HPP
+#define SYCL_BLAS_BENCHMARK_NAMES_HPP
+
+#include <common/common_utils.hpp>
+
+namespace blas_benchmark {
+namespace utils {
+
+template <typename scalar_t>
+static inline std::string get_type_name();
+
+namespace internal {
+
+template <typename T>
+std::string get_parameters_as_string(T arg) {
+  std::ostringstream str{};
+  str << arg;
+  return str.str();
+}
+
+template <typename T, typename... Args>
+std::string get_parameters_as_string(T arg, Args... args) {
+  std::ostringstream str{};
+  str << arg << "/" << get_parameters_as_string(args...);
+  return str.str();
+}
+
+template <typename scalar_t>
+std::string get_benchmark_name(const std::string &operator_name) {
+  std::ostringstream str{};
+  str << "BM_" << operator_name << "<" << get_type_name<scalar_t>() << ">";
+  return str.str();
+}
+}  // namespace internal
+
+template <Level1Op op, typename scalar_t>
+inline std::string get_name() {
+  return internal::get_benchmark_name<scalar_t>(get_operator_name<op>());
+}
+
+template <Level1Op op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << get_name<op, scalar_t>() << "/";
+  str << internal::get_parameters_as_string(args...);
+  return str.str();
+}
+
+}  // namespace utils
+}  // namespace blas_benchmark
+
+#endif  // SYCL_BLAS_BENCHMARK_NAMES_HPP

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -50,24 +50,49 @@ std::string get_parameters_as_string(T arg, Args... args) {
 }
 
 template <typename scalar_t>
-std::string get_benchmark_name(const std::string &operator_name) {
+inline std::string get_benchmark_name(const std::string &operator_name) {
   std::ostringstream str{};
   str << "BM_" << operator_name << "<" << get_type_name<scalar_t>() << ">";
   return str.str();
 }
-}  // namespace internal
 
-template <Level1Op op, typename scalar_t>
+template <Level1Op op, typename scalar_t, typename... Args>
 inline std::string get_name() {
-  return internal::get_benchmark_name<scalar_t>(get_operator_name<op>());
+  return get_benchmark_name<scalar_t>(get_operator_name<op>());
 }
 
 template <Level1Op op, typename scalar_t, typename... Args>
 inline std::string get_name(Args... args) {
   std::ostringstream str{};
   str << get_name<op, scalar_t>() << "/";
-  str << internal::get_parameters_as_string(args...);
+  str << get_parameters_as_string(args...);
   return str.str();
+}
+}  // namespace internal
+
+template <Level1Op op, typename scalar_t>
+inline typename std::enable_if<op == Level1Op::rotg || op == Level1Op::rotmg,
+                               std::string>::type
+get_name() {
+  return internal::get_name<op, scalar_t>();
+}
+
+template <Level1Op op, typename scalar_t, typename index_t>
+inline
+    typename std::enable_if<op == Level1Op::asum || op == Level1Op::axpy ||
+                                op == Level1Op::dot || op == Level1Op::iamax ||
+                                op == Level1Op::iamin || op == Level1Op::nrm2 ||
+                                op == Level1Op::rotm || op == Level1Op::scal ||
+                                op == Level1Op::sdsdot,
+                            std::string>::type
+    get_name(index_t size) {
+  return internal::get_name<op, scalar_t>(size);
+}
+
+template <Level1Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level1Op::copy, std::string>::type
+get_name(index_t size, index_t incx, index_t incy) {
+  return internal::get_name<op, scalar_t>(size, incx, incy);
 }
 
 }  // namespace utils

--- a/common/include/common/blas1_state_counters.hpp
+++ b/common/include/common/blas1_state_counters.hpp
@@ -26,22 +26,10 @@
 #ifndef COMMON_BLAS1_STATE_COUNTERS
 #define COMMON_BLAS1_STATE_COUNTERS
 
+#include "benchmark_identifier.hpp"
+
 namespace blas_benchmark {
 namespace utils {
-
-enum class Level1Op : int {
-  asum = 0,
-  axpy = 1,
-  dot = 2,
-  iamax = 3,
-  iamin = 4,
-  nrm2 = 5,
-  rotm = 6,
-  rotmg = 7,
-  scal = 8,
-  sdsdot = 9,
-  copy = 10
-};
 
 template <Level1Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level1Op::asum || op == Level1Op::iamax ||

--- a/common/include/common/blas2_state_counters.hpp
+++ b/common/include/common/blas2_state_counters.hpp
@@ -26,27 +26,10 @@
 #ifndef COMMON_BLAS2_STATE_COUNTERS
 #define COMMON_BLAS2_STATE_COUNTERS
 
+#include "benchmark_identifier.hpp"
+
 namespace blas_benchmark {
 namespace utils {
-
-enum class Level2Op : int {
-  gbmv = 0,
-  gemv = 1,
-  ger = 2,
-  sbmv = 3,
-  spmv = 4,
-  spr = 5,
-  spr2 = 6,
-  symv = 7,
-  syr = 8,
-  syr2 = 9,
-  tbmv = 10,
-  tbsv = 11,
-  tpmv = 12,
-  tpsv = 13,
-  trmv = 14,
-  trsv = 15
-};
 
 template <Level2Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level2Op::gbmv>::type

--- a/common/include/common/blas3_state_counters.hpp
+++ b/common/include/common/blas3_state_counters.hpp
@@ -26,20 +26,10 @@
 #ifndef COMMON_BLAS3_STATE_COUNTERS
 #define COMMON_BLAS3_STATE_COUNTERS
 
+#include "benchmark_identifier.hpp"
+
 namespace blas_benchmark {
 namespace utils {
-
-enum class Level3Op : int {
-  gemm_batched_strided = 0,
-  gemm_batched = 1,
-  gemm = 2,
-  symm = 3,
-  syr2k = 4,
-  syrk = 5,
-  trmm = 6,
-  trsm_batched = 7,
-  trsm = 8
-};
 
 template <Level3Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level3Op::gemm_batched_strided ||

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -18,6 +18,8 @@
 
 #include "benchmark_cli_args.hpp"
 #include "blas_meta.h"
+#include "common/benchmark_identifier.hpp"
+#include <common/benchmark_names.hpp>
 #include <common/blas1_state_counters.hpp>
 #include <common/blas2_state_counters.hpp>
 #include <common/blas3_state_counters.hpp>

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -18,7 +18,7 @@
 
 #include "benchmark_cli_args.hpp"
 #include "blas_meta.h"
-#include "common/benchmark_identifier.hpp"
+#include <common/benchmark_identifier.hpp>
 #include <common/benchmark_names.hpp>
 #include <common/blas1_state_counters.hpp>
 #include <common/blas2_state_counters.hpp>

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -104,6 +104,9 @@ namespace blas_benchmark {
 
 namespace utils {
 
+constexpr std::string MEM_TYPE_BUFFER = "buffer";
+constexpr std::string MEM_TYPE_USM = "buffer";
+
 /**
  * @brief Print the explanatory string of an exception.
  * If the exception is nested, recurse to print the explanatory of the

--- a/common/include/common/common_utils.hpp
+++ b/common/include/common/common_utils.hpp
@@ -104,8 +104,8 @@ namespace blas_benchmark {
 
 namespace utils {
 
-constexpr std::string MEM_TYPE_BUFFER = "buffer";
-constexpr std::string MEM_TYPE_USM = "buffer";
+inline constexpr char MEM_TYPE_BUFFER[] = "buffer";
+inline constexpr char MEM_TYPE_USM[] = "usm";
 
 /**
  * @brief Print the explanatory string of an exception.


### PR DESCRIPTION
This PR moves the get_name function in the BLAS Level 1 benchmarks to a common location, ensuring that different backends can obtain uniform benchmark names.