### PR TITLE
Refactor get_name for BLAS Level 3 benchmarks

### DIFF
--- a/benchmark/cublas/blas3/gemm.cpp
+++ b/benchmark/cublas/blas3/gemm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,9 +159,11 @@ void register_benchmark(blas_benchmark::Args& args,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(t1s, t2s, m, k, n).c_str(),
-                                 BM_lambda, cuda_handle_ptr, t1, t2, m, k, n,
-                                 alpha, beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(t1s, t2s, m, k,
+                                                                n)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas3/gemm.cpp
+++ b/benchmark/cublas/blas3/gemm.cpp
@@ -160,8 +160,8 @@ void register_benchmark(blas_benchmark::Args& args,
       run<scalar_t>(st, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(t1s, t2s, m, k,
-                                                                n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas3/gemm_batched.cpp
+++ b/benchmark/cublas/blas3/gemm_batched.cpp
@@ -25,16 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_count, int batch_type) {
-  std::ostringstream str{};
-  str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
-      << batch_count << "/"
-      << blas_benchmark::utils::batch_type_to_str(batch_type);
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -207,7 +199,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_count, batch_type, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_count, batch_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, batch_count, batch_type)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_count,
         batch_type, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas3/gemm_batched.cpp
+++ b/benchmark/cublas/blas3/gemm_batched.cpp
@@ -200,7 +200,8 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            t1s, t2s, m, k, n, batch_count, batch_type)
+            t1s, t2s, m, k, n, batch_count, batch_type,
+            blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_count,
         batch_type, success)

--- a/benchmark/cublas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/cublas/blas3/gemm_batched_strided.cpp
@@ -200,7 +200,7 @@ void register_benchmark(blas_benchmark::Args& args,
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
             t1s, t2s, m, k, n, batch_size, stride_a_mul, stride_b_mul,
-            stride_c_mul)
+            stride_c_mul, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         stride_a_mul, stride_b_mul, stride_c_mul, success)

--- a/benchmark/cublas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/cublas/blas3/gemm_batched_strided.cpp
@@ -25,18 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int stride_a_mul, int stride_b_mul,
-                     int stride_c_mul) {
-  std::ostringstream str{};
-  str << "BM_GemmBatchedStrided<"
-      << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
-      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
-      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul;
-
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched_strided;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -208,8 +198,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_size, strd_a_mul, strd_b_mul, strd_c_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, stride_a_mul,
-                           stride_b_mul, stride_c_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, batch_size, stride_a_mul, stride_b_mul,
+            stride_c_mul)
             .c_str(),
         BM_lambda, cuda_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         stride_a_mul, stride_b_mul, stride_c_mul, success)

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -158,7 +158,8 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            s_side, s_uplo, m, n, alpha, beta)
+            s_side, s_uplo, m, n, alpha, beta,
+            blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, s_side, s_uplo, m, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas3/symm.cpp
+++ b/benchmark/cublas/blas3/symm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, int m, int n, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Symm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << m << "/" << n << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::symm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -164,7 +157,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_side, s_uplo, m, n, alpha, beta).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_side, s_uplo, m, n, alpha, beta)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, s_side, s_uplo, m, n, alpha, beta, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas3/syr2k.cpp
+++ b/benchmark/cublas/blas3/syr2k.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Syr2k<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::syr2k;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -163,7 +156,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_uplo, s_trans, n, k, alpha, beta).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_uplo, s_trans, n, k, alpha, beta)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, s_uplo, s_trans, n, k, alpha, beta, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas3/syr2k.cpp
+++ b/benchmark/cublas/blas3/syr2k.cpp
@@ -157,7 +157,8 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            s_uplo, s_trans, n, k, alpha, beta)
+            s_uplo, s_trans, n, k, alpha, beta,
+            blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, s_uplo, s_trans, n, k, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas3/syrk.cpp
+++ b/benchmark/cublas/blas3/syrk.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Syrk<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::syrk;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -159,7 +152,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_uplo, s_trans, n, k, alpha, beta).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_uplo, s_trans, n, k, alpha, beta)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, s_uplo, s_trans, n, k, alpha, beta, success)
         ->UseRealTime();
   }

--- a/benchmark/cublas/blas3/syrk.cpp
+++ b/benchmark/cublas/blas3/syrk.cpp
@@ -153,7 +153,8 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            s_uplo, s_trans, n, k, alpha, beta)
+            s_uplo, s_trans, n, k, alpha, beta,
+            blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, s_uplo, s_trans, n, k, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/cublas/blas3/trmm.cpp
+++ b/benchmark/cublas/blas3/trmm.cpp
@@ -172,7 +172,8 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            s_side, s_uplo, s_t, s_diag, m, n)
+            s_side, s_uplo, s_t, s_diag, m, n,
+            blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, s_side, s_uplo, s_t, s_diag, m, n, alpha,
         success)

--- a/benchmark/cublas/blas3/trmm.cpp
+++ b/benchmark/cublas/blas3/trmm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char t, char diag, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Trmm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << t << "/" << diag << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trmm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -176,7 +171,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_side, s_uplo, s_t, s_diag, m, n).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_side, s_uplo, s_t, s_diag, m, n)
+            .c_str(),
         BM_lambda, cuda_handle_ptr, s_side, s_uplo, s_t, s_diag, m, n, alpha,
         success)
         ->UseRealTime();

--- a/benchmark/cublas/blas3/trsm.cpp
+++ b/benchmark/cublas/blas3/trsm.cpp
@@ -172,7 +172,7 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            side, uplo, trans, diag, m, n)
+            side, uplo, trans, diag, m, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, side, uplo, trans, diag, m, n, alpha,
         success)

--- a/benchmark/cublas/blas3/trsm.cpp
+++ b/benchmark/cublas/blas3/trsm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char trans, char diag, index_t m,
-                     index_t n) {
-  std::ostringstream str{};
-  str << "BM_Trsm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << trans << "/" << diag << "/" << m << "/"
-      << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -178,8 +171,11 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
-        cuda_handle_ptr, side, uplo, trans, diag, m, n, alpha, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, trans, diag, m, n)
+            .c_str(),
+        BM_lambda, cuda_handle_ptr, side, uplo, trans, diag, m, n, alpha,
+        success)
         ->UseRealTime();
   }
 }

--- a/benchmark/cublas/blas3/trsm_batched.cpp
+++ b/benchmark/cublas/blas3/trsm_batched.cpp
@@ -210,7 +210,7 @@ void register_benchmark(blas_benchmark::Args& args,
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
             s_side, s_uplo, s_t, s_diag, m, n, batch_count, stride_a_mul,
-            stride_b_mul)
+            stride_b_mul, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, cuda_handle_ptr, s_side, s_uplo, s_t, s_diag, m, n, alpha,
         batch_count, stride_a_mul, stride_b_mul, success)

--- a/benchmark/cublas/blas3/trsm_batched.cpp
+++ b/benchmark/cublas/blas3/trsm_batched.cpp
@@ -25,16 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(const char side, const char uplo, const char t,
-                     const char diag, int m, int n, int batch_count,
-                     int stride_a_mul, int stride_b_mul) {
-  std::ostringstream str{};
-  str << "BM_TrsmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << side << "/" << uplo << "/" << t << "/" << diag << "/" << m
-      << "/" << n << "/" << batch_count;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm_batched;
 
 template <typename scalar_t, typename... args_t>
 static inline void cublas_routine(args_t&&... args) {
@@ -216,8 +208,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_count, strd_a_mul, strd_b_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_side, s_uplo, s_t, s_diag, m, n, batch_count,
-                           stride_a_mul, stride_b_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_side, s_uplo, s_t, s_diag, m, n, batch_count, stride_a_mul,
+            stride_b_mul)
             .c_str(),
         BM_lambda, cuda_handle_ptr, s_side, s_uplo, s_t, s_diag, m, n, alpha,
         batch_count, stride_a_mul, stride_b_mul, success)

--- a/benchmark/rocblas/blas3/gemm.cpp
+++ b/benchmark/rocblas/blas3/gemm.cpp
@@ -175,8 +175,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, t1i, t2i, m, k, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(t_a, t_b, m, k,
-                                                                n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t_a, t_b, m, k, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas3/gemm.cpp
+++ b/benchmark/rocblas/blas3/gemm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t_a, std::string t_b, int m, int k, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t_a << "/" << t_b << "/" << m << "/" << k << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gemm_f(args_t&&... args) {
@@ -179,9 +174,11 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, rb_handle, t1i, t2i, m, k, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(t_a, t_b, m, k, n).c_str(),
-                                 BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n,
-                                 alpha, beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(t_a, t_b, m, k,
+                                                                n)
+            .c_str(),
+        BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/gemm_batched.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched.cpp
@@ -25,16 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int batch_type) {
-  std::ostringstream str{};
-  str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
-      << batch_size << "/"
-      << blas_benchmark::utils::batch_type_to_str(batch_type);
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gemm_batched_f(args_t&&... args) {
@@ -207,7 +199,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                     batch_size, batch_type, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t_a, t_b, m, k, n, batch_size, batch_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t_a, t_b, m, k, n, batch_size, batch_type)
+            .c_str(),
         BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, batch_size,
         batch_type, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas3/gemm_batched.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched.cpp
@@ -200,7 +200,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            t_a, t_b, m, k, n, batch_size, batch_type)
+            t_a, t_b, m, k, n, batch_size, batch_type,
+            blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, batch_size,
         batch_type, success)

--- a/benchmark/rocblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched_strided.cpp
@@ -211,7 +211,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
             t_a, t_b, m, k, n, batch_size, stride_a_mul, stride_b_mul,
-            stride_c_mul)
+            stride_c_mul, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, batch_size,
         stride_a_mul, stride_b_mul, stride_c_mul, success)

--- a/benchmark/rocblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/rocblas/blas3/gemm_batched_strided.cpp
@@ -25,18 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int stride_a_mul, int stride_b_mul,
-                     int stride_c_mul) {
-  std::ostringstream str{};
-  str << "BM_GemmBatchedStrided<"
-      << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
-      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
-      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul;
-
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched_strided;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_gemm_strided_batched(args_t&&... args) {
@@ -219,8 +209,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                     strd_a_mul, strd_b_mul, strd_c_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t_a, t_b, m, k, n, batch_size, stride_a_mul,
-                           stride_b_mul, stride_c_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t_a, t_b, m, k, n, batch_size, stride_a_mul, stride_b_mul,
+            stride_c_mul)
             .c_str(),
         BM_lambda, rb_handle, t_a_i, t_b_i, m, k, n, alpha, beta, batch_size,
         stride_a_mul, stride_b_mul, stride_c_mul, success)

--- a/benchmark/rocblas/blas3/symm.cpp
+++ b/benchmark/rocblas/blas3/symm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, int m, int n, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Symm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << m << "/" << n << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::symm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_symm_f(args_t&&... args) {
@@ -172,8 +165,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, side, uplo, m, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, m, n, alpha, beta).c_str(), BM_lambda,
-        rb_handle, side, uplo, m, n, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(side, uplo, m,
+                                                                n, alpha, beta)
+            .c_str(),
+        BM_lambda, rb_handle, side, uplo, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/symm.cpp
+++ b/benchmark/rocblas/blas3/symm.cpp
@@ -165,8 +165,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, side, uplo, m, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(side, uplo, m,
-                                                                n, alpha, beta)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, m, n, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, side, uplo, m, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas3/syr2k.cpp
+++ b/benchmark/rocblas/blas3/syr2k.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Syr2k<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::syr2k;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_syr2k_f(args_t&&... args) {
@@ -169,8 +162,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, trans, n, k, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo, trans, n, k, alpha, beta).c_str(), BM_lambda,
-        rb_handle, uplo, trans, n, k, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, trans, n,
+                                                                k, alpha, beta)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, trans, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/syr2k.cpp
+++ b/benchmark/rocblas/blas3/syr2k.cpp
@@ -162,8 +162,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, trans, n, k, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, trans, n,
-                                                                k, alpha, beta)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, trans, n, k, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplo, trans, n, k, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas3/syrk.cpp
+++ b/benchmark/rocblas/blas3/syrk.cpp
@@ -159,8 +159,8 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, trans, n, k, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, trans, n,
-                                                                k, alpha, beta)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            uplo, trans, n, k, alpha, beta, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, uplo, trans, n, k, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas3/syrk.cpp
+++ b/benchmark/rocblas/blas3/syrk.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char uplo, char trans, int n, int k, scalar_t alpha,
-                     scalar_t beta) {
-  std::ostringstream str{};
-  str << "BM_Syrk<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << uplo << "/" << trans << "/" << n << "/" << k << "/" << alpha << "/"
-      << beta;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::syrk;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_syrk_f(args_t&&... args) {
@@ -166,8 +159,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, uplo, trans, n, k, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(uplo, trans, n, k, alpha, beta).c_str(), BM_lambda,
-        rb_handle, uplo, trans, n, k, alpha, beta, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(uplo, trans, n,
+                                                                k, alpha, beta)
+            .c_str(),
+        BM_lambda, rb_handle, uplo, trans, n, k, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/trmm.cpp
+++ b/benchmark/rocblas/blas3/trmm.cpp
@@ -173,7 +173,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            side, uplo, trans, diag, m, n)
+            side, uplo, trans, diag, m, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, side, uplo, trans, diag, m, n, alpha, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas3/trmm.cpp
+++ b/benchmark/rocblas/blas3/trmm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char t, char diag, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Trmm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << t << "/" << diag << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trmm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trmm_f(args_t&&... args) {
@@ -177,8 +172,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
       run<scalar_t>(st, rb_handle, side, uplo, t, diag, m, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
-        rb_handle, side, uplo, trans, diag, m, n, alpha, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, trans, diag, m, n)
+            .c_str(),
+        BM_lambda, rb_handle, side, uplo, trans, diag, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/trsm.cpp
+++ b/benchmark/rocblas/blas3/trsm.cpp
@@ -175,7 +175,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            side, uplo, trans, diag, m, n)
+            side, uplo, trans, diag, m, n, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, side, uplo, trans, diag, m, n, alpha, success)
         ->UseRealTime();

--- a/benchmark/rocblas/blas3/trsm.cpp
+++ b/benchmark/rocblas/blas3/trsm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char trans, char diag, index_t m,
-                     index_t n) {
-  std::ostringstream str{};
-  str << "BM_Trsm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << trans << "/" << diag << "/" << m << "/"
-      << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trsm_f(args_t&&... args) {
@@ -181,8 +174,10 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                     success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
-        rb_handle, side, uplo, trans, diag, m, n, alpha, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, trans, diag, m, n)
+            .c_str(),
+        BM_lambda, rb_handle, side, uplo, trans, diag, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/rocblas/blas3/trsm_batched.cpp
+++ b/benchmark/rocblas/blas3/trsm_batched.cpp
@@ -208,7 +208,7 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
             s_side, s_uplo, s_t, s_diag, m, n, batch_size, stride_a_mul,
-            stride_b_mul)
+            stride_b_mul, blas_benchmark::utils::MEM_TYPE_USM)
             .c_str(),
         BM_lambda, rb_handle, s_side, s_uplo, s_t, s_diag, m, n, alpha,
         batch_size, stride_a_mul, stride_b_mul, success)

--- a/benchmark/rocblas/blas3/trsm_batched.cpp
+++ b/benchmark/rocblas/blas3/trsm_batched.cpp
@@ -25,17 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(const char side, const char uplo, const char t,
-                     const char diag, int m, int n, int batch_size,
-                     int stride_a_mul, int stride_b_mul) {
-  std::ostringstream str{};
-  str << "BM_TrsmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << side << "/" << uplo << "/" << t << "/" << diag << "/" << m
-      << "/" << n << "/" << batch_size << "/" << stride_a_mul << "/"
-      << stride_b_mul << "/";
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm_batched;
 
 template <typename scalar_t, typename... args_t>
 static inline void rocblas_trsm_batched_f(args_t&&... args) {
@@ -215,8 +206,9 @@ void register_benchmark(blas_benchmark::Args& args, rocblas_handle& rb_handle,
                     strd_a_mul, strd_b_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(s_side, s_uplo, s_t, s_diag, m, n, batch_size,
-                           stride_a_mul, stride_b_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            s_side, s_uplo, s_t, s_diag, m, n, batch_size, stride_a_mul,
+            stride_b_mul)
             .c_str(),
         BM_lambda, rb_handle, s_side, s_uplo, s_t, s_diag, m, n, alpha,
         batch_size, stride_a_mul, stride_b_mul, success)

--- a/benchmark/syclblas/blas3/gemm.cpp
+++ b/benchmark/syclblas/blas3/gemm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n) {
-  std::ostringstream str{};
-  str << "BM_Gemm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1, int t2,
@@ -137,9 +132,11 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
                          scalar_t alpha, scalar_t beta, bool* success) {
       run<scalar_t>(st, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(t1s, t2s, m, k, n).c_str(),
-                                 BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta,
-                                 success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(t1s, t2s, m, k,
+                                                                n)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas3/gemm.cpp
+++ b/benchmark/syclblas/blas3/gemm.cpp
@@ -133,8 +133,8 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(t1s, t2s, m, k,
-                                                                n)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas3/gemm_batched.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched.cpp
@@ -25,6 +25,9 @@
 
 #include "../utils.hpp"
 
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched;
+
 // Convert batch_type=strided to interleaved on the host
 template <typename scalar_t>
 std::vector<scalar_t> strided_to_interleaved(const std::vector<scalar_t>& input,
@@ -57,17 +60,6 @@ std::vector<scalar_t> interleaved_to_strided(const std::vector<scalar_t>& input,
     }
   }
   return output;
-}
-
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int batch_type) {
-  std::ostringstream str{};
-  str << "BM_GemmBatched<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << t1 << "/" << t2 << "/" << m << "/" << k << "/" << n << "/"
-      << batch_size << "/"
-      << blas_benchmark::utils::batch_type_to_str(batch_type);
-  return str.str();
 }
 
 template <typename scalar_t>
@@ -209,7 +201,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     batch_type, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, batch_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, batch_size, batch_type)
+            .c_str(),
         BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         batch_type, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas3/gemm_batched.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched.cpp
@@ -202,7 +202,8 @@ void register_benchmark(blas_benchmark::Args& args,
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            t1s, t2s, m, k, n, batch_size, batch_type)
+            t1s, t2s, m, k, n, batch_size, batch_type,
+            blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         batch_type, success)

--- a/benchmark/syclblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched_strided.cpp
@@ -25,17 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(std::string t1, std::string t2, int m, int k, int n,
-                     int batch_size, int stride_a_mul, int stride_b_mul,
-                     int stride_c_mul) {
-  std::ostringstream str{};
-  str << "BM_GemmBatchedStrided<"
-      << blas_benchmark::utils::get_type_name<scalar_t>() << ">/" << t1 << "/"
-      << t2 << "/" << m << "/" << k << "/" << n << "/" << batch_size << "/"
-      << stride_a_mul << "/" << stride_b_mul << "/" << stride_c_mul;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::gemm_batched_strided;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
@@ -182,8 +173,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     strd_a_mul, strd_b_mul, strd_c_mul, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(t1s, t2s, m, k, n, batch_size, stride_a_mul,
-                           stride_b_mul, stride_c_mul)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            t1s, t2s, m, k, n, batch_size, stride_a_mul, stride_b_mul,
+            stride_c_mul)
             .c_str(),
         BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         stride_a_mul, stride_b_mul, stride_c_mul, success)

--- a/benchmark/syclblas/blas3/gemm_batched_strided.cpp
+++ b/benchmark/syclblas/blas3/gemm_batched_strided.cpp
@@ -175,7 +175,7 @@ void register_benchmark(blas_benchmark::Args& args,
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
             t1s, t2s, m, k, n, batch_size, stride_a_mul, stride_b_mul,
-            stride_c_mul)
+            stride_c_mul, blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, batch_size,
         stride_a_mul, stride_b_mul, stride_c_mul, success)

--- a/benchmark/syclblas/blas3/symm.cpp
+++ b/benchmark/syclblas/blas3/symm.cpp
@@ -132,8 +132,9 @@ void register_benchmark(blas_benchmark::Args& args,
                     success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(side, uplo, m,
-                                                                n, alpha, beta)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, m, n, alpha, beta,
+            blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, side_c, uplo_c, m, n, alpha, beta, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas3/symm.cpp
+++ b/benchmark/syclblas/blas3/symm.cpp
@@ -25,13 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, int m, int n) {
-  std::ostringstream str{};
-  str << "BM_Symm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << m << "/" << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::symm;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char side,
@@ -122,19 +117,25 @@ void register_benchmark(blas_benchmark::Args& args,
   auto symm_params = blas_benchmark::utils::get_symm_params<scalar_t>(args);
 
   for (auto p : symm_params) {
-    char side, uplo;
+    std::string side, uplo;
     index_t m, n;
     scalar_t alpha, beta;
     std::tie(side, uplo, m, n, alpha, beta) = p;
 
+    char side_c = side[0];
+    char uplo_c = uplo[0];
+
     auto BM_lambda = [&](benchmark::State& st, blas::SB_Handle* sb_handle_ptr,
                          char side, char uplo, index_t m, index_t n,
                          scalar_t alpha, scalar_t beta, bool* success) {
-      run<scalar_t>(st, sb_handle_ptr, side, uplo, m, n, alpha, beta, success);
+      run<scalar_t>(st, sb_handle_ptr, side_c, uplo_c, m, n, alpha, beta,
+                    success);
     };
-    benchmark::RegisterBenchmark(get_name<scalar_t>(side, uplo, m, n).c_str(),
-                                 BM_lambda, sb_handle_ptr, side, uplo, m, n,
-                                 alpha, beta, success)
+    benchmark::RegisterBenchmark(
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(side, uplo, m,
+                                                                n, alpha, beta)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, side_c, uplo_c, m, n, alpha, beta, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/blas3/trsm.cpp
+++ b/benchmark/syclblas/blas3/trsm.cpp
@@ -168,7 +168,8 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
     };
     benchmark::RegisterBenchmark(
         blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            side, uplo, trans, diag, m, n)
+            side, uplo, trans, diag, m, n,
+            blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, side, uplo, trans, diag, m, n, alpha, success)
         ->UseRealTime();

--- a/benchmark/syclblas/blas3/trsm.cpp
+++ b/benchmark/syclblas/blas3/trsm.cpp
@@ -25,15 +25,8 @@
 
 #include "../utils.hpp"
 
-template <typename scalar_t>
-std::string get_name(char side, char uplo, char trans, char diag, index_t m,
-                     index_t n) {
-  std::ostringstream str{};
-  str << "BM_Trsm<" << blas_benchmark::utils::get_type_name<scalar_t>() << ">/"
-      << side << "/" << uplo << "/" << trans << "/" << diag << "/" << m << "/"
-      << n;
-  return str.str();
-}
+constexpr blas_benchmark::utils::Level3Op benchmark_op =
+    blas_benchmark::utils::Level3Op::trsm;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, char side,
@@ -174,8 +167,10 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, side, uplo, trans, diag, m, n, alpha, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(side, uplo, trans, diag, m, n).c_str(), BM_lambda,
-        sb_handle_ptr, side, uplo, trans, diag, m, n, alpha, success)
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            side, uplo, trans, diag, m, n)
+            .c_str(),
+        BM_lambda, sb_handle_ptr, side, uplo, trans, diag, m, n, alpha, success)
         ->UseRealTime();
   }
 }

--- a/benchmark/syclblas/extension/reduction.cpp
+++ b/benchmark/syclblas/extension/reduction.cpp
@@ -27,14 +27,8 @@
 
 using namespace blas;
 
-template <typename scalar_t>
-std::string get_name(int rows, int cols, reduction_dim_t reduction_dim) {
-  std::ostringstream str{};
-  str << "BM_Reduction<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << rows << "/" << cols << "/"
-      << (reduction_dim == reduction_dim_t::inner ? "inner" : "outer");
-  return str.str();
-}
+constexpr blas_benchmark::utils::ExtensionOp benchmark_op =
+    blas_benchmark::utils::ExtensionOp::reduction;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t rows,
@@ -147,10 +141,14 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, rows, cols, dim, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(rows, cols, reduction_dim_t::inner).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            rows, cols, "inner", blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, rows, cols, reduction_dim_t::inner, success);
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(rows, cols, reduction_dim_t::outer).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            rows, cols, "outer", blas_benchmark::utils::MEM_TYPE_BUFFER)
+            .c_str(),
         BM_lambda, sb_handle_ptr, rows, cols, reduction_dim_t::outer, success);
   }
 }

--- a/common/include/common/benchmark_identifier.hpp
+++ b/common/include/common/benchmark_identifier.hpp
@@ -142,6 +142,30 @@ std::string get_operator_name() {
     throw std::runtime_error("Unknown BLAS 2 operator");
 }
 
+template <Level3Op op>
+std::string get_operator_name() {
+  if constexpr (op == Level3Op::gemm_batched_strided)
+    return "Gemm_batched_strided";
+  else if constexpr (op == Level3Op::gemm_batched)
+    return "Gemm_batched";
+  else if constexpr (op == Level3Op::gemm)
+    return "Gemm";
+  else if constexpr (op == Level3Op::symm)
+    return "Symm";
+  else if constexpr (op == Level3Op::syr2k)
+    return "Syr2k";
+  else if constexpr (op == Level3Op::syrk)
+    return "Syrk";
+  else if constexpr (op == Level3Op::trmm)
+    return "Trmm";
+  else if constexpr (op == Level3Op::trsm_batched)
+    return "Trsm_batched";
+  else if constexpr (op == Level3Op::trsm)
+    return "Trsm";
+  else
+    throw std::runtime_error("Unknown BLAS 3 operator");
+}
+
 }  // namespace utils
 }  // namespace blas_benchmark
 

--- a/common/include/common/benchmark_identifier.hpp
+++ b/common/include/common/benchmark_identifier.hpp
@@ -74,6 +74,8 @@ enum class Level3Op : int {
   trsm = 8
 };
 
+enum class ExtensionOp : int { reduction = 0 };
+
 template <Level1Op op>
 std::string get_operator_name() {
   if constexpr (op == Level1Op::asum)
@@ -164,6 +166,14 @@ std::string get_operator_name() {
     return "Trsm";
   else
     throw std::runtime_error("Unknown BLAS 3 operator");
+}
+
+template <ExtensionOp op>
+std::string get_operator_name() {
+  if constexpr (op == ExtensionOp::reduction)
+    return "Reduction";
+  else
+    throw std::runtime_error("Unknown BLAS extension operator");
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -32,6 +32,7 @@ namespace utils {
 
 template <typename scalar_t>
 static inline std::string get_type_name();
+inline std::string batch_type_to_str(int batch_type);
 
 namespace internal {
 
@@ -70,6 +71,14 @@ inline std::string get_name(Args... args) {
 }
 
 template <Level2Op op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
+  str << get_parameters_as_string(args...);
+  return str.str();
+}
+
+template <Level3Op op, typename scalar_t, typename... Args>
 inline std::string get_name(Args... args) {
   std::ostringstream str{};
   str << get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
@@ -230,6 +239,54 @@ inline typename std::enable_if<op == Level2Op::tpmv || op == Level2Op::trmv ||
                                std::string>::type
 get_name(std::string uplo, std::string t, std::string diag, index_t n) {
   return internal::get_name<op, scalar_t>(uplo, t, diag, n);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::gemm, std::string>::type
+get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n) {
+  return internal::get_name<op, scalar_t>(t1, t2, m, k, n);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::gemm_batched, std::string>::type
+get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n,
+         index_t batch_size, int batch_type) {
+  return internal::get_name<op, scalar_t>(t1, t2, m, k, n, batch_size,
+                                          batch_type_to_str(batch_type));
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::gemm_batched_strided,
+                               std::string>::type
+get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n,
+         index_t batch_size, index_t stride_a_mul, index_t stride_b_mul,
+         index_t stride_c_mul) {
+  return internal::get_name<op, scalar_t>(
+      t1, t2, m, k, n, batch_size, stride_a_mul, stride_b_mul, stride_c_mul);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::symm || op == Level3Op::syr2k ||
+                                   op == Level3Op::syrk,
+                               std::string>::type
+get_name(std::string s1, std::string s2, index_t m, index_t n, scalar_t alpha,
+         scalar_t beta) {
+  return internal::get_name<op, scalar_t>(s1, s2, m, n, alpha, beta);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::trsm || op == Level3Op::trmm,
+                               std::string>::type
+get_name(char side, char uplo, char trans, char diag, index_t m, index_t n) {
+  return internal::get_name<op, scalar_t>(side, uplo, trans, diag, m, n);
+}
+
+template <Level3Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level3Op::trsm_batched, std::string>::type
+get_name(char side, char uplo, char trans, char diag, index_t m, index_t n,
+         index_t batch_size, index_t stride_a_mul, index_t stride_b_mul) {
+  return internal::get_name<op, scalar_t>(
+      side, uplo, trans, diag, m, n, batch_size, stride_a_mul, stride_b_mul);
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -170,6 +170,14 @@ get_name(std::string uplo, std::string t, std::string diag, index_t n,
   return internal::get_name<op, scalar_t>(uplo, t, diag, n, mem_type);
 }
 
+template <Level2Op op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << internal::get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
+  str << internal::get_parameters_as_string(args...);
+  return str.str();
+}
+
 }  // namespace utils
 }  // namespace blas_benchmark
 

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -179,80 +179,19 @@ get_name(std::string uplo, std::string t, std::string diag, index_t n,
   return internal::get_name<op, scalar_t>(uplo, t, diag, n, mem_type);
 }
 
-template <Level2Op op, typename scalar_t, typename index_t>
-inline typename std::enable_if<op == Level2Op::gbmv, std::string>::type
-get_name(std::string t, index_t m, index_t n, index_t kl, index_t ku) {
-  return internal::get_name<op, scalar_t>(t, m, n, kl, ku);
-}
-
-template <Level2Op op, typename scalar_t, typename index_t>
-inline typename std::enable_if<op == Level2Op::gemv || op == Level2Op::sbmv,
-                               std::string>::type
-get_name(std::string t, index_t m, index_t n) {
-  return internal::get_name<op, scalar_t>(t, m, n);
-}
-
-template <Level2Op op, typename scalar_t, typename index_t>
-inline typename std::enable_if<op == Level2Op::ger, std::string>::type get_name(
-    index_t m, index_t n) {
-  return internal::get_name<op, scalar_t>(m, n);
-}
-
-template <Level2Op op, typename scalar_t, typename index_t>
-inline typename std::enable_if<op == Level2Op::syr || op == Level2Op::syr2,
-                               std::string>::type
-get_name(std::string uplo, index_t n, scalar_t alpha) {
-  return internal::get_name<op, scalar_t>(uplo, n, alpha);
-}
-
-template <Level2Op op, typename scalar_t, typename index_t>
-inline typename std::enable_if<op == Level2Op::spr, std::string>::type get_name(
-    std::string uplo, index_t n, scalar_t alpha, index_t incx) {
-  return internal::get_name<op, scalar_t>(uplo, n, alpha, incx);
-}
-
-template <Level2Op op, typename scalar_t, typename index_t>
-inline typename std::enable_if<op == Level2Op::spmv || op == Level2Op::symv,
-                               std::string>::type
-get_name(std::string uplo, index_t n, scalar_t alpha, scalar_t beta) {
-  return internal::get_name<op, scalar_t>(uplo, n, alpha, beta);
-}
-
-template <Level2Op op, typename scalar_t, typename index_t>
-inline typename std::enable_if<op == Level2Op::spr2, std::string>::type
-get_name(std::string uplo, index_t n, scalar_t alpha, index_t incx,
-         index_t incy) {
-  return internal::get_name<op, scalar_t>(uplo, n, alpha, incx, incy);
-}
-
-template <Level2Op op, typename scalar_t, typename index_t>
-inline typename std::enable_if<op == Level2Op::tbmv || op == Level2Op::tbsv,
-                               std::string>::type
-get_name(std::string uplo, std::string t, std::string diag, index_t n,
-         index_t k) {
-  return internal::get_name<op, scalar_t>(uplo, t, diag, n, k);
-}
-
-template <Level2Op op, typename scalar_t, typename index_t>
-inline typename std::enable_if<op == Level2Op::tpmv || op == Level2Op::trmv ||
-                                   op == Level2Op::trsv,
-                               std::string>::type
-get_name(std::string uplo, std::string t, std::string diag, index_t n) {
-  return internal::get_name<op, scalar_t>(uplo, t, diag, n);
-}
-
 template <Level3Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level3Op::gemm, std::string>::type
-get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n) {
-  return internal::get_name<op, scalar_t>(t1, t2, m, k, n);
+get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(t1, t2, m, k, n, mem_type);
 }
 
 template <Level3Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level3Op::gemm_batched, std::string>::type
 get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n,
-         index_t batch_size, int batch_type) {
-  return internal::get_name<op, scalar_t>(t1, t2, m, k, n, batch_size,
-                                          batch_type_to_str(batch_type));
+         index_t batch_size, int batch_type, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(
+      t1, t2, m, k, n, batch_size, batch_type_to_str(batch_type), mem_type);
 }
 
 template <Level3Op op, typename scalar_t, typename index_t>
@@ -260,9 +199,10 @@ inline typename std::enable_if<op == Level3Op::gemm_batched_strided,
                                std::string>::type
 get_name(std::string t1, std::string t2, index_t m, index_t k, index_t n,
          index_t batch_size, index_t stride_a_mul, index_t stride_b_mul,
-         index_t stride_c_mul) {
-  return internal::get_name<op, scalar_t>(
-      t1, t2, m, k, n, batch_size, stride_a_mul, stride_b_mul, stride_c_mul);
+         index_t stride_c_mul, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(t1, t2, m, k, n, batch_size,
+                                          stride_a_mul, stride_b_mul,
+                                          stride_c_mul, mem_type);
 }
 
 template <Level3Op op, typename scalar_t, typename index_t>
@@ -270,23 +210,27 @@ inline typename std::enable_if<op == Level3Op::symm || op == Level3Op::syr2k ||
                                    op == Level3Op::syrk,
                                std::string>::type
 get_name(std::string s1, std::string s2, index_t m, index_t n, scalar_t alpha,
-         scalar_t beta) {
-  return internal::get_name<op, scalar_t>(s1, s2, m, n, alpha, beta);
+         scalar_t beta, std::string mem_type) {
+  return internal::get_name<op, scalar_t>(s1, s2, m, n, alpha, beta, mem_type);
 }
 
 template <Level3Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level3Op::trsm || op == Level3Op::trmm,
                                std::string>::type
-get_name(char side, char uplo, char trans, char diag, index_t m, index_t n) {
-  return internal::get_name<op, scalar_t>(side, uplo, trans, diag, m, n);
+get_name(char side, char uplo, char trans, char diag, index_t m, index_t n,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(side, uplo, trans, diag, m, n,
+                                          mem_type);
 }
 
 template <Level3Op op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == Level3Op::trsm_batched, std::string>::type
 get_name(char side, char uplo, char trans, char diag, index_t m, index_t n,
-         index_t batch_size, index_t stride_a_mul, index_t stride_b_mul) {
-  return internal::get_name<op, scalar_t>(
-      side, uplo, trans, diag, m, n, batch_size, stride_a_mul, stride_b_mul);
+         index_t batch_size, index_t stride_a_mul, index_t stride_b_mul,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(side, uplo, trans, diag, m, n,
+                                          batch_size, stride_a_mul,
+                                          stride_b_mul, mem_type);
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -170,12 +170,66 @@ get_name(std::string uplo, std::string t, std::string diag, index_t n,
   return internal::get_name<op, scalar_t>(uplo, t, diag, n, mem_type);
 }
 
-template <Level2Op op, typename scalar_t, typename... Args>
-inline std::string get_name(Args... args) {
-  std::ostringstream str{};
-  str << internal::get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
-  str << internal::get_parameters_as_string(args...);
-  return str.str();
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::gbmv, std::string>::type
+get_name(std::string t, index_t m, index_t n, index_t kl, index_t ku) {
+  return internal::get_name<op, scalar_t>(t, m, n, kl, ku);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::gemv || op == Level2Op::sbmv,
+                               std::string>::type
+get_name(std::string t, index_t m, index_t n) {
+  return internal::get_name<op, scalar_t>(t, m, n);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::ger, std::string>::type get_name(
+    index_t m, index_t n) {
+  return internal::get_name<op, scalar_t>(m, n);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::syr || op == Level2Op::syr2,
+                               std::string>::type
+get_name(std::string uplo, index_t n, scalar_t alpha) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::spr, std::string>::type get_name(
+    std::string uplo, index_t n, scalar_t alpha, index_t incx) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, incx);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::spmv || op == Level2Op::symv,
+                               std::string>::type
+get_name(std::string uplo, index_t n, scalar_t alpha, scalar_t beta) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, beta);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::spr2, std::string>::type
+get_name(std::string uplo, index_t n, scalar_t alpha, index_t incx,
+         index_t incy) {
+  return internal::get_name<op, scalar_t>(uplo, n, alpha, incx, incy);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::tbmv || op == Level2Op::tbsv,
+                               std::string>::type
+get_name(std::string uplo, std::string t, std::string diag, index_t n,
+         index_t k) {
+  return internal::get_name<op, scalar_t>(uplo, t, diag, n, k);
+}
+
+template <Level2Op op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == Level2Op::tpmv || op == Level2Op::trmv ||
+                                   op == Level2Op::trsv,
+                               std::string>::type
+get_name(std::string uplo, std::string t, std::string diag, index_t n) {
+  return internal::get_name<op, scalar_t>(uplo, t, diag, n);
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -86,6 +86,14 @@ inline std::string get_name(Args... args) {
   return str.str();
 }
 
+template <ExtensionOp op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
+  str << get_parameters_as_string(args...);
+  return str.str();
+}
+
 }  // namespace internal
 
 template <Level1Op op, typename scalar_t>
@@ -231,6 +239,13 @@ get_name(char side, char uplo, char trans, char diag, index_t m, index_t n,
   return internal::get_name<op, scalar_t>(side, uplo, trans, diag, m, n,
                                           batch_size, stride_a_mul,
                                           stride_b_mul, mem_type);
+}
+
+template <ExtensionOp op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == ExtensionOp::reduction, std::string>::type
+get_name(index_t rows, index_t cols, std::string reduction_dim,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(rows, cols, reduction_dim, mem_type);
 }
 
 }  // namespace utils


### PR DESCRIPTION
This PR moves the get_name function in the BLAS Level 3 benchmarks to a common location, ensuring that different backends can obtain uniform benchmark names.