### PR TITLE
Refactor get_name for BLAS extension benchmarks

### DIFF
--- a/benchmark/syclblas/extension/reduction.cpp
+++ b/benchmark/syclblas/extension/reduction.cpp
@@ -27,14 +27,8 @@
 
 using namespace blas;
 
-template <typename scalar_t>
-std::string get_name(int rows, int cols, reduction_dim_t reduction_dim) {
-  std::ostringstream str{};
-  str << "BM_Reduction<" << blas_benchmark::utils::get_type_name<scalar_t>()
-      << ">/" << rows << "/" << cols << "/"
-      << (reduction_dim == reduction_dim_t::inner ? "inner" : "outer");
-  return str.str();
-}
+constexpr blas_benchmark::utils::ExtensionOp benchmark_op =
+    blas_benchmark::utils::ExtensionOp::reduction;
 
 template <typename scalar_t>
 void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t rows,
@@ -147,10 +141,14 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, rows, cols, dim, success);
     };
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(rows, cols, reduction_dim_t::inner).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(rows, cols,
+                                                                "inner")
+            .c_str(),
         BM_lambda, sb_handle_ptr, rows, cols, reduction_dim_t::inner, success);
     benchmark::RegisterBenchmark(
-        get_name<scalar_t>(rows, cols, reduction_dim_t::outer).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(rows, cols,
+                                                                "outer")
+            .c_str(),
         BM_lambda, sb_handle_ptr, rows, cols, reduction_dim_t::outer, success);
   }
 }

--- a/benchmark/syclblas/extension/reduction.cpp
+++ b/benchmark/syclblas/extension/reduction.cpp
@@ -141,13 +141,13 @@ void register_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_p
       run<scalar_t>(st, sb_handle_ptr, rows, cols, dim, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(rows, cols,
-                                                                "inner")
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            rows, cols, "inner", blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, rows, cols, reduction_dim_t::inner, success);
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(rows, cols,
-                                                                "outer")
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
+            rows, cols, "outer", blas_benchmark::utils::MEM_TYPE_BUFFER)
             .c_str(),
         BM_lambda, sb_handle_ptr, rows, cols, reduction_dim_t::outer, success);
   }

--- a/common/include/common/benchmark_identifier.hpp
+++ b/common/include/common/benchmark_identifier.hpp
@@ -74,6 +74,8 @@ enum class Level3Op : int {
   trsm = 8
 };
 
+enum class ExtensionOp : int { reduction = 0 };
+
 template <Level1Op op>
 std::string get_operator_name() {
   if constexpr (op == Level1Op::asum)
@@ -164,6 +166,14 @@ std::string get_operator_name() {
     return "Trsm";
   else
     throw std::runtime_error("Unknown BLAS 3 operator");
+}
+
+template <ExtensionOp op>
+std::string get_operator_name() {
+  if constexpr (op == ExtensionOp::reduction)
+    return "Reduction";
+  else
+    throw std::runtime_error("Unknown BLAS extension operator");
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -233,6 +233,14 @@ get_name(char side, char uplo, char trans, char diag, index_t m, index_t n,
                                           stride_b_mul, mem_type);
 }
 
+template <Level2Op op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << internal::get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
+  str << internal::get_parameters_as_string(args...);
+  return str.str();
+}
+
 }  // namespace utils
 }  // namespace blas_benchmark
 

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -233,14 +233,6 @@ get_name(char side, char uplo, char trans, char diag, index_t m, index_t n,
                                           stride_b_mul, mem_type);
 }
 
-template <Level2Op op, typename scalar_t, typename... Args>
-inline std::string get_name(Args... args) {
-  std::ostringstream str{};
-  str << internal::get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
-  str << internal::get_parameters_as_string(args...);
-  return str.str();
-}
-
 }  // namespace utils
 }  // namespace blas_benchmark
 

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -243,8 +243,9 @@ get_name(char side, char uplo, char trans, char diag, index_t m, index_t n,
 
 template <ExtensionOp op, typename scalar_t, typename index_t>
 inline typename std::enable_if<op == ExtensionOp::reduction, std::string>::type
-get_name(index_t rows, index_t cols, std::string reduction_dim) {
-  return internal::get_name<op, scalar_t>(rows, cols, reduction_dim);
+get_name(index_t rows, index_t cols, std::string reduction_dim,
+         std::string mem_type) {
+  return internal::get_name<op, scalar_t>(rows, cols, reduction_dim, mem_type);
 }
 
 }  // namespace utils

--- a/common/include/common/benchmark_names.hpp
+++ b/common/include/common/benchmark_names.hpp
@@ -86,6 +86,14 @@ inline std::string get_name(Args... args) {
   return str.str();
 }
 
+template <ExtensionOp op, typename scalar_t, typename... Args>
+inline std::string get_name(Args... args) {
+  std::ostringstream str{};
+  str << get_benchmark_name<scalar_t>(get_operator_name<op>()) << "/";
+  str << get_parameters_as_string(args...);
+  return str.str();
+}
+
 }  // namespace internal
 
 template <Level1Op op, typename scalar_t>
@@ -231,6 +239,12 @@ get_name(char side, char uplo, char trans, char diag, index_t m, index_t n,
   return internal::get_name<op, scalar_t>(side, uplo, trans, diag, m, n,
                                           batch_size, stride_a_mul,
                                           stride_b_mul, mem_type);
+}
+
+template <ExtensionOp op, typename scalar_t, typename index_t>
+inline typename std::enable_if<op == ExtensionOp::reduction, std::string>::type
+get_name(index_t rows, index_t cols, std::string reduction_dim) {
+  return internal::get_name<op, scalar_t>(rows, cols, reduction_dim);
 }
 
 }  // namespace utils


### PR DESCRIPTION
This PR moves the get_name function in the BLAS extension benchmarks to a common location, ensuring that different backends can obtain uniform benchmark names.