### PR TITLE
Refactor get_name for BLAS Level 2 benchmarks

### DIFF
--- a/benchmark/cublas/blas1/asum.cpp
+++ b/benchmark/cublas/blas1/asum.cpp
@@ -135,8 +135,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t size, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
-                                 cuda_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            size, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas1/asum.cpp
+++ b/benchmark/cublas/blas1/asum.cpp
@@ -135,11 +135,8 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t size, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, size, success);
     };
-    benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            size, blas_benchmark::utils::MEM_TYPE_USM)
-            .c_str(),
-        BM_lambda, cuda_handle_ptr, size, success)
+    benchmark::RegisterBenchmark(get_name<scalar_t>(size).c_str(), BM_lambda,
+                                 cuda_handle_ptr, size, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/gbmv.cpp
+++ b/benchmark/cublas/blas2/gbmv.cpp
@@ -162,8 +162,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, t, m, n, kl, ku, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n, kl,
-                                                                ku)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            ts, m, n, kl, ku, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, t, m, n, kl, ku, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/gbmv.cpp
+++ b/benchmark/cublas/blas2/gbmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t, int m, int n, int kl, int ku) {
-  std::ostringstream str{};
-  str << "BM_Gbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n << "/" << kl << "/" << ku;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::gbmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -166,9 +161,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, t, m, n, kl, ku, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n, kl, ku).c_str(),
-                                 BM_lambda, cuda_handle_ptr, t, m, n, kl, ku,
-                                 alpha, beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n, kl,
+                                                                ku)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, t, m, n, kl, ku, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/gemv.cpp
+++ b/benchmark/cublas/blas2/gemv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::gemv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,9 +159,10 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t beta, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, t, m, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n).c_str(),
-                                 BM_lambda, cuda_handle_ptr, t, m, n, alpha,
-                                 beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, t, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/gemv.cpp
+++ b/benchmark/cublas/blas2/gemv.cpp
@@ -160,7 +160,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, t, m, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            ts, m, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, t, m, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/ger.cpp
+++ b/benchmark/cublas/blas2/ger.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Ger<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::ger;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -158,8 +153,9 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t m, index_t n, scalar_t alpha, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, m, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(m, n).c_str(), BM_lambda,
-                                 cuda_handle_ptr, m, n, alpha, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(m, n).c_str(),
+        BM_lambda, cuda_handle_ptr, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/ger.cpp
+++ b/benchmark/cublas/blas2/ger.cpp
@@ -154,7 +154,9 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, m, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(m, n).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            m, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, m, n, alpha, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas2/sbmv.cpp
+++ b/benchmark/cublas/blas2/sbmv.cpp
@@ -160,7 +160,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, n, k, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n, k)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, k, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, uplos, n, k, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/sbmv.cpp
+++ b/benchmark/cublas/blas2/sbmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, int k) {
-  std::ostringstream str{};
-  str << "BM_Sbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::sbmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,9 +159,10 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, uplos, n, k, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplos, n, k).c_str(),
-                                 BM_lambda, cuda_handle_ptr, uplos, n, k, alpha,
-                                 beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n, k)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/spmv.cpp
+++ b/benchmark/cublas/blas2/spmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha, scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Spmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha << "/" << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -163,8 +158,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, n, alpha, beta).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, n, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n, alpha,
+                                                                beta)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/spmv.cpp
+++ b/benchmark/cublas/blas2/spmv.cpp
@@ -158,8 +158,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n, alpha,
-                                                                beta)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, uplos, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/spr.cpp
+++ b/benchmark/cublas/blas2/spr.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, int n, scalar_t alpha, int incX) {
-  std::ostringstream str{};
-  str << "BM_Spr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha << "/" << incX;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spr;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -157,8 +152,10 @@ void register_benchmark(blas_benchmark::Args& args,
           run<scalar_t>(st, cuda_handle_ptr, uplo, n, alpha, incX, success);
         };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo_c, n, alpha, incX).c_str(), BM_lambda_col,
-        cuda_handle_ptr, uplo_c, n, alpha, incX, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo_c, n,
+                                                                alpha, incX)
+            .c_str(),
+        BM_lambda_col, cuda_handle_ptr, uplo_c, n, alpha, incX, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/spr.cpp
+++ b/benchmark/cublas/blas2/spr.cpp
@@ -152,8 +152,8 @@ void register_benchmark(blas_benchmark::Args& args,
           run<scalar_t>(st, cuda_handle_ptr, uplo, n, alpha, incX, success);
         };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo_c, n,
-                                                                alpha, incX)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo_c, n, alpha, incX, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda_col, cuda_handle_ptr, uplo_c, n, alpha, incX, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/spr2.cpp
+++ b/benchmark/cublas/blas2/spr2.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, int size, scalar_t alpha, int incX, int incY) {
-  std::ostringstream str{};
-  str << "BM_Spr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << size << "/" << alpha << "/" << incX << "/" << incY;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spr2;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -160,8 +155,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplo, n, alpha, incX, incY, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo_c, n, alpha, incX, incY).c_str(), BM_lambda_col,
-        cuda_handle_ptr, uplo_c, n, alpha, incX, incY, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo_c, n, alpha, incX, incY)
+            .c_str(),
+        BM_lambda_col, cuda_handle_ptr, uplo_c, n, alpha, incX, incY, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/spr2.cpp
+++ b/benchmark/cublas/blas2/spr2.cpp
@@ -156,7 +156,7 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            uplo_c, n, alpha, incX, incY)
+            uplo_c, n, alpha, incX, incY, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda_col, cuda_handle_ptr, uplo_c, n, alpha, incX, incY, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/symv.cpp
+++ b/benchmark/cublas/blas2/symv.cpp
@@ -160,8 +160,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n, alpha,
-                                                                beta)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, uplos, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/symv.cpp
+++ b/benchmark/cublas/blas2/symv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha, scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Symv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha << "/" << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::symv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -165,8 +160,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, n, alpha, beta).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, n, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n, alpha,
+                                                                beta)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/syr.cpp
+++ b/benchmark/cublas/blas2/syr.cpp
@@ -152,7 +152,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplo, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, alpha)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, alpha, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, uplo, n, alpha, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/syr.cpp
+++ b/benchmark/cublas/blas2/syr.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha) {
-  std::ostringstream str{};
-  str << "BM_Syr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::syr;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -156,9 +151,10 @@ void register_benchmark(blas_benchmark::Args& args,
                          bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, uplo, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, alpha).c_str(),
-                                 BM_lambda, cuda_handle_ptr, uplo, n, alpha,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, alpha)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplo, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/syr2.cpp
+++ b/benchmark/cublas/blas2/syr2.cpp
@@ -161,7 +161,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplo, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, alpha)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, alpha, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, uplo, n, alpha, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/syr2.cpp
+++ b/benchmark/cublas/blas2/syr2.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha) {
-  std::ostringstream str{};
-  str << "BM_Syr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::syr2;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -165,9 +160,10 @@ void register_benchmark(blas_benchmark::Args& args,
                          bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, uplo, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, alpha).c_str(),
-                                 BM_lambda, cuda_handle_ptr, uplo, n, alpha,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, alpha)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplo, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/tbmv.cpp
+++ b/benchmark/cublas/blas2/tbmv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n,
-                     int k) {
-  std::ostringstream str{};
-  str << "BM_Tbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tbmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -167,8 +161,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, ts, diags, n, k, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n, k)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, k, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/tbmv.cpp
+++ b/benchmark/cublas/blas2/tbmv.cpp
@@ -161,8 +161,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n, k)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, k, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, k, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/tbsv.cpp
+++ b/benchmark/cublas/blas2/tbsv.cpp
@@ -171,8 +171,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n, k)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, k, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, k, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/tbsv.cpp
+++ b/benchmark/cublas/blas2/tbsv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag,
-                     const int n, const int k) {
-  std::ostringstream str{};
-  str << "BM_Tbsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tbsv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -177,8 +171,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, ts, diags, n, k, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n, k)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, k, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/tpmv.cpp
+++ b/benchmark/cublas/blas2/tpmv.cpp
@@ -159,8 +159,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/tpmv.cpp
+++ b/benchmark/cublas/blas2/tpmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Tpmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tpmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,8 +159,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/tpsv.cpp
+++ b/benchmark/cublas/blas2/tpsv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Tpsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tpsv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -175,8 +170,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/tpsv.cpp
+++ b/benchmark/cublas/blas2/tpsv.cpp
@@ -170,8 +170,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/trmv.cpp
+++ b/benchmark/cublas/blas2/trmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Trmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::trmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -177,8 +172,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/trmv.cpp
+++ b/benchmark/cublas/blas2/trmv.cpp
@@ -172,8 +172,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas2/trsv.cpp
+++ b/benchmark/cublas/blas2/trsv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Trsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::trsv;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -173,8 +168,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        cuda_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas2/trsv.cpp
+++ b/benchmark/cublas/blas2/trsv.cpp
@@ -168,8 +168,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas3/gemm.cpp
+++ b/benchmark/cublas/blas3/gemm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,9 +159,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(t1s, t2s, m, k, n).c_str(),
-                                 BM_lambda, cuda_handle_ptr, t1, t2, m, k, n,
-                                 alpha, beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas3/gemm_batched.cpp
+++ b/benchmark/cublas/blas3/gemm_batched.cpp
@@ -25,16 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_count, int batch_type) {
-  std::ostringstream str{};
-  str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
-      << batch_count << "/"
-      << blas_benchmark::utils::batch_type_to_str(batch_type);
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -207,7 +199,10 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_count, batch_type, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_count, batch_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, batch_count, batch_type,
+            blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_count,
         batch_type, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/cublas/blas3/gemm_batched_strided.cpp
@@ -25,18 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int stride_a_mul, int stride_b_mul,
-                     int stride_c_mul) {
-  std::ostringstream str{};
-  str << "BM_GemmBatchedStrided<"
-      << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
-      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
-      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul;
-
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched_strided;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -208,8 +198,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_size, strd_a_mul, strd_b_mul, strd_c_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, stride_a_mul,
-                           stride_b_mul, stride_c_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, batch_size, stride_a_mul, stride_b_mul,
+            stride_c_mul, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         stride_a_mul, stride_b_mul, stride_c_mul, success)

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, int m, int n, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Symm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << m << "/" << n << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::symm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,7 +157,10 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_side, s_uplo, m, n, alpha, beta).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_side, s_uplo, m, n, alpha, beta,
+            blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, s_side, s_uplo, m, n, alpha, beta, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas3/syr2k.cpp
+++ b/benchmark/cublas/blas3/syr2k.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Syr2k<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::syr2k;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -163,7 +156,10 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_uplo, s_trans, n, k, alpha, beta).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_uplo, s_trans, n, k, alpha, beta,
+            blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, s_uplo, s_trans, n, k, alpha, beta, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas3/syrk.cpp
+++ b/benchmark/cublas/blas3/syrk.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Syrk<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::syrk;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -159,7 +152,10 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_uplo, s_trans, n, k, alpha, beta).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_uplo, s_trans, n, k, alpha, beta,
+            blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, s_uplo, s_trans, n, k, alpha, beta, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas3/trmm.cpp
+++ b/benchmark/cublas/blas3/trmm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char t, char diag, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Trmm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << t << "/" << diag << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trmm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -176,7 +171,10 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_side, s_uplo, s_t, s_diag, m, n).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_side, s_uplo, s_t, s_diag, m, n,
+            blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, s_side, s_uplo, s_t, s_diag, m, n, alpha,
         success)
         ->UseRealTime();

--- a/benchmark/cublas/blas3/trsm.cpp
+++ b/benchmark/cublas/blas3/trsm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char trans, char diag, index_t m,
-                     index_t n) {
-  std::ostringstream str{};
-  str << "BM_Trsm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << trans << "/" << diag << "/" << m << "/"
-      << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -178,8 +171,11 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
-        cuda_handle_ptr, side, uplo, trans, diag, m, n, alpha, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, trans, diag, m, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, side, uplo, trans, diag, m, n, alpha,
+        success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas3/trsm_batched.cpp
+++ b/benchmark/cublas/blas3/trsm_batched.cpp
@@ -25,16 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(const char side, const char uplo, const char t,
-                     const char diag, int m, int n, int batch_count,
-                     int stride_a_mul, int stride_b_mul) {
-  std::ostringstream str{};
-  str << "BM_TrsmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << side << "/" << uplo << "/" << t << "/" << diag << "/" << m
-      << "/" << n << "/" << batch_count;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm_batched;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -216,8 +208,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_count, strd_a_mul, strd_b_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_side, s_uplo, s_t, s_diag, m, n, batch_count,
-                           stride_a_mul, stride_b_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_side, s_uplo, s_t, s_diag, m, n, batch_count, stride_a_mul,
+            stride_b_mul, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, s_side, s_uplo, s_t, s_diag, m, n, alpha,
         batch_count, stride_a_mul, stride_b_mul, success)

--- a/benchmark/rocblas/blas2/gbmv.cpp
+++ b/benchmark/rocblas/blas2/gbmv.cpp
@@ -176,8 +176,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, t, m, n, kl, ku, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n, kl,
-                                                                ku)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            ts, m, n, kl, ku, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, t, m, n, kl, ku, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/gbmv.cpp
+++ b/benchmark/rocblas/blas2/gbmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t, int m, int n, int kl, int ku) {
-  std::ostringstream str{};
-  str << "BM_Gbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n << "/" << kl << "/" << ku;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::gbmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gbmv_f(args_t&&... args) {
@@ -180,9 +175,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, t, m, n, kl, ku, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n, kl, ku).c_str(),
-                                 BM_lambda, rb_handle, t, m, n, kl, ku, alpha,
-                                 beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n, kl,
+                                                                ku)
+            .c_str(),
+        BM_lambda, rb_handle, t, m, n, kl, ku, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/gemv.cpp
+++ b/benchmark/rocblas/blas2/gemv.cpp
@@ -175,7 +175,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, t, m, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            ts, m, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, t, m, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/gemv.cpp
+++ b/benchmark/rocblas/blas2/gemv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::gemv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gemv_f(args_t&&... args) {
@@ -179,9 +174,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          bool* success) {
       run<scalar_t>(st, rb_handle, t, m, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n).c_str(),
-                                 BM_lambda, rb_handle, t, m, n, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n)
+            .c_str(),
+        BM_lambda, rb_handle, t, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/ger.cpp
+++ b/benchmark/rocblas/blas2/ger.cpp
@@ -163,7 +163,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, m, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(m, n).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            m, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, rb_handle, m, n, alpha, success)
         ->UseRealTime();
   }

--- a/benchmark/rocblas/blas2/ger.cpp
+++ b/benchmark/rocblas/blas2/ger.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Ger<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::ger;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_ger_f(args_t&&... args) {
@@ -167,8 +162,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t m, index_t n, scalar_t alpha, bool* success) {
       run<scalar_t>(st, rb_handle, m, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(m, n).c_str(), BM_lambda,
-                                 rb_handle, m, n, alpha, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(m, n).c_str(),
+        BM_lambda, rb_handle, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/sbmv.cpp
+++ b/benchmark/rocblas/blas2/sbmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, int k) {
-  std::ostringstream str{};
-  str << "BM_Sbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::sbmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_sbmv_f(args_t&&... args) {
@@ -176,9 +171,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, uplo, n, k, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, k).c_str(),
-                                 BM_lambda, rb_handle, uplo, n, k, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, k)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/sbmv.cpp
+++ b/benchmark/rocblas/blas2/sbmv.cpp
@@ -172,7 +172,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, n, k, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, k)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, k, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplo, n, k, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/spmv.cpp
+++ b/benchmark/rocblas/blas2/spmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n) {
-  std::ostringstream str{};
-  str << "BM_Spmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_spmv_f(args_t&&... args) {
@@ -173,9 +168,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, uplos, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplos, n).c_str(),
-                                 BM_lambda, rb_handle, uplos, n, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n)
+            .c_str(),
+        BM_lambda, rb_handle, uplos, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/spmv.cpp
+++ b/benchmark/rocblas/blas2/spmv.cpp
@@ -169,7 +169,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplos, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/spr.cpp
+++ b/benchmark/rocblas/blas2/spr.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, int n, scalar_t alpha, int incX) {
-  std::ostringstream str{};
-  str << "BM_Spr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha << "/" << incX;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spr;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_spr_f(args_t&&... args) {
@@ -165,8 +160,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, n, alpha, incX, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo_str, n, alpha, incX).c_str(), BM_lambda_col,
-        rb_handle, uplo_str, n, alpha, incX, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo_str, n,
+                                                                alpha, incX)
+            .c_str(),
+        BM_lambda_col, rb_handle, uplo_str, n, alpha, incX, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/spr.cpp
+++ b/benchmark/rocblas/blas2/spr.cpp
@@ -160,8 +160,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, n, alpha, incX, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo_str, n,
-                                                                alpha, incX)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo_str, n, alpha, incX, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda_col, rb_handle, uplo_str, n, alpha, incX, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/spr2.cpp
+++ b/benchmark/rocblas/blas2/spr2.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, int size, scalar_t alpha, index_t incX,
-                     index_t incY) {
-  std::ostringstream str{};
-  str << "BM_Spr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << size << "/" << alpha << "/" << incX << "/" << incY;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spr2;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_spr2_f(args_t&&... args) {
@@ -174,8 +168,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, n, alpha, incX, incY, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo_c, n, alpha, incX, incY).c_str(), BM_lambda,
-        rb_handle, uplo_c, n, alpha, incX, incY, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo_c, n, alpha, incX, incY)
+            .c_str(),
+        BM_lambda, rb_handle, uplo_c, n, alpha, incX, incY, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/spr2.cpp
+++ b/benchmark/rocblas/blas2/spr2.cpp
@@ -169,7 +169,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            uplo_c, n, alpha, incX, incY)
+            uplo_c, n, alpha, incX, incY, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplo_c, n, alpha, incX, incY, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/symv.cpp
+++ b/benchmark/rocblas/blas2/symv.cpp
@@ -172,7 +172,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplos, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/symv.cpp
+++ b/benchmark/rocblas/blas2/symv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n) {
-  std::ostringstream str{};
-  str << "BM_Symv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::symv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_symv_f(args_t&&... args) {
@@ -176,9 +171,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, uplos, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplos, n).c_str(),
-                                 BM_lambda, rb_handle, uplos, n, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n)
+            .c_str(),
+        BM_lambda, rb_handle, uplos, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/syr.cpp
+++ b/benchmark/rocblas/blas2/syr.cpp
@@ -165,7 +165,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplo, n, alpha, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/syr.cpp
+++ b/benchmark/rocblas/blas2/syr.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n) {
-  std::ostringstream str{};
-  str << "BM_Syr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::syr;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_syr_f(args_t&&... args) {
@@ -169,8 +164,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          bool* success) {
       run<scalar_t>(st, rb_handle, uplo, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n).c_str(), BM_lambda,
-                                 rb_handle, uplo, n, alpha, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/syr2.cpp
+++ b/benchmark/rocblas/blas2/syr2.cpp
@@ -171,7 +171,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplo, n, alpha, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/syr2.cpp
+++ b/benchmark/rocblas/blas2/syr2.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n) {
-  std::ostringstream str{};
-  str << "BM_Syr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::syr2;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_syr2_f(args_t&&... args) {
@@ -175,8 +170,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          bool* success) {
       run<scalar_t>(st, rb_handle, uplo, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n).c_str(), BM_lambda,
-                                 rb_handle, uplo, n, alpha, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/tbmv.cpp
+++ b/benchmark/rocblas/blas2/tbmv.cpp
@@ -169,8 +169,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n, k)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, k, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplos, ts, diags, n, k, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/tbmv.cpp
+++ b/benchmark/rocblas/blas2/tbmv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n,
-                     int k) {
-  std::ostringstream str{};
-  str << "BM_Tbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tbmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_tbmv_f(args_t&&... args) {
@@ -175,8 +169,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
-        rb_handle, uplos, ts, diags, n, k, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n, k)
+            .c_str(),
+        BM_lambda, rb_handle, uplos, ts, diags, n, k, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/tbsv.cpp
+++ b/benchmark/rocblas/blas2/tbsv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n,
-                     int k) {
-  std::ostringstream str{};
-  str << "BM_Tbsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tbsv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_tbsv_f(args_t&&... args) {
@@ -185,8 +179,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo, ts, diags, n, k).c_str(), BM_lambda, rb_handle,
-        uplo, ts, diags, n, k, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, ts, diags,
+                                                                n, k)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, ts, diags, n, k, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/tbsv.cpp
+++ b/benchmark/rocblas/blas2/tbsv.cpp
@@ -179,8 +179,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, ts, diags,
-                                                                n, k)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, ts, diags, n, k, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplo, ts, diags, n, k, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/tpmv.cpp
+++ b/benchmark/rocblas/blas2/tpmv.cpp
@@ -167,8 +167,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, ts, diags,
-                                                                n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplo, ts, diags, n, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/tpmv.cpp
+++ b/benchmark/rocblas/blas2/tpmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Tpmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tpmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_tpmv_f(args_t&&... args) {
@@ -171,9 +166,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t n, bool* success) {
       run<scalar_t>(st, rb_handle, uplo, ts, diags, n, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, ts, diags, n).c_str(),
-                                 BM_lambda, rb_handle, uplo, ts, diags, n,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, ts, diags,
+                                                                n)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/tpsv.cpp
+++ b/benchmark/rocblas/blas2/tpsv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Tpsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tpsv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_tpsv_f(args_t&&... args) {
@@ -181,9 +176,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          index_t n, bool* success) {
       run<scalar_t>(st, rb_handle, uplo, ts, diags, n, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, ts, diags, n).c_str(),
-                                 BM_lambda, rb_handle, uplo, ts, diags, n,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, ts, diags,
+                                                                n)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/tpsv.cpp
+++ b/benchmark/rocblas/blas2/tpsv.cpp
@@ -177,8 +177,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, ts, diags,
-                                                                n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplo, ts, diags, n, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/trmv.cpp
+++ b/benchmark/rocblas/blas2/trmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Trmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::trmv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trmv_f(args_t&&... args) {
@@ -173,8 +168,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda, rb_handle,
-        uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n)
+            .c_str(),
+        BM_lambda, rb_handle, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas2/trmv.cpp
+++ b/benchmark/rocblas/blas2/trmv.cpp
@@ -168,8 +168,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplos, ts, diags, n, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -176,8 +176,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplos, ts, diags, n, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas2/trsv.cpp
+++ b/benchmark/rocblas/blas2/trsv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Trsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::trsv;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trsv_f(args_t&&... args) {
@@ -181,8 +176,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda, rb_handle,
-        uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n)
+            .c_str(),
+        BM_lambda, rb_handle, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/gemm.cpp
+++ b/benchmark/rocblas/blas3/gemm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t_a, std::string t_b, int m, int k, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t_a << "/" << t_b << "/" << m << "/" << k << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gemm_f(args_t&&... args) {
@@ -179,9 +174,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, t1i, t2i, m, k, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(t_a, t_b, m, k, n).c_str(),
-                                 BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n,
-                                 alpha, beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t_a, t_b, m, k, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/gemm_batched.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched.cpp
@@ -25,16 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int batch_type) {
-  std::ostringstream str{};
-  str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
-      << batch_size << "/"
-      << blas_benchmark::utils::batch_type_to_str(batch_type);
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gemm_batched_f(args_t&&... args) {
@@ -207,7 +199,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                     batch_size, batch_type, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t_a, t_b, m, k, n, batch_size, batch_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t_a, t_b, m, k, n, batch_size, batch_type,
+            blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
         BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, batch_size,
         batch_type, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched_strided.cpp
@@ -25,18 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int stride_a_mul, int stride_b_mul,
-                     int stride_c_mul) {
-  std::ostringstream str{};
-  str << "BM_GemmBatchedStrided<"
-      << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
-      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
-      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul;
-
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched_strided;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gemm_strided_batched(args_t&&... args) {
@@ -219,8 +209,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                     strd_a_mul, strd_b_mul, strd_c_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t_a, t_b, m, k, n, batch_size, stride_a_mul,
-                           stride_b_mul, stride_c_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t_a, t_b, m, k, n, batch_size, stride_a_mul, stride_b_mul,
+            stride_c_mul, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, batch_size,
         stride_a_mul, stride_b_mul, stride_c_mul, success)

--- a/benchmark/rocblas/blas3/symm.cpp
+++ b/benchmark/rocblas/blas3/symm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, int m, int n, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Symm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << m << "/" << n << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::symm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_symm_f(args_t&&... args) {
@@ -172,8 +165,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, side, uplo, m, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, m, n, alpha, beta).c_str(), BM_lambda,
-        rb_handle, side, uplo, m, n, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, m, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, side, uplo, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/syr2k.cpp
+++ b/benchmark/rocblas/blas3/syr2k.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Syr2k<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::syr2k;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_syr2k_f(args_t&&... args) {
@@ -169,8 +162,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, trans, n, k, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo, trans, n, k, alpha, beta).c_str(), BM_lambda,
-        rb_handle, uplo, trans, n, k, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, trans, n, k, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, trans, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/syrk.cpp
+++ b/benchmark/rocblas/blas3/syrk.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Syrk<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::syrk;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_syrk_f(args_t&&... args) {
@@ -166,8 +159,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, trans, n, k, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo, trans, n, k, alpha, beta).c_str(), BM_lambda,
-        rb_handle, uplo, trans, n, k, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, trans, n, k, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, trans, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/trmm.cpp
+++ b/benchmark/rocblas/blas3/trmm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char t, char diag, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Trmm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << t << "/" << diag << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trmm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trmm_f(args_t&&... args) {
@@ -177,8 +172,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, side, uplo, t, diag, m, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
-        rb_handle, side, uplo, trans, diag, m, n, alpha, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, trans, diag, m, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, side, uplo, trans, diag, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/trsm.cpp
+++ b/benchmark/rocblas/blas3/trsm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char trans, char diag, index_t m,
-                     index_t n) {
-  std::ostringstream str{};
-  str << "BM_Trsm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << trans << "/" << diag << "/" << m << "/"
-      << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trsm_f(args_t&&... args) {
@@ -181,8 +174,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
-        rb_handle, side, uplo, trans, diag, m, n, alpha, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, trans, diag, m, n, blas_benchmark::utils::MEM_TYPE_USM)
+            .c_str(),
+        BM_lambda, rb_handle, side, uplo, trans, diag, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/trsm_batched.cpp
+++ b/benchmark/rocblas/blas3/trsm_batched.cpp
@@ -25,17 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(const char side, const char uplo, const char t,
-                     const char diag, int m, int n, int batch_size,
-                     int stride_a_mul, int stride_b_mul) {
-  std::ostringstream str{};
-  str << "BM_TrsmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << side << "/" << uplo << "/" << t << "/" << diag << "/" << m
-      << "/" << n << "/" << batch_size << "/" << stride_a_mul << "/"
-      << stride_b_mul << "/";
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm_batched;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trsm_batched_f(args_t&&... args) {
@@ -215,8 +206,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                     strd_a_mul, strd_b_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_side, s_uplo, s_t, s_diag, m, n, batch_size,
-                           stride_a_mul, stride_b_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_side, s_uplo, s_t, s_diag, m, n, batch_size, stride_a_mul,
+            stride_b_mul, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, s_side, s_uplo, s_t, s_diag, m, n, alpha,
         batch_size, stride_a_mul, stride_b_mul, success)

--- a/benchmark/syclblas/blas2/gbmv.cpp
+++ b/benchmark/syclblas/blas2/gbmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t, int m, int n, int kl, int ku) {
-  std::ostringstream str{};
-  str << "BM_Gbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n << "/" << kl << "/" << ku;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::gbmv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int ti,
@@ -140,9 +135,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, t, m, n, kl, ku, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n, kl, ku).c_str(),
-                                 BM_lambda, sb_handle_ptr, t, m, n, kl, ku,
-                                 alpha, beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n, kl,
+                                                                ku)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, t, m, n, kl, ku, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/gbmv.cpp
+++ b/benchmark/syclblas/blas2/gbmv.cpp
@@ -136,8 +136,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, t, m, n, kl, ku, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n, kl,
-                                                                ku)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            ts, m, n, kl, ku, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, t, m, n, kl, ku, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/gemv.cpp
+++ b/benchmark/syclblas/blas2/gemv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::gemv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int ti,
@@ -139,9 +134,10 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          bool* success) {
       run<scalar_t>(st, sb_handle_ptr, t, m, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(ts, m, n).c_str(),
-                                 BM_lambda, sb_handle_ptr, t, m, n, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, t, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/gemv.cpp
+++ b/benchmark/syclblas/blas2/gemv.cpp
@@ -135,7 +135,8 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, t, m, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            ts, m, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, t, m, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/ger.cpp
+++ b/benchmark/syclblas/blas2/ger.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Ger<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::ger;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t m,
@@ -134,8 +129,9 @@ void register_benchmark(blas_benchmark::Args& args,
                          index_t m, index_t n, scalar_t alpha, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, m, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(m, n).c_str(), BM_lambda,
-                                 sb_handle_ptr, m, n, alpha, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(m, n).c_str(),
+        BM_lambda, sb_handle_ptr, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/ger.cpp
+++ b/benchmark/syclblas/blas2/ger.cpp
@@ -130,7 +130,9 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, m, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(m, n).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            m, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, m, n, alpha, success)
         ->UseRealTime();
   }

--- a/benchmark/syclblas/blas2/sbmv.cpp
+++ b/benchmark/syclblas/blas2/sbmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, int k) {
-  std::ostringstream str{};
-  str << "BM_Sbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::sbmv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -137,9 +132,10 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, uplos, n, k, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplos, n, k).c_str(),
-                                 BM_lambda, sb_handle_ptr, uplos, n, k, alpha,
-                                 beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n, k)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/sbmv.cpp
+++ b/benchmark/syclblas/blas2/sbmv.cpp
@@ -133,7 +133,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, n, k, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n, k)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, k, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, uplos, n, k, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/spmv.cpp
+++ b/benchmark/syclblas/blas2/spmv.cpp
@@ -131,8 +131,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n, alpha,
-                                                                beta)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, uplos, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/spmv.cpp
+++ b/benchmark/syclblas/blas2/spmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha, scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Spmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha << "/" << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spmv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -136,8 +131,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, n, alpha, beta).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, n, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n, alpha,
+                                                                beta)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/spr.cpp
+++ b/benchmark/syclblas/blas2/spr.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, int size, scalar_t alpha, int incX) {
-  std::ostringstream str{};
-  str << "BM_Spr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << size << "/" << alpha << "/" << incX;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spr;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char uplo,
@@ -133,8 +128,10 @@ void register_benchmark(blas_benchmark::Args& args,
           run<scalar_t>(st, sb_handle_ptr, uplo, size, alpha, incX, success);
         };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo_c, n, alpha, incX).c_str(), BM_lambda_col,
-        sb_handle_ptr, uplo_c, n, alpha, incX, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo_c, n,
+                                                                alpha, incX)
+            .c_str(),
+        BM_lambda_col, sb_handle_ptr, uplo_c, n, alpha, incX, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/spr.cpp
+++ b/benchmark/syclblas/blas2/spr.cpp
@@ -128,8 +128,8 @@ void register_benchmark(blas_benchmark::Args& args,
           run<scalar_t>(st, sb_handle_ptr, uplo, size, alpha, incX, success);
         };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo_c, n,
-                                                                alpha, incX)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, alpha,
+                                                                incX)
             .c_str(),
         BM_lambda_col, sb_handle_ptr, uplo_c, n, alpha, incX, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/spr.cpp
+++ b/benchmark/syclblas/blas2/spr.cpp
@@ -128,8 +128,8 @@ void register_benchmark(blas_benchmark::Args& args,
           run<scalar_t>(st, sb_handle_ptr, uplo, size, alpha, incX, success);
         };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, alpha,
-                                                                incX)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, alpha, incX, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda_col, sb_handle_ptr, uplo_c, n, alpha, incX, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/spr2.cpp
+++ b/benchmark/syclblas/blas2/spr2.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, int size, scalar_t alpha, int incX, int incY) {
-  std::ostringstream str{};
-  str << "BM_Spr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << size << "/" << alpha << "/" << incX << "/" << incY;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::spr2;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char uplo,
@@ -136,8 +131,10 @@ void register_benchmark(blas_benchmark::Args& args,
           run<scalar_t>(st, sb_handle_ptr, uplo, n, alpha, incX, incY, success);
         };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo_c, n, alpha, incX, incY).c_str(), BM_lambda_col,
-        sb_handle_ptr, uplo_c, n, alpha, incX, incY, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo_c, n, alpha, incX, incY)
+            .c_str(),
+        BM_lambda_col, sb_handle_ptr, uplo_c, n, alpha, incX, incY, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/spr2.cpp
+++ b/benchmark/syclblas/blas2/spr2.cpp
@@ -118,7 +118,7 @@ void register_benchmark(blas_benchmark::Args& args,
   auto spr2_params = blas_benchmark::utils::get_spr2_params<scalar_t>(args);
 
   for (auto p : spr2_params) {
-    int n, incX, incY;
+    index_t n, incX, incY;
     std::string uplo;
     scalar_t alpha;
     std::tie(uplo, n, alpha, incX, incY) = p;
@@ -131,8 +131,8 @@ void register_benchmark(blas_benchmark::Args& args,
           run<scalar_t>(st, sb_handle_ptr, uplo, n, alpha, incX, incY, success);
         };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            uplo_c, n, alpha, incX, incY)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, alpha,
+                                                                incX, incY)
             .c_str(),
         BM_lambda_col, sb_handle_ptr, uplo_c, n, alpha, incX, incY, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/spr2.cpp
+++ b/benchmark/syclblas/blas2/spr2.cpp
@@ -131,8 +131,8 @@ void register_benchmark(blas_benchmark::Args& args,
           run<scalar_t>(st, sb_handle_ptr, uplo, n, alpha, incX, incY, success);
         };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, alpha,
-                                                                incX, incY)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, alpha, incX, incY, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda_col, sb_handle_ptr, uplo_c, n, alpha, incX, incY, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/symv.cpp
+++ b/benchmark/syclblas/blas2/symv.cpp
@@ -132,8 +132,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n, alpha,
-                                                                beta)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, uplos, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/symv.cpp
+++ b/benchmark/syclblas/blas2/symv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha, scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Symv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha << "/" << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::symv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -137,8 +132,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, n, alpha, beta).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, n, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, n, alpha,
+                                                                beta)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/syr.cpp
+++ b/benchmark/syclblas/blas2/syr.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha) {
-  std::ostringstream str{};
-  str << "BM_Syr<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::syr;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -129,9 +124,10 @@ void register_benchmark(blas_benchmark::Args& args,
                          bool* success) {
       run<scalar_t>(st, sb_handle_ptr, uplo, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, alpha).c_str(),
-                                 BM_lambda, sb_handle_ptr, uplo, n, alpha,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, alpha)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplo, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/syr.cpp
+++ b/benchmark/syclblas/blas2/syr.cpp
@@ -125,7 +125,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplo, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, alpha)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, alpha, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, uplo, n, alpha, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/syr2.cpp
+++ b/benchmark/syclblas/blas2/syr2.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, int n, scalar_t alpha) {
-  std::ostringstream str{};
-  str << "BM_Syr2<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << n << "/" << alpha;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::syr2;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -138,9 +133,10 @@ void register_benchmark(blas_benchmark::Args& args,
                          bool* success) {
       run<scalar_t>(st, sb_handle_ptr, uplo, n, alpha, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(uplo, n, alpha).c_str(),
-                                 BM_lambda, sb_handle_ptr, uplo, n, alpha,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, alpha)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplo, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/syr2.cpp
+++ b/benchmark/syclblas/blas2/syr2.cpp
@@ -134,7 +134,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplo, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, n, alpha)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, n, alpha, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, uplo, n, alpha, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/tbmv.cpp
+++ b/benchmark/syclblas/blas2/tbmv.cpp
@@ -130,8 +130,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n, k)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, k, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, uplos, ts, diags, n, k, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/tbmv.cpp
+++ b/benchmark/syclblas/blas2/tbmv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n,
-                     int k) {
-  std::ostringstream str{};
-  str << "BM_Tbmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tbmv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -136,8 +130,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, ts, diags, n, k, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n, k)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, ts, diags, n, k, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/tbsv.cpp
+++ b/benchmark/syclblas/blas2/tbsv.cpp
@@ -140,8 +140,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n, k)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, k, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, uplos, ts, diags, n, k, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/tbsv.cpp
+++ b/benchmark/syclblas/blas2/tbsv.cpp
@@ -25,14 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag,
-                     const int n, const int k) {
-  std::ostringstream str{};
-  str << "BM_Tbsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n << "/" << k;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tbsv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -146,8 +140,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, k, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n, k).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, ts, diags, n, k, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n, k)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, ts, diags, n, k, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/tpmv.cpp
+++ b/benchmark/syclblas/blas2/tpmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Tpmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::tpmv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -130,8 +125,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/tpmv.cpp
+++ b/benchmark/syclblas/blas2/tpmv.cpp
@@ -125,8 +125,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/trmv.cpp
+++ b/benchmark/syclblas/blas2/trmv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Trmv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::trmv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -135,8 +130,10 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, ts, diags, n, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas2/trmv.cpp
+++ b/benchmark/syclblas/blas2/trmv.cpp
@@ -130,8 +130,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas2/trsv.cpp
+++ b/benchmark/syclblas/blas2/trsv.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string uplo, std::string t, std::string diag, int n) {
-  std::ostringstream str{};
-  str << "BM_Trsv<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << t << "/" << diag << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level2Op benchmark_op =
+    blas_benchmark::utils::Level2Op::trsv;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr,
@@ -142,8 +137,11 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplos, ts, diags, n).c_str(), BM_lambda,
-        sb_handle_ptr, uplos, ts, diags, n, success)->UseRealTime();
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
+                                                                diags, n)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, uplos, ts, diags, n, success)
+        ->UseRealTime();
   }
 }
 

--- a/benchmark/syclblas/blas2/trsv.cpp
+++ b/benchmark/syclblas/blas2/trsv.cpp
@@ -137,8 +137,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, sb_handle_ptr, uplos, ts, diags, n, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplos, ts,
-                                                                diags, n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplos, ts, diags, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, uplos, ts, diags, n, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas3/gemm.cpp
+++ b/benchmark/syclblas/blas3/gemm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1, int t2,
@@ -137,9 +132,11 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(t1s, t2s, m, k, n).c_str(),
-                                 BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas3/gemm_batched.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched.cpp
@@ -25,6 +25,9 @@
 
 #include "../utils.hpp"
 
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched;
+
 // Convert batch_type=strided to interleaved on the host
 template <typename scalar_t>
 std::vector<scalar_t> strided_to_interleaved(const std::vector<scalar_t>& input,
@@ -57,17 +60,6 @@ std::vector<scalar_t> interleaved_to_strided(const std::vector<scalar_t>& input,
     }
   }
   return output;
-}
-
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int batch_type) {
-  std::ostringstream str{};
-  str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
-      << batch_size << "/"
-      << blas_benchmark::utils::batch_type_to_str(batch_type);
-  return str.str();
 }
 
 template <typename scalar_t>
@@ -209,7 +201,10 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_type, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, batch_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, batch_size, batch_type,
+            blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         batch_type, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched_strided.cpp
@@ -25,17 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int stride_a_mul, int stride_b_mul,
-                     int stride_c_mul) {
-  std::ostringstream str{};
-  str << "BM_GemmBatchedStrided<"
-      << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
-      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
-      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched_strided;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
@@ -182,8 +173,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     strd_a_mul, strd_b_mul, strd_c_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, stride_a_mul,
-                           stride_b_mul, stride_c_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, batch_size, stride_a_mul, stride_b_mul,
+            stride_c_mul, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         stride_a_mul, stride_b_mul, stride_c_mul, success)

--- a/benchmark/syclblas/blas3/trsm.cpp
+++ b/benchmark/syclblas/blas3/trsm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char trans, char diag, index_t m,
-                     index_t n) {
-  std::ostringstream str{};
-  str << "BM_Trsm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << trans << "/" << diag << "/" << m << "/"
-      << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char side,
@@ -174,8 +167,11 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, side, uplo, trans, diag, m, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
-        sb_handle_ptr, side, uplo, trans, diag, m, n, alpha, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, trans, diag, m, n,
+            blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, side, uplo, trans, diag, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/extension/reduction.cpp
+++ b/benchmark/syclblas/extension/reduction.cpp
@@ -27,14 +27,8 @@
 
 using namespace blas;
 
-template <typename scalar_t>
-std::string get_name(int rows, int cols, reduction_dim_t reduction_dim) {
-  std::ostringstream str{};
-  str << "BM_Reduction<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << rows << "/" << cols << "/"
-      << (reduction_dim == reduction_dim_t::inner ? "inner" : "outer");
-  return str.str();
-}
+constexpr blas_benchmark::utils::ExtensionOp benchmark_op =
+    blas_benchmark::utils::ExtensionOp::reduction;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t rows,
@@ -147,10 +141,14 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, rows, cols, dim, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(rows, cols, reduction_dim_t::inner).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            rows, cols, "inner", blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, rows, cols, reduction_dim_t::inner, success);
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(rows, cols, reduction_dim_t::outer).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            rows, cols, "outer", blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, rows, cols, reduction_dim_t::outer, success);
   }
 }

--- a/common/include/common/benchmark_identifier.hpp
+++ b/common/include/common/benchmark_identifier.hpp
@@ -74,6 +74,8 @@ enum class Level3Op : int {
   trsm = 8
 };
 
+enum class ExtensionOp : int { reduction = 0 };
+
 template <Level1Op op>
 std::string get_operator_name() {
   if constexpr (op == Level1Op::asum)
@@ -140,6 +142,38 @@ std::string get_operator_name() {
     return "Trsv";
   else
     throw std::runtime_error("Unknown BLAS 2 operator");
+}
+
+template <Level3Op op>
+std::string get_operator_name() {
+  if constexpr (op == Level3Op::gemm_batched_strided)
+    return "Gemm_batched_strided";
+  else if constexpr (op == Level3Op::gemm_batched)
+    return "Gemm_batched";
+  else if constexpr (op == Level3Op::gemm)
+    return "Gemm";
+  else if constexpr (op == Level3Op::symm)
+    return "Symm";
+  else if constexpr (op == Level3Op::syr2k)
+    return "Syr2k";
+  else if constexpr (op == Level3Op::syrk)
+    return "Syrk";
+  else if constexpr (op == Level3Op::trmm)
+    return "Trmm";
+  else if constexpr (op == Level3Op::trsm_batched)
+    return "Trsm_batched";
+  else if constexpr (op == Level3Op::trsm)
+    return "Trsm";
+  else
+    throw std::runtime_error("Unknown BLAS 3 operator");
+}
+
+template <ExtensionOp op>
+std::string get_operator_name() {
+  if constexpr (op == ExtensionOp::reduction)
+    return "Reduction";
+  else
+    throw std::runtime_error("Unknown BLAS extension operator");
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_identifier.hpp
+++ b/common/include/common/benchmark_identifier.hpp
@@ -104,6 +104,44 @@ std::string get_operator_name() {
     throw std::runtime_error("Unknown BLAS 1 operator");
 }
 
+template <Level2Op op>
+std::string get_operator_name() {
+  if constexpr (op == Level2Op::gbmv)
+    return "Gbmv";
+  else if constexpr (op == Level2Op::gemv)
+    return "Gemv";
+  else if constexpr (op == Level2Op::ger)
+    return "Ger";
+  else if constexpr (op == Level2Op::sbmv)
+    return "Sbmv";
+  else if constexpr (op == Level2Op::spmv)
+    return "Spmv";
+  else if constexpr (op == Level2Op::spr)
+    return "Spr";
+  else if constexpr (op == Level2Op::spr2)
+    return "Spr2";
+  else if constexpr (op == Level2Op::symv)
+    return "Symv";
+  else if constexpr (op == Level2Op::syr)
+    return "Syr";
+  else if constexpr (op == Level2Op::syr2)
+    return "Syr2";
+  else if constexpr (op == Level2Op::tbmv)
+    return "Tbmv";
+  else if constexpr (op == Level2Op::tbsv)
+    return "Tbsv";
+  else if constexpr (op == Level2Op::tpmv)
+    return "Tpmv";
+  else if constexpr (op == Level2Op::tpsv)
+    return "Tpsv";
+  else if constexpr (op == Level2Op::trmv)
+    return "Trmv";
+  else if constexpr (op == Level2Op::trsv)
+    return "Trsv";
+  else
+    throw std::runtime_error("Unknown BLAS 2 operator");
+}
+
 }  // namespace utils
 }  // namespace blas_benchmark
 

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -106,64 +106,68 @@ get_name(index_t size, index_t incx, index_t incy, std::string mem_type) {
 
 template <Level2Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level2Op::gbmv, std::string>::type
-get_name(std::string t, index_t m, index_t n, index_t kl, index_t ku) {
-  return internal::get_name<op, scalar_t>(t, m, n, kl, ku);
+get_name(std::string t, index_t m, index_t n, index_t kl, index_t ku,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(t, m, n, kl, ku, mem_type);
 }
 
 template <Level2Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level2Op::gemv || op == Level2Op::sbmv,
                                std::string>::type
-get_name(std::string t, index_t m, index_t n) {
-  return internal::get_name<op, scalar_t>(t, m, n);
+get_name(std::string t, index_t m, index_t n, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(t, m, n, mem_type);
 }
 
 template <Level2Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level2Op::ger, std::string>::type get_name(
-    index_t m, index_t n) {
-  return internal::get_name<op, scalar_t>(m, n);
+    index_t m, index_t n, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(m, n, mem_type);
 }
 
 template <Level2Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level2Op::syr || op == Level2Op::syr2,
                                std::string>::type
-get_name(std::string uplo, index_t n, scalar_t alpha) {
-  return internal::get_name<op, scalar_t>(uplo, n, alpha);
+get_name(std::string uplo, index_t n, scalar_t alpha, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, mem_type);
 }
 
 template <Level2Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level2Op::spr, std::string>::type get_name(
-    std::string uplo, index_t n, scalar_t alpha, index_t incx) {
-  return internal::get_name<op, scalar_t>(uplo, n, alpha, incx);
+    std::string uplo, index_t n, scalar_t alpha, index_t incx,
+    std::string mem_type) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, incx, mem_type);
 }
 
 template <Level2Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level2Op::spmv || op == Level2Op::symv,
                                std::string>::type
-get_name(std::string uplo, index_t n, scalar_t alpha, scalar_t beta) {
-  return internal::get_name<op, scalar_t>(uplo, n, alpha, beta);
+get_name(std::string uplo, index_t n, scalar_t alpha, scalar_t beta,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, beta, mem_type);
 }
 
 template <Level2Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level2Op::spr2, std::string>::type
 get_name(std::string uplo, index_t n, scalar_t alpha, index_t incx,
-         index_t incy) {
-  return internal::get_name<op, scalar_t>(uplo, n, alpha, incx, incy);
+         index_t incy, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, incx, incy, mem_type);
 }
 
 template <Level2Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level2Op::tbmv || op == Level2Op::tbsv,
                                std::string>::type
 get_name(std::string uplo, std::string t, std::string diag, index_t n,
-         index_t k) {
-  return internal::get_name<op, scalar_t>(uplo, t, diag, n, k);
+         index_t k, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(uplo, t, diag, n, k, mem_type);
 }
 
 template <Level2Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level2Op::tpmv || op == Level2Op::trmv ||
                                    op == Level2Op::trsv,
                                std::string>::type
-get_name(std::string uplo, std::string t, std::string diag, index_t n) {
-  return internal::get_name<op, scalar_t>(uplo, t, diag, n);
+get_name(std::string uplo, std::string t, std::string diag, index_t n,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(uplo, t, diag, n, mem_type);
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -32,6 +32,7 @@ namespace utils {
 
 template <typename scalar_t>
 static inline std::string get_type_name();
+inline std::string batch_type_to_str(int batch_type);
 
 namespace internal {
 
@@ -70,6 +71,22 @@ inline std::string get_name(Args... args) {
 }
 
 template <Level2Op op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
+  str << get_parameters_as_string(args...);
+  return str.str();
+}
+
+template <Level3Op op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
+  str << get_parameters_as_string(args...);
+  return str.str();
+}
+
+template <ExtensionOp op, typename scalar_t, typename... Args>
 inline std::string get_name(Args... args) {
   std::ostringstream str{};
   str << get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
@@ -168,6 +185,67 @@ inline typename std::enable_if<op == Level2Op::tpmv || op == Level2Op::trmv ||
 get_name(std::string uplo, std::string t, std::string diag, index_t n,
          std::string mem_type) {
   return internal::get_name<op, scalar_t>(uplo, t, diag, n, mem_type);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::gemm, std::string>::type
+get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(t1, t2, m, k, n, mem_type);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::gemm_batched, std::string>::type
+get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n,
+         index_t batch_size, int batch_type, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(
+      t1, t2, m, k, n, batch_size, batch_type_to_str(batch_type), mem_type);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::gemm_batched_strided,
+                               std::string>::type
+get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n,
+         index_t batch_size, index_t stride_a_mul, index_t stride_b_mul,
+         index_t stride_c_mul, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(t1, t2, m, k, n, batch_size,
+                                          stride_a_mul, stride_b_mul,
+                                          stride_c_mul, mem_type);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::symm || op == Level3Op::syr2k ||
+                                   op == Level3Op::syrk,
+                               std::string>::type
+get_name(std::string s1, std::string s2, index_t m, index_t n, scalar_t alpha,
+         scalar_t beta, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(s1, s2, m, n, alpha, beta, mem_type);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::trsm || op == Level3Op::trmm,
+                               std::string>::type
+get_name(char side, char uplo, char trans, char diag, index_t m, index_t n,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(side, uplo, trans, diag, m, n,
+                                          mem_type);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::trsm_batched, std::string>::type
+get_name(char side, char uplo, char trans, char diag, index_t m, index_t n,
+         index_t batch_size, index_t stride_a_mul, index_t stride_b_mul,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(side, uplo, trans, diag, m, n,
+                                          batch_size, stride_a_mul,
+                                          stride_b_mul, mem_type);
+}
+
+template <ExtensionOp op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == ExtensionOp::reduction, std::string>::type
+get_name(index_t rows, index_t cols, std::string reduction_dim,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(rows, cols, reduction_dim, mem_type);
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -68,6 +68,15 @@ inline std::string get_name(Args... args) {
   str << get_parameters_as_string(args...);
   return str.str();
 }
+
+template <Level2Op op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
+  str << get_parameters_as_string(args...);
+  return str.str();
+}
+
 }  // namespace internal
 
 template <Level1Op op, typename scalar_t>
@@ -95,12 +104,66 @@ get_name(index_t size, index_t incx, index_t incy, std::string mem_type) {
   return internal::get_name<op, scalar_t>(size, incx, incy, mem_type);
 }
 
-template <Level2Op op, typename scalar_t, typename... Args>
-inline std::string get_name(Args... args) {
-  std::ostringstream str{};
-  str << internal::get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
-  str << internal::get_parameters_as_string(args...);
-  return str.str();
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::gbmv, std::string>::type
+get_name(std::string t, index_t m, index_t n, index_t kl, index_t ku) {
+  return internal::get_name<op, scalar_t>(t, m, n, kl, ku);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::gemv || op == Level2Op::sbmv,
+                               std::string>::type
+get_name(std::string t, index_t m, index_t n) {
+  return internal::get_name<op, scalar_t>(t, m, n);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::ger, std::string>::type get_name(
+    index_t m, index_t n) {
+  return internal::get_name<op, scalar_t>(m, n);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::syr || op == Level2Op::syr2,
+                               std::string>::type
+get_name(std::string uplo, index_t n, scalar_t alpha) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::spr, std::string>::type get_name(
+    std::string uplo, index_t n, scalar_t alpha, index_t incx) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, incx);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::spmv || op == Level2Op::symv,
+                               std::string>::type
+get_name(std::string uplo, index_t n, scalar_t alpha, scalar_t beta) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, beta);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::spr2, std::string>::type
+get_name(std::string uplo, index_t n, scalar_t alpha, index_t incx,
+         index_t incy) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, incx, incy);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::tbmv || op == Level2Op::tbsv,
+                               std::string>::type
+get_name(std::string uplo, std::string t, std::string diag, index_t n,
+         index_t k) {
+  return internal::get_name<op, scalar_t>(uplo, t, diag, n, k);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::tpmv || op == Level2Op::trmv ||
+                                   op == Level2Op::trsv,
+                               std::string>::type
+get_name(std::string uplo, std::string t, std::string diag, index_t n) {
+  return internal::get_name<op, scalar_t>(uplo, t, diag, n);
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -95,6 +95,14 @@ get_name(index_t size, index_t incx, index_t incy, std::string mem_type) {
   return internal::get_name<op, scalar_t>(size, incx, incy, mem_type);
 }
 
+template <Level2Op op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << internal::get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
+  str << internal::get_parameters_as_string(args...);
+  return str.str();
+}
+
 }  // namespace utils
 }  // namespace blas_benchmark
 


### PR DESCRIPTION
This PR moves the get_name function in the BLAS Level 2 benchmarks to a common location, ensuring that different backends can obtain uniform benchmark names.